### PR TITLE
Add site reports and clean up engine internals

### DIFF
--- a/.agents/skills/java-code-review/SKILL.md
+++ b/.agents/skills/java-code-review/SKILL.md
@@ -15,6 +15,8 @@ Use this skill when the task is to review a diff, branch, or pull request in Hes
 - Prefer code shapes where each class has one clear concern and one main lifecycle.
 - Treat mixed responsibilities in one class as maintainability findings when they increase coupling, blur persistence/runtime boundaries, or make testing harder.
 - Prefer separate top-level or package-private helper classes over `private static final` nested classes when the nested type has non-trivial behavior, domain meaning, or test value outside one tiny local helper use.
+- Verify that name of classes, method variables and other identifiers are meaningful and consistent with their behavior and domain meaning. Avoid generic names like `Helper`, `Util`, `Manager`, or `Processor` without clear justification.
+- Make sure that algorithms logic is clear and straightforward, and that control flow is easy to follow. Flag complex or nested logic that could be simplified or clarified.
 - Do not flag every nested class by default; flag them when they hide meaningful logic, grow beyond a tiny scoped helper, or make the host class harder to understand.
 - Keep summaries brief and secondary.
 - If no findings are present, state that explicitly and mention any remaining verification gaps.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ pok.png
 #.vscode
 jpf/src/main/java/
 site/
+!src/site/
+!src/site/site.xml
+!engine/src/site/
+!engine/src/site/site.xml

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -144,6 +144,113 @@
 				<version>3.8.0</version>
 			</plugin>
 			<plugin>
+				<groupId>com.github.ferstl</groupId>
+				<artifactId>depgraph-maven-plugin</artifactId>
+				<version>${depgraph.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>generate-engine-dependency-json</id>
+						<phase>site</phase>
+						<goals>
+							<goal>graph</goal>
+						</goals>
+						<configuration>
+							<graphFormat>json</graphFormat>
+							<mergeClassifiers>true</mergeClassifiers>
+							<mergeScopes>true</mergeScopes>
+							<mergeTypes>true</mergeTypes>
+							<outputDirectory>${project.build.directory}/site/depgraph</outputDirectory>
+							<outputFileName>engine-dependencies</outputFileName>
+							<showGroupIds>true</showGroupIds>
+							<showVersions>true</showVersions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jdeps-plugin</artifactId>
+				<version>${jdeps.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>generate-engine-jdeps-dot</id>
+						<phase>site</phase>
+						<goals>
+							<goal>jdkinternals</goal>
+						</goals>
+						<configuration>
+							<dotOutput>${project.build.directory}/site/jdeps</dotOutput>
+							<failOnWarning>false</failOnWarning>
+							<multiRelease>${java.version}</multiRelease>
+							<verbose>package</verbose>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${antrun.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>render-engine-dependency-site</id>
+						<phase>site</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<mkdir dir="${project.build.directory}/site/depgraph" />
+								<exec executable="python3" failonerror="true">
+									<arg value="${maven.multiModuleProjectDirectory}/scripts/generate_dependency_site_report.py" />
+									<arg value="engine" />
+									<arg value="--json" />
+									<arg value="${project.build.directory}/site/depgraph/engine-dependencies.json" />
+									<arg value="--html" />
+									<arg value="${project.build.directory}/site/external-dependencies.html" />
+									<arg value="--dot" />
+									<arg value="${project.build.directory}/site/depgraph/engine-external-dependencies.dot" />
+									<arg value="--png" />
+									<arg value="${project.build.directory}/site/depgraph/engine-external-dependencies.png" />
+									<arg value="--include-group-id" />
+									<arg value="${project.groupId}" />
+									<arg value="--root-artifact" />
+									<arg value="${project.groupId}:${project.artifactId}" />
+									<arg value="--page-title" />
+									<arg value="${project.name} External Dependencies" />
+								</exec>
+							</target>
+						</configuration>
+					</execution>
+					<execution>
+						<id>render-engine-jdeps-site</id>
+						<phase>site</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<mkdir dir="${project.build.directory}/site/jdeps" />
+								<exec executable="python3" failonerror="true">
+									<arg value="${maven.multiModuleProjectDirectory}/scripts/generate_jdeps_site_report.py" />
+									<arg value="--summary-dot" />
+									<arg value="${project.build.directory}/site/jdeps/summary.dot" />
+									<arg value="--raw-dir" />
+									<arg value="${project.build.directory}/site/jdeps" />
+									<arg value="--html" />
+									<arg value="${project.build.directory}/site/jdeps-report.html" />
+									<arg value="--png" />
+									<arg value="${project.build.directory}/site/jdeps/jdeps-summary.png" />
+									<arg value="--page-title" />
+									<arg value="${project.name} JDeps Summary" />
+									<arg value="--multi-release" />
+									<arg value="${java.version}" />
+								</exec>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>${maven.site.plugin.version}</version>
 			</plugin>
@@ -166,7 +273,7 @@
 				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.4.1</version>
-					<configuration>
+				<configuration>
 						<quiet>true</quiet>
 						<additionalOptions>-Xdoclint:none</additionalOptions>
 					</configuration>
@@ -263,13 +370,18 @@
 					<skipEmptyReport>false</skipEmptyReport>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-jxr-plugin</artifactId>
-				<version>3.6.0</version>
-			</plugin>
-			<plugin>
-				<groupId>com.github.spotbugs</groupId>
-				<artifactId>spotbugs-maven-plugin</artifactId>
+				<plugin>
+					<artifactId>maven-jxr-plugin</artifactId>
+					<version>3.6.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>jdepend-maven-plugin</artifactId>
+					<version>${jdepend.plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
 				<version>4.9.8.2</version>
 				<configuration>
 					<plugins>

--- a/engine/src/main/java/org/hestiastore/index/EntryIterator.java
+++ b/engine/src/main/java/org/hestiastore/index/EntryIterator.java
@@ -26,7 +26,7 @@ public interface EntryIterator<K, V>
      * @param iterator required iterator
      * @return entry iterator
      */
-    public static <M, N> EntryIterator<M, N> make(
+    static <M, N> EntryIterator<M, N> make(
             final Iterator<Entry<M, N>> iterator) {
         Vldtn.requireNonNull(iterator, "iterator");
         class Adapter extends AbstractCloseableResource

--- a/engine/src/main/java/org/hestiastore/index/bloomfilter/BloomFilterStats.java
+++ b/engine/src/main/java/org/hestiastore/index/bloomfilter/BloomFilterStats.java
@@ -32,7 +32,7 @@ public class BloomFilterStats {
         if (bloomFilterCalls == 0) {
             return 0;
         }
-        return (keyIsNotStored / (double) bloomFilterCalls * 100);
+        return keyIsNotStored / (double) bloomFilterCalls * 100;
     }
 
     String getStatsString() {

--- a/engine/src/main/java/org/hestiastore/index/chunkstore/ChunkFilter.java
+++ b/engine/src/main/java/org/hestiastore/index/chunkstore/ChunkFilter.java
@@ -5,11 +5,11 @@ package org.hestiastore.index.chunkstore;
  */
 public interface ChunkFilter {
 
-    public static final int BIT_POSITION_MAGIC_NUMBER = 0;
-    public static final int BIT_POSITION_CRC32 = 1;
-    public static final int BIT_POSITION_SNAPPY_COMPRESSION = 3;
-    public static final int BIT_POSITION_XOR_ENCRYPT = 4;
-    public static final int BIT_POSITION_AES_GCM_ENCRYPT = 5;
+    int BIT_POSITION_MAGIC_NUMBER = 0;
+    int BIT_POSITION_CRC32 = 1;
+    int BIT_POSITION_SNAPPY_COMPRESSION = 3;
+    int BIT_POSITION_XOR_ENCRYPT = 4;
+    int BIT_POSITION_AES_GCM_ENCRYPT = 5;
 
     /**
      * Apply the filter to the input chunk data.

--- a/engine/src/main/java/org/hestiastore/index/chunkstore/ChunkFilterAesGcmEncrypt.java
+++ b/engine/src/main/java/org/hestiastore/index/chunkstore/ChunkFilterAesGcmEncrypt.java
@@ -71,7 +71,7 @@ public final class ChunkFilterAesGcmEncrypt implements ChunkFilter {
     }
 
     static byte[] buildAad(final ChunkData input, final long flags) {
-        return ByteBuffer.allocate((Long.BYTES * 3) + Integer.BYTES)
+        return ByteBuffer.allocate(Long.BYTES * 3 + Integer.BYTES)
                 .putLong(input.getMagicNumber())
                 .putInt(input.getVersion())
                 .putLong(input.getCrc())

--- a/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockByteReaderImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockByteReaderImpl.java
@@ -40,7 +40,7 @@ public class DataBlockByteReaderImpl extends AbstractCloseableResource
             if (requestedPosition >= dataBlockPayloadSize) {
                 throw new IllegalArgumentException(String.format(
                         "Initial cell index '%s' is out of range. Max allowed is '%s'",
-                        initialCellIndex, (dataBlockPayloadSize / 16) - 1));
+                        initialCellIndex, dataBlockPayloadSize / 16 - 1));
             }
             moveToNextDataBlock();
             this.currentBlockPosition = requestedPosition;

--- a/engine/src/main/java/org/hestiastore/index/properties/IndexPropertiesSchema.java
+++ b/engine/src/main/java/org/hestiastore/index/properties/IndexPropertiesSchema.java
@@ -194,8 +194,9 @@ public final class IndexPropertiesSchema {
             return null;
         }
         final String value = provider.provide(view);
-        if (value == null
-                || (value.isBlank() && !blankAllowedKeys.contains(key))) {
+        final boolean blankValueNotAllowed = value != null && value.isBlank()
+                && !blankAllowedKeys.contains(key);
+        if (value == null || blankValueNotAllowed) {
             return null;
         }
         return value;

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
@@ -441,10 +441,9 @@ final class SegmentCache<K, V> {
                     consumeIfEquals(writeCursor, minKey);
 
                     final V value = resolveValue(minKey, write, frozen, delta);
-                    if (value == null) {
-                        continue;
+                    if (value != null) {
+                        return Entry.of(minKey, value);
                     }
-                    return Entry.of(minKey, value);
                 }
                 return null;
             }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/IndexRetryPolicy.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/IndexRetryPolicy.java
@@ -12,7 +12,6 @@ import org.hestiastore.index.segment.SegmentId;
  */
 public final class IndexRetryPolicy {
 
-    private final int backoffMillis;
     private final int timeoutMillis;
     private final long backoffNanos;
     private final long maxJitterNanos;
@@ -26,8 +25,7 @@ public final class IndexRetryPolicy {
      */
     public IndexRetryPolicy(final int backoffMillis,
             final int timeoutMillis) {
-        this.backoffMillis = Vldtn.requireGreaterThanZero(backoffMillis,
-                "indexBusyBackoffMillis");
+        Vldtn.requireGreaterThanZero(backoffMillis, "indexBusyBackoffMillis");
         this.timeoutMillis = Vldtn.requireGreaterThanZero(timeoutMillis,
                 "indexBusyTimeoutMillis");
         this.backoffNanos = TimeUnit.MILLISECONDS.toNanos(backoffMillis);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinator.java
@@ -123,16 +123,18 @@ final class IndexOperationCoordinator<K, V> {
             final Supplier<IndexResult<T>> operation, final String opName,
             final boolean retryClosed) {
         final long startNanos = retryPolicy.startNanos();
-        while (true) {
-            final IndexResult<T> result = operation.get();
-            final IndexResultStatus status = result.getStatus();
-            if (status == IndexResultStatus.BUSY
-                    || (retryClosed && status == IndexResultStatus.CLOSED)) {
-                retryPolicy.backoffOrThrow(startNanos, opName, null);
-                continue;
-            }
-            return result;
+        IndexResult<T> result = operation.get();
+        while (shouldRetry(result.getStatus(), retryClosed)) {
+            retryPolicy.backoffOrThrow(startNanos, opName, null);
+            result = operation.get();
         }
+        return result;
+    }
+
+    private boolean shouldRetry(final IndexResultStatus status,
+            final boolean retryClosed) {
+        return status == IndexResultStatus.BUSY
+                || retryClosed && status == IndexResultStatus.CLOSED;
     }
 
     private IndexException newIndexException(final String operation,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinator.java
@@ -14,7 +14,6 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
-import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
 import org.slf4j.Logger;
 
@@ -98,33 +97,29 @@ final class IndexRecoveryCleanupCoordinator<K, V> {
 
     private void deleteOrphanedSegmentDirectory(final SegmentId segmentId) {
         final long startNanos = retryPolicy.startNanos();
-        while (true) {
-            final SegmentRegistryResult<Void> deleteResult = segmentRegistry
-                    .deleteSegment(segmentId);
-            if (deleteResult.getStatus() == SegmentRegistryResultStatus.OK
-                    || deleteResult
-                            .getStatus() == SegmentRegistryResultStatus.CLOSED) {
-                logger.info(
-                        "Deleted orphaned segment directory '{}' during recovery/consistency cleanup.",
+        SegmentRegistryResultStatus status = segmentRegistry
+                .deleteSegment(segmentId).getStatus();
+        while (status == SegmentRegistryResultStatus.BUSY) {
+            try {
+                retryPolicy.backoffOrThrow(startNanos,
+                        OPERATION_CLEANUP_ORPHAN_SEGMENT, segmentId);
+            } catch (final IndexException timeout) {
+                logger.warn(
+                        "Orphaned segment directory '{}' could not be deleted because cleanup timed out.",
                         segmentId);
                 return;
             }
-            if (deleteResult.getStatus() == SegmentRegistryResultStatus.BUSY) {
-                try {
-                    retryPolicy.backoffOrThrow(startNanos,
-                            OPERATION_CLEANUP_ORPHAN_SEGMENT, segmentId);
-                } catch (final IndexException timeout) {
-                    logger.warn(
-                            "Orphaned segment directory '{}' could not be deleted because cleanup timed out.",
-                            segmentId);
-                    return;
-                }
-                continue;
-            }
+            status = segmentRegistry.deleteSegment(segmentId).getStatus();
+        }
+        if (status == SegmentRegistryResultStatus.OK
+                || status == SegmentRegistryResultStatus.CLOSED) {
+            logger.info(
+                    "Deleted orphaned segment directory '{}' during recovery/consistency cleanup.",
+                    segmentId);
+        } else {
             logger.warn(
                     "Orphaned segment directory '{}' could not be deleted during cleanup: {}",
-                    segmentId, deleteResult.getStatus());
-            return;
+                    segmentId, status);
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexStateClosing.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexStateClosing.java
@@ -10,11 +10,12 @@ import org.hestiastore.index.directory.FileLock;
  * @param <K> key type
  * @param <V> value type
  */
-final record IndexStateClosing<K, V>(FileLock fileLock)
-        implements IndexState<K, V> {
+final class IndexStateClosing<K, V> implements IndexState<K, V> {
 
-    IndexStateClosing {
-        fileLock = Vldtn.requireNonNull(fileLock, "fileLock");
+    private final FileLock fileLock;
+
+    IndexStateClosing(final FileLock fileLock) {
+        this.fileLock = Vldtn.requireNonNull(fileLock, "fileLock");
     }
 
     /** {@inheritDoc} */

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntime.java
@@ -16,7 +16,6 @@ import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
-import org.hestiastore.index.segmentregistry.SegmentFactory;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.slf4j.Logger;
 
@@ -30,11 +29,9 @@ final class SegmentIndexRuntime<K, V> {
 
     private final RuntimeTuningState runtimeTuningState;
     private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
-    private final SegmentFactory<K, V> segmentFactory;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop;
-    private final StableSegmentGateway<K, V> stableSegmentGateway;
     private final StableSegmentCoordinator<K, V> stableSegmentCoordinator;
     private final PartitionDrainCoordinator<K, V> partitionDrainCoordinator;
     private final PartitionWriteCoordinator<K, V> partitionWriteCoordinator;
@@ -53,11 +50,9 @@ final class SegmentIndexRuntime<K, V> {
     SegmentIndexRuntime(
             final RuntimeTuningState runtimeTuningState,
             final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
-            final SegmentFactory<K, V> segmentFactory,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop,
-            final StableSegmentGateway<K, V> stableSegmentGateway,
             final StableSegmentCoordinator<K, V> stableSegmentCoordinator,
             final PartitionDrainCoordinator<K, V> partitionDrainCoordinator,
             final PartitionWriteCoordinator<K, V> partitionWriteCoordinator,
@@ -73,11 +68,9 @@ final class SegmentIndexRuntime<K, V> {
             final SegmentRuntimeLimitApplier<K, V> runtimeLimitApplier) {
         this.runtimeTuningState = runtimeTuningState;
         this.keyToSegmentMap = keyToSegmentMap;
-        this.segmentFactory = segmentFactory;
         this.segmentRegistry = segmentRegistry;
         this.backgroundSplitCoordinator = backgroundSplitCoordinator;
         this.backgroundSplitPolicyLoop = backgroundSplitPolicyLoop;
-        this.stableSegmentGateway = stableSegmentGateway;
         this.stableSegmentCoordinator = stableSegmentCoordinator;
         this.partitionDrainCoordinator = partitionDrainCoordinator;
         this.partitionWriteCoordinator = partitionWriteCoordinator;

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
@@ -225,9 +225,8 @@ final class SegmentIndexRuntimeBuilder<K, V> {
             final SegmentRuntimeLimitApplier<K, V> runtimeLimitApplier = new SegmentRuntimeLimitApplier<>(
                     segmentRegistry, segmentFactory);
             return new SegmentIndexRuntime<>(runtimeTuningState,
-                    keyToSegmentMap, segmentFactory, segmentRegistry,
-                    backgroundSplitCoordinator, backgroundSplitPolicyLoop,
-                    stableSegmentGateway, stableSegmentCoordinator,
+                    keyToSegmentMap, segmentRegistry, backgroundSplitCoordinator,
+                    backgroundSplitPolicyLoop, stableSegmentCoordinator,
                     partitionDrainCoordinator, partitionWriteCoordinator,
                     partitionReadCoordinator, maintenanceCoordinator,
                     recoveryCleanupCoordinator, retryPolicy, walRuntime,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/split/PartitionStableSplitCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/split/PartitionStableSplitCoordinator.java
@@ -517,44 +517,37 @@ public class PartitionStableSplitCoordinator<K, V> {
 
     private void deleteRetiredParentSegment(final SegmentId segmentId) {
         final long startNanos = retryPolicy.startNanos();
-        while (true) {
-            final SegmentRegistryResult<Void> deleteResult = segmentRegistry
-                    .deleteSegment(segmentId);
-            if (deleteResult.getStatus() == SegmentRegistryResultStatus.OK
-                    || deleteResult
-                            .getStatus() == SegmentRegistryResultStatus.CLOSED) {
+        SegmentRegistryResultStatus status = segmentRegistry.deleteSegment(segmentId)
+                .getStatus();
+        while (status == SegmentRegistryResultStatus.BUSY) {
+            try {
+                retryPolicy.backoffOrThrow(startNanos, "deleteRetiredSplit",
+                        segmentId);
+            } catch (final IndexException timeout) {
+                logger.warn(
+                        "Retired parent segment '{}' remained on disk because delete timed out after split publish.",
+                        segmentId);
                 return;
             }
-            if (deleteResult.getStatus() == SegmentRegistryResultStatus.BUSY) {
-                try {
-                    retryPolicy.backoffOrThrow(startNanos, "deleteRetiredSplit",
-                            segmentId);
-                } catch (final IndexException timeout) {
-                    logger.warn(
-                            "Retired parent segment '{}' remained on disk because delete timed out after split publish.",
-                            segmentId);
-                    return;
-                }
-                continue;
-            }
+            status = segmentRegistry.deleteSegment(segmentId).getStatus();
+        }
+        if (status != SegmentRegistryResultStatus.OK
+                && status != SegmentRegistryResultStatus.CLOSED) {
             logger.warn(
                     "Retired parent segment '{}' could not be deleted after split publish: {}",
-                    segmentId, deleteResult.getStatus());
-            return;
+                    segmentId, status);
         }
     }
 
     private SegmentRegistryResult<Segment<K, V>> createSegment() {
         final long startNanos = retryPolicy.startNanos();
-        while (true) {
-            final SegmentRegistryResult<Segment<K, V>> result = segmentRegistry
-                    .createSegment();
-            if (result.getStatus() == SegmentRegistryResultStatus.BUSY) {
-                retryPolicy.backoffOrThrow(startNanos, "createSegment", null);
-                continue;
-            }
-            return result;
+        SegmentRegistryResult<Segment<K, V>> result = segmentRegistry
+                .createSegment();
+        while (result.getStatus() == SegmentRegistryResultStatus.BUSY) {
+            retryPolicy.backoffOrThrow(startNanos, "createSegment", null);
+            result = segmentRegistry.createSegment();
         }
+        return result;
     }
 
     private void deleteSplitSegments(final SegmentId lowerSegmentId,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalStorageFactory.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalStorageFactory.java
@@ -39,9 +39,10 @@ final class WalStorageFactory {
                 if (value instanceof File file) {
                     return file.toPath();
                 }
-            } catch (NoSuchFieldException e) {
-                // Continue with superclass lookup.
-            } catch (ReflectiveOperationException e) {
+            } catch (final NoSuchFieldException ex) {
+                type = type.getSuperclass();
+                continue;
+            } catch (final ReflectiveOperationException ex) {
                 return null;
             }
             type = type.getSuperclass();

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalStorageFs.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalStorageFs.java
@@ -163,7 +163,7 @@ final class WalStorageFs implements WalStorage {
 
     @Override
     public Stream<String> listFileNames() {
-        try (final Stream<Path> listing = Files.list(walDirectory)) {
+        try (Stream<Path> listing = Files.list(walDirectory)) {
             return listing.sorted(Comparator.comparing(Path::getFileName))
                     .map(path -> path.getFileName().toString()).toList()
                     .stream();

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalTool.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalTool.java
@@ -157,7 +157,7 @@ public final class WalTool {
                             file.getFileName().toString(), offset,
                             "DELETE record must have zero value length.");
                 }
-                if (lsn <= 0L || (previousLsn > 0L && lsn <= previousLsn)) {
+                if (lsn <= 0L || previousLsn > 0L && lsn <= previousLsn) {
                     return new VerifyResult(false, files.size(), records, maxLsn,
                             file.getFileName().toString(), offset,
                             "Non-monotonic or invalid LSN.");

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryBuilder.java
@@ -190,14 +190,24 @@ public final class SegmentRegistryBuilder<K, V> {
         final SegmentRegistryCache<SegmentId, Segment<K, V>> cache = new SegmentRegistryCache<>(
                 maxNumberOfSegmentsInCache, maintenance::loadSegment,
                 maintenance::closeSegmentIfNeeded,
-                resolvedRegistryMaintenanceExecutor,
-                segment -> segment != null && (segment.getState() == SegmentState.CLOSED
-                        || (!pinnedSegments.contains(segment.getId())
-                                && segment.getState() == SegmentState.READY
-                                && segment.getNumberOfKeysInWriteCache() == 0)));
+                resolvedRegistryMaintenanceExecutor, segment -> isEvictable(
+                        segment, pinnedSegments));
         return new SegmentRegistryImpl<>(resolvedAllocator, resolvedFileSystem,
                 cache, resolvedRegistryCloseRetryPolicy, gate,
                 pinnedSegments);
+    }
+
+    private static <K, V> boolean isEvictable(final Segment<K, V> segment,
+            final Set<SegmentId> pinnedSegments) {
+        return segment != null && (segment.getState() == SegmentState.CLOSED
+                || isUnpinnedReadySegment(segment, pinnedSegments));
+    }
+
+    private static <K, V> boolean isUnpinnedReadySegment(
+            final Segment<K, V> segment, final Set<SegmentId> pinnedSegments) {
+        return !pinnedSegments.contains(segment.getId())
+                && segment.getState() == SegmentState.READY
+                && segment.getNumberOfKeysInWriteCache() == 0;
     }
 
     private static int sanitizeRetryConf(final Integer configured,

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryFileSystem.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryFileSystem.java
@@ -73,11 +73,7 @@ final class SegmentRegistryFileSystem {
         final Directory directory = directoryFacade
                 .openSubDirectory(directoryName);
         clearDirectory(directory);
-        try {
-            directoryFacade.rmdir(directoryName);
-        } catch (final RuntimeException e) {
-            // Best-effort cleanup.
-        }
+        removeDirectory(directoryName);
     }
 
     /**
@@ -94,30 +90,11 @@ final class SegmentRegistryFileSystem {
     private void clearDirectory(final Directory directory) {
         try (Stream<String> files = directory.getFileNames()) {
             files.forEach(fileName -> {
-                boolean deleted = false;
-                try {
-                    deleted = directory.deleteFile(fileName);
-                    if (deleted) {
-                        return;
-                    }
-                } catch (final RuntimeException e) {
-                    // fall through to directory cleanup
-                }
-                try {
-                    if (!directory.isFileExists(fileName)) {
-                        return;
-                    }
-                } catch (final RuntimeException e) {
+                if (tryDeleteFile(directory, fileName)
+                        || !exists(directory, fileName)) {
                     return;
                 }
-                try {
-                    final Directory subDirectory = directory
-                            .openSubDirectory(fileName);
-                    clearDirectory(subDirectory);
-                    directory.rmdir(fileName);
-                } catch (final RuntimeException e) {
-                    // Best-effort cleanup.
-                }
+                deleteSubDirectory(directory, fileName);
             });
         }
     }
@@ -130,6 +107,43 @@ final class SegmentRegistryFileSystem {
      */
     private boolean exists(final String fileName) {
         return directoryFacade.isFileExists(fileName);
+    }
+
+    private void removeDirectory(final String directoryName) {
+        try {
+            directoryFacade.rmdir(directoryName);
+        } catch (final RuntimeException ex) {
+            return;
+        }
+    }
+
+    private boolean tryDeleteFile(final Directory directory,
+            final String fileName) {
+        try {
+            return directory.deleteFile(fileName);
+        } catch (final RuntimeException ex) {
+            return false;
+        }
+    }
+
+    private boolean exists(final Directory directory, final String fileName) {
+        try {
+            return directory.isFileExists(fileName);
+        } catch (final RuntimeException ex) {
+            return false;
+        }
+    }
+
+    private void deleteSubDirectory(final Directory directory,
+            final String directoryName) {
+        try {
+            final Directory subDirectory = directory
+                    .openSubDirectory(directoryName);
+            clearDirectory(subDirectory);
+            directory.rmdir(directoryName);
+        } catch (final RuntimeException ex) {
+            return;
+        }
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -132,26 +132,37 @@ public final class SegmentRegistryImpl<K, V> implements SegmentRegistry<K, V> {
         if (state != SegmentRegistryState.READY) {
             return SegmentRegistryResult.fromStatus(resultForState(state));
         }
-        while (true) {
-            final Segment<K, V> segment;
-            try {
-                segment = cache.get(segmentId);
-            } catch (final SegmentRegistryCache.EntryBusyException
-                    | SegmentBusyException ex) {
-                return SegmentRegistryResult.busy();
-            } catch (final RuntimeException ex) {
-                logger.error("Failed to load segment '{}'.", segmentId, ex);
-                return SegmentRegistryResult.error();
-            }
-            if (segment == null) {
-                return SegmentRegistryResult.error();
-            }
-            if (segment.getState() == SegmentState.CLOSED) {
-                cache.invalidate(segmentId);
-                continue;
-            }
-            return SegmentRegistryResult.ok(segment);
+        SegmentRegistryResult<Segment<K, V>> result = loadSegmentFromCache(
+                segmentId);
+        while (isClosedSegment(result)) {
+            cache.invalidate(segmentId);
+            result = loadSegmentFromCache(segmentId);
         }
+        return result;
+    }
+
+    private SegmentRegistryResult<Segment<K, V>> loadSegmentFromCache(
+            final SegmentId segmentId) {
+        final Segment<K, V> segment;
+        try {
+            segment = cache.get(segmentId);
+        } catch (final SegmentRegistryCache.EntryBusyException
+                | SegmentBusyException ex) {
+            return SegmentRegistryResult.busy();
+        } catch (final RuntimeException ex) {
+            logger.error("Failed to load segment '{}'.", segmentId, ex);
+            return SegmentRegistryResult.error();
+        }
+        if (segment == null) {
+            return SegmentRegistryResult.error();
+        }
+        return SegmentRegistryResult.ok(segment);
+    }
+
+    private boolean isClosedSegment(
+            final SegmentRegistryResult<Segment<K, V>> result) {
+        return result.isOk() && result.getValue() != null
+                && result.getValue().getState() == SegmentState.CLOSED;
     }
 
     /**

--- a/engine/src/site/site.xml
+++ b/engine/src/site/site.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site xmlns="http://maven.apache.org/SITE/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd"
+    name="${project.name}">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.0.0-M11</version>
+    </skin>
+    <body>
+        <menu name="Dependency Reports">
+            <item name="External Dependencies" href="external-dependencies.html" />
+            <item name="JDeps Summary" href="jdeps-report.html" />
+            <item name="JDepend" href="jdepend-report.html" />
+        </menu>
+        <menu ref="reports" />
+    </body>
+</site>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
         <jacoco.version>0.8.14</jacoco.version>
         <maven.site.plugin.version>4.0.0-M16</maven.site.plugin.version>
         <project.info.reports.plugin.version>3.9.0</project.info.reports.plugin.version>
+        <jdepend.plugin.version>2.2.1-SNAPSHOT</jdepend.plugin.version>
+        <jdeps.plugin.version>3.2.0</jdeps.plugin.version>
+        <depgraph.plugin.version>4.0.3</depgraph.plugin.version>
+        <antrun.plugin.version>3.1.0</antrun.plugin.version>
         <pmd.plugin.version>3.21.2</pmd.plugin.version>
         <spotbugs.plugin.version>4.9.8.2</spotbugs.plugin.version>
         <micrometer.version>1.16.4</micrometer.version>
@@ -114,6 +118,68 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${maven.site.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.ferstl</groupId>
+                <artifactId>depgraph-maven-plugin</artifactId>
+                <version>${depgraph.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>generate-reactor-dependency-json</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <classpathScope>compile</classpathScope>
+                            <graphFormat>json</graphFormat>
+                            <mergeClassifiers>true</mergeClassifiers>
+                            <mergeScopes>true</mergeScopes>
+                            <mergeTypes>true</mergeTypes>
+                            <outputDirectory>${project.build.directory}/site/depgraph</outputDirectory>
+                            <outputFileName>reactor-dependencies</outputFileName>
+                            <reduceEdges>false</reduceEdges>
+                            <showGroupIds>true</showGroupIds>
+                            <showVersions>true</showVersions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${antrun.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>render-reactor-dependency-site</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/site/depgraph" />
+                                <exec executable="python3" failonerror="true">
+                                    <arg value="${maven.multiModuleProjectDirectory}/scripts/generate_dependency_site_report.py" />
+                                    <arg value="reactor" />
+                                    <arg value="--json" />
+                                    <arg value="${project.build.directory}/site/depgraph/reactor-dependencies.json" />
+                                    <arg value="--html" />
+                                    <arg value="${project.build.directory}/site/module-dependencies.html" />
+                                    <arg value="--dot" />
+                                    <arg value="${project.build.directory}/site/depgraph/reactor-dependencies.dot" />
+                                    <arg value="--png" />
+                                    <arg value="${project.build.directory}/site/depgraph/reactor-dependencies.png" />
+                                    <arg value="--include-group-id" />
+                                    <arg value="${project.groupId}" />
+                                    <arg value="--page-title" />
+                                    <arg value="${project.name} Module Dependencies" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/scripts/generate_dependency_site_report.py
+++ b/scripts/generate_dependency_site_report.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Generate custom Maven site pages from depgraph JSON output."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+SCOPE_ORDER = {
+    "compile": 0,
+    "provided": 1,
+    "runtime": 2,
+    "system": 3,
+    "test": 4,
+}
+
+SCOPE_COLORS = {
+    "compile": "#dbeafe",
+    "provided": "#fde68a",
+    "runtime": "#bbf7d0",
+    "system": "#f5d0fe",
+    "test": "#e5e7eb",
+}
+
+DEGREE_COLORS = {
+    0: "#f8fafc",
+    1: "#e2e8f0",
+    2: "#bfdbfe",
+    3: "#93c5fd",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("engine", "reactor"))
+    parser.add_argument("--json", dest="json_path", required=True)
+    parser.add_argument("--html", dest="html_path", required=True)
+    parser.add_argument("--dot", dest="dot_path", required=True)
+    parser.add_argument("--png", dest="png_path", required=True)
+    parser.add_argument("--include-group-id", required=True)
+    parser.add_argument("--page-title", required=True)
+    parser.add_argument("--root-artifact")
+    return parser.parse_args()
+
+
+def sort_scopes(scopes: list[str]) -> list[str]:
+    return sorted(scopes, key=lambda scope: SCOPE_ORDER.get(scope, len(SCOPE_ORDER)))
+
+
+def scope_sort_key(artifact: dict[str, object]) -> tuple[int, str, str]:
+    scopes = sort_scopes(list(artifact.get("scopes", [])))
+    primary_scope = scopes[0] if scopes else "zz"
+    return (
+        SCOPE_ORDER.get(primary_scope, len(SCOPE_ORDER)),
+        str(artifact["groupId"]),
+        str(artifact["artifactId"]),
+    )
+
+
+def artifact_coords(artifact: dict[str, object]) -> str:
+    return f"{artifact['groupId']}:{artifact['artifactId']}"
+
+
+def artifact_label(artifact: dict[str, object]) -> str:
+    version = str(artifact.get("version", ""))
+    scopes = ", ".join(sort_scopes(list(artifact.get("scopes", []))))
+    label_lines = [str(artifact["artifactId"])]
+    if version:
+        label_lines.append(version)
+    if scopes:
+        label_lines.append(scopes)
+    return "\\n".join(label_lines)
+
+
+def html_text(value: object) -> str:
+    return html.escape(str(value))
+
+
+def dot_text(value: object) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def render_png(dot_path: Path, png_path: Path) -> bool:
+    dot_executable = shutil.which("dot")
+    if not dot_executable:
+        return False
+
+    subprocess.run(
+        [dot_executable, "-Tpng", str(dot_path), "-o", str(png_path)],
+        check=True,
+    )
+    return True
+
+
+def html_page(title: str, intro: str, image_html: str, sections: list[str]) -> str:
+    sections_html = "\n".join(sections)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{html_text(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --border: #dbe3ee;
+      --text: #0f172a;
+      --muted: #475569;
+      --accent: #1d4ed8;
+    }}
+    body {{
+      margin: 0;
+      padding: 2rem;
+      background: linear-gradient(180deg, #eef4ff 0%, var(--bg) 220px);
+      color: var(--text);
+      font: 16px/1.5 "IBM Plex Sans", "Segoe UI", sans-serif;
+    }}
+    main {{
+      max-width: 1200px;
+      margin: 0 auto;
+    }}
+    h1, h2 {{
+      line-height: 1.2;
+    }}
+    .lead {{
+      max-width: 72ch;
+      color: var(--muted);
+    }}
+    .panel {{
+      margin-top: 1.5rem;
+      padding: 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--panel);
+      box-shadow: 0 16px 48px rgba(15, 23, 42, 0.06);
+    }}
+    .cards {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-top: 1.25rem;
+    }}
+    .card {{
+      padding: 1rem;
+      border-radius: 14px;
+      background: #f8fbff;
+      border: 1px solid var(--border);
+    }}
+    .metric {{
+      display: block;
+      font-size: 1.8rem;
+      font-weight: 700;
+    }}
+    .metric-label {{
+      color: var(--muted);
+    }}
+    img {{
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: #fff;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+    }}
+    th, td {{
+      padding: 0.7rem;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+    }}
+    th {{
+      font-size: 0.92rem;
+      color: var(--muted);
+    }}
+    code {{
+      background: #eff6ff;
+      border-radius: 6px;
+      padding: 0.1rem 0.35rem;
+    }}
+    .note {{
+      color: var(--muted);
+    }}
+    a {{
+      color: var(--accent);
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{html_text(title)}</h1>
+    <p class="lead">{intro}</p>
+    {image_html}
+    {sections_html}
+  </main>
+</body>
+</html>
+"""
+
+
+def summary_cards(cards: list[tuple[str, object]]) -> str:
+    items = "\n".join(
+        (
+            f'<div class="card"><span class="metric">{html_text(value)}</span>'
+            f'<span class="metric-label">{html_text(label)}</span></div>'
+        )
+        for label, value in cards
+    )
+    return f'<section class="cards">{items}</section>'
+
+
+def table_section(title: str, headers: list[str], rows: list[list[object]]) -> str:
+    header_html = "".join(f"<th>{html_text(header)}</th>" for header in headers)
+    body_rows = []
+    for row in rows:
+        columns = "".join(f"<td>{html_text(column)}</td>" for column in row)
+        body_rows.append(f"<tr>{columns}</tr>")
+    rows_html = "\n".join(body_rows) if body_rows else "<tr><td colspan=\"99\">No rows.</td></tr>"
+    return (
+        f'<section class="panel"><h2>{html_text(title)}</h2><table>'
+        f"<thead><tr>{header_html}</tr></thead><tbody>{rows_html}</tbody></table></section>"
+    )
+
+
+def image_section(title: str, image_path: Path, generated: bool) -> str:
+    if generated:
+        image_html = (
+            f'<img src="{html_text(image_path.as_posix())}" alt="{html_text(title)}" />'
+            '<p class="note">Image generated from the same JSON source as the tables below.</p>'
+        )
+    else:
+        image_html = (
+            '<p class="note">Graphviz <code>dot</code> was not available, '
+            "so only the table report was generated.</p>"
+        )
+    return f'<section class="panel"><h2>{html_text(title)}</h2>{image_html}</section>'
+
+
+def degree_color(total_degree: int) -> str:
+    if total_degree >= 3:
+        return DEGREE_COLORS[3]
+    return DEGREE_COLORS.get(total_degree, DEGREE_COLORS[0])
+
+
+def reachable_nodes(start: str, adjacency: dict[str, set[str]]) -> set[str]:
+    seen: set[str] = set()
+    stack = list(adjacency.get(start, ()))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(adjacency.get(current, ()))
+    return seen
+
+
+def build_engine_report(
+    args: argparse.Namespace, data: dict[str, object]
+) -> tuple[str, str, str, Path, list[str]]:
+    root_group_id, root_artifact_id = args.root_artifact.split(":", 1)
+    artifacts = {artifact["id"]: artifact for artifact in data["artifacts"]}
+
+    root_artifact = next(
+        (
+            artifact
+            for artifact in artifacts.values()
+            if artifact["groupId"] == root_group_id and artifact["artifactId"] == root_artifact_id
+        ),
+        None,
+    )
+    if root_artifact is None:
+        raise ValueError(f"Root artifact {args.root_artifact} was not found in {args.json_path}.")
+
+    direct_external_edges = []
+    for dependency in data["dependencies"]:
+        if dependency["from"] != root_artifact["id"]:
+            continue
+        target_artifact = artifacts[dependency["to"]]
+        if target_artifact["groupId"] == args.include_group_id:
+            continue
+        direct_external_edges.append((dependency, target_artifact))
+
+    direct_external_edges.sort(key=lambda item: scope_sort_key(item[1]))
+    direct_external_artifacts = [artifact for _, artifact in direct_external_edges]
+
+    compile_like = 0
+    test_only = 0
+    for artifact in direct_external_artifacts:
+        scopes = set(artifact.get("scopes", []))
+        if scopes == {"test"}:
+            test_only += 1
+        else:
+            compile_like += 1
+
+    rows = []
+    for _, artifact in direct_external_edges:
+        rows.append(
+            [
+                artifact_coords(artifact),
+                artifact.get("version", ""),
+                ", ".join(sort_scopes(list(artifact.get("scopes", [])))),
+                ", ".join(sorted(artifact.get("types", []))),
+                "yes" if artifact.get("optional", False) else "no",
+            ]
+        )
+
+    dot_lines = [
+        'digraph "engine_external_dependencies" {',
+        "  rankdir=LR;",
+        '  graph [bgcolor="transparent", pad="0.2"];',
+        '  node [shape=box, style="rounded,filled", color="#475569", fontname="Helvetica"];',
+        '  edge [color="#64748b", arrowsize="0.8", fontname="Helvetica"];',
+        (
+            f'  "{dot_text(root_artifact["id"])}" '
+            f'[label="{dot_text(root_artifact["artifactId"])}", fillcolor="#0f172a", fontcolor="white"];'
+        ),
+    ]
+
+    for _, artifact in direct_external_edges:
+        scopes = sort_scopes(list(artifact.get("scopes", [])))
+        primary_scope = scopes[0] if scopes else "compile"
+        dot_lines.append(
+            (
+                f'  "{dot_text(artifact["id"])}" '
+                f'[label="{dot_text(artifact_label(artifact))}", '
+                f'fillcolor="{SCOPE_COLORS.get(primary_scope, "#e2e8f0")}"];'
+            )
+        )
+        dot_lines.append(
+            (
+                f'  "{dot_text(root_artifact["id"])}" -> "{dot_text(artifact["id"])}" '
+                f'[label="{dot_text(", ".join(scopes))}"];'
+            )
+        )
+    dot_lines.append("}")
+
+    cards = summary_cards(
+        [
+            ("Direct external dependencies", len(direct_external_artifacts)),
+            ("Production-oriented scopes", compile_like),
+            ("Test-only scopes", test_only),
+        ]
+    )
+    tables = [
+        cards,
+        (
+            '<section class="panel"><h2>Standard Maven Tables</h2>'
+            '<p class="note">The built-in Maven dependency table remains available in '
+            '<a href="dependencies.html">Dependencies</a>. '
+            "The custom page below keeps the direct external view compact.</p></section>"
+        ),
+        table_section(
+            "Direct External Dependencies",
+            ["Dependency", "Version", "Scopes", "Type", "Optional"],
+            rows,
+        ),
+    ]
+
+    intro = (
+        "This page summarizes the direct external dependencies of the engine module. "
+        "It keeps the graph focused on first-level dependencies and leaves the full transitive table "
+        "to the standard Maven dependencies report."
+    )
+    return (
+        "\n".join(dot_lines),
+        intro,
+        "Direct External Dependency Graph",
+        Path("depgraph/engine-external-dependencies.png"),
+        tables,
+    )
+
+
+def build_reactor_report(
+    args: argparse.Namespace, data: dict[str, object]
+) -> tuple[str, str, str, Path, list[str]]:
+    artifacts = {
+        artifact["id"]: artifact
+        for artifact in data.get("artifacts", [])
+        if artifact["groupId"] == args.include_group_id and "pom" not in artifact.get("types", [])
+    }
+    dependencies = [
+        dependency
+        for dependency in data.get("dependencies", [])
+        if dependency["from"] in artifacts and dependency["to"] in artifacts
+    ]
+    dependencies.sort(
+        key=lambda dependency: (
+            str(artifacts[dependency["from"]]["artifactId"]),
+            str(artifacts[dependency["to"]]["artifactId"]),
+        )
+    )
+
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    reverse_adjacency: dict[str, set[str]] = defaultdict(set)
+    for artifact_id in artifacts:
+        adjacency.setdefault(artifact_id, set())
+        reverse_adjacency.setdefault(artifact_id, set())
+    for dependency in dependencies:
+        adjacency[dependency["from"]].add(dependency["to"])
+        reverse_adjacency[dependency["to"]].add(dependency["from"])
+
+    summary_rows = []
+    for artifact_id, artifact in sorted(
+        artifacts.items(),
+        key=lambda item: str(item[1]["artifactId"]),
+    ):
+        transitive_out = reachable_nodes(artifact_id, adjacency)
+        transitive_in = reachable_nodes(artifact_id, reverse_adjacency)
+        summary_rows.append(
+            [
+                artifact["artifactId"],
+                len(adjacency[artifact_id]),
+                len(reverse_adjacency[artifact_id]),
+                len(transitive_out),
+                len(transitive_in),
+            ]
+        )
+
+    strongest_source = "-"
+    strongest_out = 0
+    for module_name, direct_out, _, _, _ in summary_rows:
+        if direct_out > strongest_out:
+            strongest_source = str(module_name)
+            strongest_out = int(direct_out)
+
+    edge_rows = []
+    for dependency in dependencies:
+        source = artifacts[dependency["from"]]
+        target = artifacts[dependency["to"]]
+        edge_rows.append(
+            [
+                source["artifactId"],
+                target["artifactId"],
+                dependency.get("resolution", ""),
+            ]
+        )
+
+    dot_lines = [
+        'digraph "module_dependencies" {',
+        "  rankdir=LR;",
+        '  graph [bgcolor="transparent", pad="0.2"];',
+        '  node [shape=box, style="rounded,filled", color="#475569", fontname="Helvetica"];',
+        '  edge [color="#64748b", arrowsize="0.8"];',
+    ]
+    for artifact_id, artifact in sorted(
+        artifacts.items(),
+        key=lambda item: str(item[1]["artifactId"]),
+    ):
+        direct_out = len(adjacency[artifact_id])
+        direct_in = len(reverse_adjacency[artifact_id])
+        total_degree = direct_out + direct_in
+        label = f"{artifact['artifactId']}\\nout:{direct_out} in:{direct_in}"
+        dot_lines.append(
+            (
+                f'  "{dot_text(artifact_id)}" [label="{dot_text(label)}", '
+                f'fillcolor="{degree_color(total_degree)}"];'
+            )
+        )
+    for dependency in dependencies:
+        dot_lines.append(
+            f'  "{dot_text(dependency["from"])}" -> "{dot_text(dependency["to"])}";'
+        )
+    dot_lines.append("}")
+
+    cards = summary_cards(
+        [
+            ("Modules in graph", len(artifacts)),
+            ("Direct module edges", len(dependencies)),
+            (
+                "Highest direct fan-out",
+                f"{strongest_source} ({strongest_out})" if summary_rows else "-",
+            ),
+        ]
+    )
+    tables = [
+        cards,
+        (
+            '<section class="panel"><h2>How Strength Is Estimated</h2>'
+            "<p class=\"note\">Maven does not expose a weighted coupling score for reactor modules. "
+            "This report uses direct incoming and outgoing dependency counts, plus transitive reach, "
+            "as a practical proxy for dependency strength.</p></section>"
+        ),
+        table_section(
+            "Direct Module Dependencies",
+            ["From", "To", "Resolution"],
+            edge_rows,
+        ),
+        table_section(
+            "Coupling Summary",
+            [
+                "Module",
+                "Direct Out",
+                "Direct In",
+                "Transitive Out",
+                "Transitive In",
+            ],
+            summary_rows,
+        ),
+    ]
+
+    intro = (
+        "This page focuses on direct compile-scope dependencies between modules in the reactor. "
+        "The graph highlights the structural connections, while the tables provide a simple coupling summary."
+    )
+    return (
+        "\n".join(dot_lines),
+        intro,
+        "Compile-Scope Module Graph",
+        Path("depgraph/reactor-dependencies.png"),
+        tables,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    data = json.loads(Path(args.json_path).read_text(encoding="utf-8"))
+
+    if args.mode == "engine":
+        if not args.root_artifact:
+            raise ValueError("--root-artifact is required in engine mode.")
+        dot_content, intro, image_title, image_path, sections = build_engine_report(args, data)
+    else:
+        dot_content, intro, image_title, image_path, sections = build_reactor_report(args, data)
+
+    dot_path = Path(args.dot_path)
+    html_path = Path(args.html_path)
+    png_path = Path(args.png_path)
+
+    write_text(dot_path, dot_content)
+    image_generated = render_png(dot_path, png_path)
+    html_content = html_page(
+        args.page_title,
+        intro,
+        image_section(image_title, image_path, image_generated),
+        sections,
+    )
+    write_text(html_path, html_content)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - site generation should fail loudly.
+        print(f"Failed to generate dependency site report: {exc}", file=sys.stderr)
+        raise

--- a/scripts/generate_jdeps_site_report.py
+++ b/scripts/generate_jdeps_site_report.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate an HTML site page from jdeps DOT output."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+EDGE_PATTERN = re.compile(r'^\s*"(?P<source>.+?)"\s*->\s*"(?P<target>.+?)";\s*$')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--summary-dot", required=True)
+    parser.add_argument("--raw-dir", required=True)
+    parser.add_argument("--html", dest="html_path", required=True)
+    parser.add_argument("--png", dest="png_path", required=True)
+    parser.add_argument("--page-title", required=True)
+    parser.add_argument("--multi-release", required=True)
+    return parser.parse_args()
+
+
+def html_text(value: object) -> str:
+    return html.escape(str(value))
+
+
+def parse_edges(summary_dot: Path) -> list[tuple[str, str]]:
+    edges: list[tuple[str, str]] = []
+    for line in summary_dot.read_text(encoding="utf-8").splitlines():
+        match = EDGE_PATTERN.match(line)
+        if match:
+            edges.append((match.group("source"), match.group("target")))
+    return edges
+
+
+def classify_target(target: str) -> str:
+    if target == "not found":
+        return "Unresolved"
+    if target.startswith("java.") or target.startswith("jdk."):
+        return "JDK module"
+    return "Classpath dependency"
+
+
+def render_png(summary_dot: Path, png_path: Path) -> bool:
+    dot_executable = shutil.which("dot")
+    if not dot_executable:
+        return False
+
+    png_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [dot_executable, "-Tpng", str(summary_dot), "-o", str(png_path)],
+        check=True,
+    )
+    return True
+
+
+def summary_cards(cards: list[tuple[str, object]]) -> str:
+    items = "\n".join(
+        (
+            f'<div class="card"><span class="metric">{html_text(value)}</span>'
+            f'<span class="metric-label">{html_text(label)}</span></div>'
+        )
+        for label, value in cards
+    )
+    return f'<section class="cards">{items}</section>'
+
+
+def table_section(title: str, headers: list[str], rows: list[list[object]]) -> str:
+    header_html = "".join(f"<th>{html_text(header)}</th>" for header in headers)
+    body_rows = []
+    for row in rows:
+        columns = "".join(f"<td>{html_text(column)}</td>" for column in row)
+        body_rows.append(f"<tr>{columns}</tr>")
+    rows_html = "\n".join(body_rows) if body_rows else "<tr><td colspan=\"99\">No rows.</td></tr>"
+    return (
+        f'<section class="panel"><h2>{html_text(title)}</h2><table>'
+        f"<thead><tr>{header_html}</tr></thead><tbody>{rows_html}</tbody></table></section>"
+    )
+
+
+def image_section(image_rel_path: str, generated: bool) -> str:
+    if generated:
+        body = (
+            f'<img src="{html_text(image_rel_path)}" alt="JDeps dependency graph" />'
+            '<p class="note">Rendered directly from the DOT files emitted by <code>jdeps</code>.</p>'
+        )
+    else:
+        body = (
+            '<p class="note">Graphviz <code>dot</code> was not available, '
+            "so the page includes only tables and raw DOT links.</p>"
+        )
+    return f'<section class="panel"><h2>JDeps Summary Graph</h2>{body}</section>'
+
+
+def html_page(title: str, intro: str, image_html: str, sections: list[str]) -> str:
+    sections_html = "\n".join(sections)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{html_text(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --border: #dbe3ee;
+      --text: #0f172a;
+      --muted: #475569;
+      --accent: #1d4ed8;
+    }}
+    body {{
+      margin: 0;
+      padding: 2rem;
+      background: linear-gradient(180deg, #eef4ff 0%, var(--bg) 220px);
+      color: var(--text);
+      font: 16px/1.5 "IBM Plex Sans", "Segoe UI", sans-serif;
+    }}
+    main {{
+      max-width: 1200px;
+      margin: 0 auto;
+    }}
+    .lead {{
+      max-width: 72ch;
+      color: var(--muted);
+    }}
+    .panel {{
+      margin-top: 1.5rem;
+      padding: 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--panel);
+      box-shadow: 0 16px 48px rgba(15, 23, 42, 0.06);
+    }}
+    .cards {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-top: 1.25rem;
+    }}
+    .card {{
+      padding: 1rem;
+      border-radius: 14px;
+      background: #f8fbff;
+      border: 1px solid var(--border);
+    }}
+    .metric {{
+      display: block;
+      font-size: 1.8rem;
+      font-weight: 700;
+    }}
+    .metric-label, .note {{
+      color: var(--muted);
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+    }}
+    th, td {{
+      padding: 0.7rem;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+    }}
+    th {{
+      font-size: 0.92rem;
+      color: var(--muted);
+    }}
+    img {{
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: #fff;
+    }}
+    a {{
+      color: var(--accent);
+    }}
+    code {{
+      background: #eff6ff;
+      border-radius: 6px;
+      padding: 0.1rem 0.35rem;
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{html_text(title)}</h1>
+    <p class="lead">{intro}</p>
+    {image_html}
+    {sections_html}
+  </main>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    args = parse_args()
+    summary_dot = Path(args.summary_dot)
+    raw_dir = Path(args.raw_dir)
+    html_path = Path(args.html_path)
+    png_path = Path(args.png_path)
+
+    edges = parse_edges(summary_dot)
+    nodes = sorted({value for edge in edges for value in edge})
+    raw_files = sorted(raw_dir.glob("*.dot"))
+
+    jdk_targets = sum(1 for _, target in edges if classify_target(target) == "JDK module")
+    unresolved_targets = sum(1 for _, target in edges if classify_target(target) == "Unresolved")
+    classpath_targets = sum(1 for _, target in edges if classify_target(target) == "Classpath dependency")
+
+    generated = render_png(summary_dot, png_path)
+
+    edge_rows = [[source, target, classify_target(target)] for source, target in edges]
+    raw_rows = [[path.name, f"jdeps/{path.name}"] for path in raw_files]
+
+    cards = summary_cards(
+        [
+            ("Nodes in summary graph", len(nodes)),
+            ("Dependency edges", len(edges)),
+            ("JDK module targets", jdk_targets),
+            ("Classpath targets", classpath_targets),
+            ("Unresolved targets", unresolved_targets),
+        ]
+    )
+
+    note = (
+        '<section class="panel"><h2>What This Page Shows</h2>'
+        "<p class=\"note\">This page is built from <code>maven-jdeps-plugin:jdkinternals</code> "
+        "with DOT output enabled and <code>--multi-release "
+        f"{html_text(args.multi_release)}</code>. The goal still prints any internal-JDK findings "
+        "to the Maven log during the build; this page focuses on the generated graph artifacts.</p>"
+        "</section>"
+    )
+
+    sections = [
+        cards,
+        note,
+        table_section("Summary Edges", ["From", "To", "Kind"], edge_rows),
+        table_section("Raw DOT Files", ["File", "Relative Path"], raw_rows),
+    ]
+
+    intro = (
+        "JDeps analyzes compiled bytecode. In this setup it runs against the engine main classes and "
+        "its compile-scope dependencies, then exposes the generated DOT files through the site."
+    )
+    html_content = html_page(
+        args.page_title,
+        intro,
+        image_section("jdeps/jdeps-summary.png", generated),
+        sections,
+    )
+
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+    html_path.write_text(html_content, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site xmlns="http://maven.apache.org/SITE/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd"
+    name="${project.name}">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.0.0-M11</version>
+    </skin>
+    <body>
+        <menu name="Dependency Reports">
+            <item name="Module Dependencies" href="module-dependencies.html" />
+        </menu>
+        <menu ref="reports" />
+    </body>
+</site>


### PR DESCRIPTION
## Summary
- add Maven site descriptors and report-generation scripts for dependency and JDeps reporting
- wire the parent and engine builds for the new site/report outputs
- clean up engine runtime, registry, WAL, and related helper code across the current worktree
- include the existing repo metadata updates in this branch as requested

## Testing
- mvn clean verify
- mvn clean site