### PR TITLE
Improve missing-file read handling

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockFile.java
+++ b/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockFile.java
@@ -73,21 +73,17 @@ public class DataBlockFile {
             throw new IllegalArgumentException(String.format(
                     "Block position must be >= '%s'", FIRST_BLOCK.getValue()));
         }
-        if (directoryFacade.isFileExists(fileName)) {
-            try {
-                final FileReaderSeekable reader = getFileReader(blockPosition,
-                        seekableReader);
-                final boolean closeOnClose = seekableReader == null;
-                return new DataBlockReaderImpl(reader, blockPosition, blockSize,
-                        closeOnClose);
-            } catch (final RuntimeException e) {
-                if (!directoryFacade.isFileExists(fileName)) {
-                    return new DataBlockReaderEmpty();
-                }
-                throw e;
+        try {
+            final FileReaderSeekable reader = getFileReader(blockPosition,
+                    seekableReader);
+            final boolean closeOnClose = seekableReader == null;
+            return new DataBlockReaderImpl(reader, blockPosition, blockSize,
+                    closeOnClose);
+        } catch (final RuntimeException e) {
+            if (!directoryFacade.isFileExists(fileName)) {
+                return new DataBlockReaderEmpty();
             }
-        } else {
-            return new DataBlockReaderEmpty();
+            throw e;
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/directory/MemDirectory.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/MemDirectory.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.directory;
 
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,8 +30,7 @@ public class MemDirectory implements Directory {
         try {
             final byte[] bytes = data.get(fileName);
             if (bytes == null) {
-                throw new IndexException(
-                        String.format(ERROR_MSG_NO_FILE, fileName));
+                throw createMissingFileException(fileName);
             }
             return new MemFileReader(bytes);
         } finally {
@@ -43,8 +43,7 @@ public class MemDirectory implements Directory {
         try {
             final byte[] bytes = data.get(fileName);
             if (bytes == null) {
-                throw new IndexException(
-                        String.format(ERROR_MSG_NO_FILE, fileName));
+                throw createMissingFileException(fileName);
             }
             return ByteSequences.wrap(bytes);
         } finally {
@@ -70,8 +69,7 @@ public class MemDirectory implements Directory {
         try {
             final byte[] bytes = data.get(fileName);
             if (bytes == null) {
-                throw new IndexException(
-                        String.format(ERROR_MSG_NO_FILE, fileName));
+                throw createMissingFileException(fileName);
             }
             return new MemFileReader(bytes);
         } finally {
@@ -100,10 +98,9 @@ public class MemDirectory implements Directory {
             final String newFileName) {
         writeLock.lock();
         try {
-            if (directories.containsKey(newFileName)) {
-                throw new IndexException(String.format(
-                        "There is required file but '%s' is directory.",
-                        newFileName));
+            if (!data.containsKey(currentFileName)
+                    && !directories.containsKey(currentFileName)) {
+                throw createMissingFileException(currentFileName);
             }
             if (directories.containsKey(currentFileName)) {
                 if (data.containsKey(newFileName)) {
@@ -115,6 +112,11 @@ public class MemDirectory implements Directory {
                         .remove(currentFileName);
                 directories.put(newFileName, directory);
                 return;
+            }
+            if (directories.containsKey(newFileName)) {
+                throw new IndexException(String.format(
+                        "There is required file but '%s' is directory.",
+                        newFileName));
             }
             if (data.containsKey(currentFileName)) {
                 final byte[] tmp = data.remove(currentFileName);
@@ -139,8 +141,8 @@ public class MemDirectory implements Directory {
             } else {
                 final byte[] a = data.get(fileName);
                 if (a == null) {
-                    throw new IndexException(
-                            String.format("No such file '%s'", fileName));
+                    data.put(fileName, bytes);
+                    return;
                 }
                 byte[] c = new byte[a.length + bytes.length];
                 System.arraycopy(a, 0, c, 0, a.length);
@@ -270,13 +272,17 @@ public class MemDirectory implements Directory {
         try {
             final byte[] fileData = data.get(fileName);
             if (fileData == null) {
-                throw new IllegalArgumentException(
-                        String.format("No such file '%s'.", fileName));
+                throw createMissingFileException(fileName);
             }
             return new MemFileReaderSeekable(fileData);
         } finally {
             readLock.unlock();
         }
+    }
+
+    private IndexException createMissingFileException(final String fileName) {
+        final String message = String.format(ERROR_MSG_NO_FILE, fileName);
+        return new IndexException(message, new FileNotFoundException(message));
     }
 
     private boolean isEmpty() {

--- a/engine/src/test/java/org/hestiastore/index/directory/MemDirectoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/directory/MemDirectoryTest.java
@@ -1,9 +1,12 @@
 package org.hestiastore.index.directory;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.FileNotFoundException;
 
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.directory.Directory.Access;
@@ -115,6 +118,24 @@ class MemDirectoryTest {
     }
 
     @Test
+    void test_getFileReader_missingFile_hasFileNotFoundCause() {
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> directory.getFileReader("missing"));
+
+        assertEquals("There is no file 'missing'", exception.getMessage());
+        assertInstanceOf(FileNotFoundException.class, exception.getCause());
+    }
+
+    @Test
+    void test_getFileReaderSeekable_missingFile_hasFileNotFoundCause() {
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> directory.getFileReaderSeekable("missing"));
+
+        assertEquals("There is no file 'missing'", exception.getMessage());
+        assertInstanceOf(FileNotFoundException.class, exception.getCause());
+    }
+
+    @Test
     void test_getFileWriter_invalid_cacheSize() {
         final Exception e = assertThrows(IllegalArgumentException.class,
                 () -> directory.getFileWriter("pok", Access.OVERWRITE, 0));
@@ -141,6 +162,21 @@ class MemDirectoryTest {
     }
 
     @Test
+    void test_append_creates_missing_file() {
+        try (FileWriter fw = directory.getFileWriter("missing.txt",
+                Access.APPEND)) {
+            fw.write(NAME);
+        }
+
+        assertTrue(directory.isFileExists("missing.txt"));
+        try (FileReader reader = directory.getFileReader("missing.txt")) {
+            final byte[] bytes = new byte[NAME.length];
+            assertEquals(NAME.length, reader.read(bytes));
+            assertEquals("Karel", new String(bytes));
+        }
+    }
+
+    @Test
     void test_subdirectory_rejects_file_name_conflict() {
         FileWriter fw = directory.getFileWriter("sub");
         fw.write(NAME);
@@ -148,6 +184,16 @@ class MemDirectoryTest {
 
         assertThrows(IndexException.class,
                 () -> directory.openSubDirectory("sub"));
+    }
+
+    @Test
+    void test_renameFile_missingSource_throwsIndexException() {
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> directory.renameFile("missing.txt", "target.txt"));
+
+        assertEquals("There is no file 'missing.txt'",
+                exception.getMessage());
+        assertInstanceOf(FileNotFoundException.class, exception.getCause());
     }
 
     private String readStr(final FileReader fr, final int length) {


### PR DESCRIPTION
## Summary
- align `MemDirectory` missing-file failures with filesystem-backed behavior by wrapping `FileNotFoundException`
- make `APPEND` create missing files and fail `renameFile` when the source path is missing
- remove the eager `isFileExists` pre-check in `DataBlockFile.openReader`

## Testing
- mvn -pl engine -Dtest=IntegrationDataBlockFileTest,IntegrationChunkStoreFileTest,IntegrationChunkEntryFileTest,SegmentReadPathTest,IntegrationSegmentTest,IntegrationSegmentIndexSimpleTest test
- mvn clean verify