### PR TITLE
benchmarks: add nightly diskio profile

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -56,8 +56,14 @@ concurrency:
 
 jobs:
   compare:
+    name: compare (${{ matrix.profile }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJson(github.event_name == 'schedule' && '[{"profile":"segment-index-nightly"},{"profile":"diskio-nightly"}]' || format('[{{"profile":"{0}"}}]', github.event_name == 'workflow_dispatch' && inputs.profile || 'segment-index-pr-smoke')) }}
     permissions:
       contents: write
       issues: write
@@ -89,7 +95,7 @@ jobs:
       run: |
         set -euo pipefail
 
-        PROFILE="segment-index-pr-smoke"
+        PROFILE="${{ matrix.profile }}"
         FAIL_ON_REGRESSION="false"
         HISTORY_BRANCH="perf-artifacts"
         HISTORY_CHANNEL="main"
@@ -98,12 +104,10 @@ jobs:
         FALLBACK_BASELINE_REF=""
 
         if [ "${{ github.event_name }}" = "schedule" ]; then
-          PROFILE="segment-index-nightly"
           CANDIDATE_REF="${GITHUB_SHA}"
           FALLBACK_BASELINE_REF="$(git rev-parse "${GITHUB_SHA}~1")"
           PUBLISH_HISTORY="true"
         elif [ "${{ github.event_name }}" = "push" ]; then
-          PROFILE="segment-index-pr-smoke"
           CANDIDATE_REF="${GITHUB_SHA}"
           FALLBACK_BASELINE_REF="$(git rev-parse "${GITHUB_SHA}~1")"
           PUBLISH_HISTORY="true"
@@ -118,7 +122,6 @@ jobs:
           git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}" "${CANDIDATE_REF}"
           FALLBACK_BASELINE_REF="$(git merge-base "${CANDIDATE_REF}" "${BASE_BRANCH}")"
         else
-          PROFILE="${{ inputs.profile }}"
           FAIL_ON_REGRESSION="${{ inputs.fail_on_regression }}"
           HISTORY_BRANCH="${{ inputs.history_branch }}"
           HISTORY_CHANNEL="${{ inputs.history_channel }}"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,6 +42,8 @@ java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexHotPartiti
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMixedDrainBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexPersistedMutationBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexLifecycleBenchmark
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SequentialFileReadingBenchmark
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SequentialFileWritingBenchmark
 ```
 
 Compare both modes in one run (recommended):
@@ -107,8 +109,8 @@ PR benchmark runs now surface in three places:
 
 Canonical `main` baselines continue to advance through
 `history/<profile>/latest-main.json`. Today, `segment-index-pr-smoke`
-publishes there on `push` to `main`, while `segment-index-nightly`
-publishes there from the nightly schedule.
+publishes there on `push` to `main`, while `segment-index-nightly` and
+`diskio-nightly` publish there from the nightly schedule.
 
 Run a profile locally:
 
@@ -117,6 +119,15 @@ python3 benchmarks/scripts/run_jmh_profile.py \
   --repo-root . \
   --profile segment-index-pr-smoke \
   --output-dir /tmp/hestia-bench/current
+```
+
+Run the nightly disk I/O profile locally:
+
+```sh
+python3 benchmarks/scripts/run_jmh_profile.py \
+  --repo-root . \
+  --profile diskio-nightly \
+  --output-dir /tmp/hestia-bench/diskio
 ```
 
 Compare two profile runs:

--- a/benchmarks/benchmark-history.md
+++ b/benchmarks/benchmark-history.md
@@ -19,8 +19,10 @@ Profile definitions live in [profiles](/Users/jan/projects/HestiaStore/benchmark
   - short per-change profile for PRs and local refactor validation
 - `segment-index-nightly`
   - longer profile for trend tracking on `main`
+- `diskio-nightly`
+  - filesystem-backed nightly profile for disk I/O buffer-size trend tracking
 
-Both profiles currently include:
+Both SegmentIndex profiles currently include:
 
 - `SegmentIndexGetBenchmark` with `readPathMode=persisted`
 - `SegmentIndexGetBenchmark` with `readPathMode=overlay`
@@ -35,6 +37,11 @@ The nightly profile additionally includes:
 - `SegmentIndexMultiSegmentGetBenchmark` with `workingSetMode=cold`
 - `SegmentIndexLifecycleBenchmark` for `open`, `checkAndRepairConsistency`,
   and `compactAndWait`
+
+The disk I/O nightly profile includes:
+
+- `SequentialFileWritingBenchmark` with 1 KiB, 4 KiB, and 32 KiB buffers
+- `SequentialFileReadingBenchmark` with 1 KiB, 4 KiB, and 32 KiB buffers
 
 ## Runner and Compare Scripts
 
@@ -122,10 +129,11 @@ Current behavior:
     `history/segment-index-pr-smoke/latest-main.json`
 - nightly schedule
   - run `segment-index-nightly`
-  - compare `HEAD` against the latest stored nightly baseline from
+  - run `diskio-nightly`
+  - compare each nightly profile against the latest stored nightly baseline from
     `perf-artifacts`
   - if no stored baseline exists yet, fall back to `HEAD~1`
-  - publish the new candidate run into `perf-artifacts`
+  - publish each new candidate run into `perf-artifacts`
 - manual dispatch
   - can override profile, history branch, history channel, optional PR number,
     baseline ref, candidate ref, fail policy, and whether to publish into

--- a/benchmarks/profiles/diskio-nightly.json
+++ b/benchmarks/profiles/diskio-nightly.json
@@ -1,0 +1,78 @@
+{
+  "profile": "diskio-nightly",
+  "description": "Nightly filesystem-backed disk I/O benchmark set for buffer-size trend tracking.",
+  "benchmarks": [
+    {
+      "label": "diskio-sequential-write-1k",
+      "include": "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=1024"
+      ]
+    },
+    {
+      "label": "diskio-sequential-write-4k",
+      "include": "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=4096"
+      ]
+    },
+    {
+      "label": "diskio-sequential-write-32k",
+      "include": "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=32768"
+      ]
+    },
+    {
+      "label": "diskio-sequential-read-1k",
+      "include": "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=1024"
+      ]
+    },
+    {
+      "label": "diskio-sequential-read-4k",
+      "include": "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=4096"
+      ]
+    },
+    {
+      "label": "diskio-sequential-read-32k",
+      "include": "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-p", "diskIoBufferSizeBytes=32768"
+      ]
+    }
+  ]
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/BenchmarkFileSupport.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/BenchmarkFileSupport.java
@@ -1,4 +1,4 @@
-package org.hestiastore.benchmark.diskio;
+package org.hestiastore.benchmark;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,16 +9,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 /**
- * Shared filesystem-backed benchmark helpers for deterministic disk I/O runs.
+ * Shared benchmark filesystem and wait helpers.
  */
-public final class DiskIoBenchmarkSupport {
+public final class BenchmarkFileSupport {
 
     private static final Comparator<File> REVERSE_FILE_ORDER = Comparator
             .comparing(File::getAbsolutePath).reversed();
     private static final Path JMH_TEMP_ROOT = Path.of("target", "jmh-temp");
-    private static final int KEY_WIDTH = 10;
 
-    private DiskIoBenchmarkSupport() {
+    private BenchmarkFileSupport() {
     }
 
     public static File createTempDir(final String prefix) throws IOException {
@@ -42,22 +41,6 @@ public final class DiskIoBenchmarkSupport {
                     "Unable to delete benchmark temp path: "
                             + file.getAbsolutePath());
         }
-    }
-
-    public static String buildSequentialKey(final int value) {
-        final String raw = String.valueOf(value);
-        if (raw.length() >= KEY_WIDTH) {
-            return raw;
-        }
-        final StringBuilder padded = new StringBuilder(KEY_WIDTH);
-        for (int index = raw.length(); index < KEY_WIDTH; index++) {
-            padded.append('0');
-        }
-        return padded.append(raw).toString();
-    }
-
-    public static Long buildLongValue(final int value) {
-        return Long.valueOf((value * 1_103_515_245L) ^ 0x5DEECE66DL);
     }
 
     public static void awaitCondition(final BooleanSupplier condition,

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/AbstractDiskIoBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/AbstractDiskIoBenchmark.java
@@ -1,0 +1,72 @@
+package org.hestiastore.benchmark.diskio;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.hestiastore.benchmark.BenchmarkFileSupport;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.datatype.TypeDescriptorLong;
+import org.hestiastore.index.datatype.TypeDescriptorString;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.FsDirectory;
+import org.hestiastore.index.unsorteddatafile.UnsortedDataFile;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@State(Scope.Benchmark)
+public abstract class AbstractDiskIoBenchmark {
+
+    protected static final TypeDescriptor<String> TYPE_DESCRIPTOR_STRING = new TypeDescriptorString();
+    protected static final TypeDescriptor<Long> TYPE_DESCRIPTOR_LONG = new TypeDescriptorLong();
+
+    @Param({ "1024", "4096", "32768" })
+    protected int diskIoBufferSizeBytes;
+
+    protected Directory directory;
+    protected UnsortedDataFile<String, Long> testFile;
+
+    private File tempDir;
+
+    @Setup(Level.Trial)
+    public final void setUpBenchmark() throws IOException {
+        tempDir = BenchmarkFileSupport.createTempDir(tempDirPrefix());
+        directory = new FsDirectory(tempDir);
+        testFile = buildDataFile(fileName(), diskIoBufferSizeBytes);
+        prepareBenchmarkData();
+    }
+
+    @TearDown(Level.Trial)
+    public final void tearDownBenchmark() {
+        testFile = null;
+        directory = null;
+        if (tempDir != null) {
+            BenchmarkFileSupport.deleteRecursively(tempDir);
+            tempDir = null;
+        }
+    }
+
+    protected abstract String tempDirPrefix();
+
+    protected abstract String fileName();
+
+    protected void prepareBenchmarkData() {
+        // Default no-op.
+    }
+
+    protected final UnsortedDataFile<String, Long> buildDataFile(
+            final String fileName, final int bufferSize) {
+        return UnsortedDataFile.<String, Long>builder()//
+                .withDirectory(directory)//
+                .withFileName(fileName)//
+                .withKeyWriter(TYPE_DESCRIPTOR_STRING.getTypeWriter())//
+                .withKeyReader(TYPE_DESCRIPTOR_STRING.getTypeReader())//
+                .withValueWriter(TYPE_DESCRIPTOR_LONG.getTypeWriter())//
+                .withValueReader(TYPE_DESCRIPTOR_LONG.getTypeReader())//
+                .withDiskIoBufferSize(bufferSize)//
+                .build();
+    }
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/DiskIoBenchmarkSupport.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/DiskIoBenchmarkSupport.java
@@ -1,0 +1,82 @@
+package org.hestiastore.benchmark.diskio;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Shared filesystem-backed benchmark helpers for deterministic disk I/O runs.
+ */
+public final class DiskIoBenchmarkSupport {
+
+    private static final Comparator<File> REVERSE_FILE_ORDER = Comparator
+            .comparing(File::getAbsolutePath).reversed();
+    private static final Path JMH_TEMP_ROOT = Path.of("target", "jmh-temp");
+    private static final int KEY_WIDTH = 10;
+
+    private DiskIoBenchmarkSupport() {
+    }
+
+    public static File createTempDir(final String prefix) throws IOException {
+        Files.createDirectories(JMH_TEMP_ROOT);
+        return Files.createTempDirectory(JMH_TEMP_ROOT, prefix).toFile();
+    }
+
+    public static void deleteRecursively(final File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        final File[] children = file.listFiles();
+        if (children != null) {
+            java.util.Arrays.sort(children, REVERSE_FILE_ORDER);
+            for (final File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        if (!file.delete()) {
+            throw new IllegalStateException(
+                    "Unable to delete benchmark temp path: "
+                            + file.getAbsolutePath());
+        }
+    }
+
+    public static String buildSequentialKey(final int value) {
+        final String raw = String.valueOf(value);
+        if (raw.length() >= KEY_WIDTH) {
+            return raw;
+        }
+        final StringBuilder padded = new StringBuilder(KEY_WIDTH);
+        for (int index = raw.length(); index < KEY_WIDTH; index++) {
+            padded.append('0');
+        }
+        return padded.append(raw).toString();
+    }
+
+    public static Long buildLongValue(final int value) {
+        return Long.valueOf((value * 1_103_515_245L) ^ 0x5DEECE66DL);
+    }
+
+    public static void awaitCondition(final BooleanSupplier condition,
+            final long timeoutMillis, final String message) {
+        final long deadline = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            try {
+                Thread.sleep(10L);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(message, e);
+            }
+        }
+        if (!condition.getAsBoolean()) {
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/DiskIoDataSupport.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/DiskIoDataSupport.java
@@ -1,0 +1,25 @@
+package org.hestiastore.benchmark.diskio;
+
+public final class DiskIoDataSupport {
+
+    private static final int KEY_WIDTH = 10;
+
+    private DiskIoDataSupport() {
+    }
+
+    public static String buildSequentialKey(final int value) {
+        final String raw = String.valueOf(value);
+        if (raw.length() >= KEY_WIDTH) {
+            return raw;
+        }
+        final StringBuilder padded = new StringBuilder(KEY_WIDTH);
+        for (int index = raw.length(); index < KEY_WIDTH; index++) {
+            padded.append('0');
+        }
+        return padded.append(raw).toString();
+    }
+
+    public static Long buildLongValue(final int value) {
+        return Long.valueOf((value * 1_103_515_245L) ^ 0x5DEECE66DL);
+    }
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/read/sequential/SequentialFileReadingBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/read/sequential/SequentialFileReadingBenchmark.java
@@ -1,30 +1,19 @@
 package org.hestiastore.benchmark.diskio.read.sequential;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.hestiastore.benchmark.diskio.DiskIoBenchmarkSupport;
+import org.hestiastore.benchmark.diskio.AbstractDiskIoBenchmark;
+import org.hestiastore.benchmark.diskio.DiskIoDataSupport;
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
-import org.hestiastore.index.datatype.TypeDescriptor;
-import org.hestiastore.index.datatype.TypeDescriptorLong;
-import org.hestiastore.index.datatype.TypeDescriptorString;
-import org.hestiastore.index.directory.Directory;
-import org.hestiastore.index.directory.FsDirectory;
-import org.hestiastore.index.unsorteddatafile.UnsortedDataFile;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -39,29 +28,26 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 @Threads(1)
-public class SequentialFileReadingBenchmark {
+public class SequentialFileReadingBenchmark extends AbstractDiskIoBenchmark {
 
-    private static final String FILE_NAME = "read-benchmark.unsorted";
     private static final int NUMBER_OF_TESTING_PAIRS = 800_000;
-    private static final TypeDescriptor<String> TYPE_DESCRIPTOR_STRING = new TypeDescriptorString();
-    private static final TypeDescriptor<Long> TYPE_DESCRIPTOR_LONG = new TypeDescriptorLong();
 
-    @Param({ "1024", "4096", "32768" })
-    private int diskIoBufferSizeBytes;
+    @Override
+    protected String tempDirPrefix() {
+        return "hestia-jmh-seq-read";
+    }
 
-    private File tempDir;
-    private Directory directory;
-    private UnsortedDataFile<String, Long> testFile;
+    @Override
+    protected String fileName() {
+        return "read-benchmark.unsorted";
+    }
 
-    @Setup(Level.Trial)
-    public void setup() throws IOException {
-        tempDir = DiskIoBenchmarkSupport.createTempDir("hestia-jmh-seq-read");
-        directory = new FsDirectory(tempDir);
-        testFile = getDataFile(diskIoBufferSizeBytes);
+    @Override
+    protected void prepareBenchmarkData() {
         testFile.openWriterTx().execute(writer -> {
             for (int index = 0; index < NUMBER_OF_TESTING_PAIRS; index++) {
-                writer.write(DiskIoBenchmarkSupport.buildSequentialKey(index),
-                        DiskIoBenchmarkSupport.buildLongValue(index));
+                writer.write(DiskIoDataSupport.buildSequentialKey(index),
+                        DiskIoDataSupport.buildLongValue(index));
             }
         });
     }
@@ -78,28 +64,6 @@ public class SequentialFileReadingBenchmark {
             }
         }
         return checksum;
-    }
-
-    @TearDown(Level.Trial)
-    public void tearDown() {
-        testFile = null;
-        directory = null;
-        if (tempDir != null) {
-            DiskIoBenchmarkSupport.deleteRecursively(tempDir);
-            tempDir = null;
-        }
-    }
-
-    private UnsortedDataFile<String, Long> getDataFile(final int bufferSize) {
-        return UnsortedDataFile.<String, Long>builder()//
-                .withDirectory(directory)//
-                .withFileName(FILE_NAME)//
-                .withKeyWriter(TYPE_DESCRIPTOR_STRING.getTypeWriter())//
-                .withKeyReader(TYPE_DESCRIPTOR_STRING.getTypeReader())//
-                .withValueWriter(TYPE_DESCRIPTOR_LONG.getTypeWriter())//
-                .withValueReader(TYPE_DESCRIPTOR_LONG.getTypeReader())//
-                .withDiskIoBufferSize(bufferSize)//
-                .build();
     }
 
 }

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/read/sequential/SequentialFileReadingBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/read/sequential/SequentialFileReadingBenchmark.java
@@ -1,0 +1,105 @@
+package org.hestiastore.benchmark.diskio.read.sequential;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.benchmark.diskio.DiskIoBenchmarkSupport;
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.datatype.TypeDescriptorLong;
+import org.hestiastore.index.datatype.TypeDescriptorString;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.FsDirectory;
+import org.hestiastore.index.unsorteddatafile.UnsortedDataFile;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Measures one full sequential scan over a filesystem-backed unsorted data
+ * file.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+public class SequentialFileReadingBenchmark {
+
+    private static final String FILE_NAME = "read-benchmark.unsorted";
+    private static final int NUMBER_OF_TESTING_PAIRS = 800_000;
+    private static final TypeDescriptor<String> TYPE_DESCRIPTOR_STRING = new TypeDescriptorString();
+    private static final TypeDescriptor<Long> TYPE_DESCRIPTOR_LONG = new TypeDescriptorLong();
+
+    @Param({ "1024", "4096", "32768" })
+    private int diskIoBufferSizeBytes;
+
+    private File tempDir;
+    private Directory directory;
+    private UnsortedDataFile<String, Long> testFile;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        tempDir = DiskIoBenchmarkSupport.createTempDir("hestia-jmh-seq-read");
+        directory = new FsDirectory(tempDir);
+        testFile = getDataFile(diskIoBufferSizeBytes);
+        testFile.openWriterTx().execute(writer -> {
+            for (int index = 0; index < NUMBER_OF_TESTING_PAIRS; index++) {
+                writer.write(DiskIoBenchmarkSupport.buildSequentialKey(index),
+                        DiskIoBenchmarkSupport.buildLongValue(index));
+            }
+        });
+    }
+
+    @Benchmark
+    public long readSequentialFile() {
+        long checksum = 0;
+        try (EntryIterator<String, Long> pairIterator = testFile
+                .openIterator()) {
+            while (pairIterator.hasNext()) {
+                final Entry<String, Long> entry = pairIterator.next();
+                checksum += entry.getKey().length();
+                checksum += entry.getValue().longValue();
+            }
+        }
+        return checksum;
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        testFile = null;
+        directory = null;
+        if (tempDir != null) {
+            DiskIoBenchmarkSupport.deleteRecursively(tempDir);
+            tempDir = null;
+        }
+    }
+
+    private UnsortedDataFile<String, Long> getDataFile(final int bufferSize) {
+        return UnsortedDataFile.<String, Long>builder()//
+                .withDirectory(directory)//
+                .withFileName(FILE_NAME)//
+                .withKeyWriter(TYPE_DESCRIPTOR_STRING.getTypeWriter())//
+                .withKeyReader(TYPE_DESCRIPTOR_STRING.getTypeReader())//
+                .withValueWriter(TYPE_DESCRIPTOR_LONG.getTypeWriter())//
+                .withValueReader(TYPE_DESCRIPTOR_LONG.getTypeReader())//
+                .withDiskIoBufferSize(bufferSize)//
+                .build();
+    }
+
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/write/sequential/SequentialFileWritingBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/write/sequential/SequentialFileWritingBenchmark.java
@@ -1,28 +1,17 @@
 package org.hestiastore.benchmark.diskio.write.sequential;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.hestiastore.benchmark.diskio.DiskIoBenchmarkSupport;
-import org.hestiastore.index.datatype.TypeDescriptor;
-import org.hestiastore.index.datatype.TypeDescriptorLong;
-import org.hestiastore.index.datatype.TypeDescriptorString;
-import org.hestiastore.index.directory.Directory;
-import org.hestiastore.index.directory.FsDirectory;
-import org.hestiastore.index.unsorteddatafile.UnsortedDataFile;
+import org.hestiastore.benchmark.diskio.AbstractDiskIoBenchmark;
+import org.hestiastore.benchmark.diskio.DiskIoDataSupport;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -36,32 +25,29 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 @Threads(1)
-public class SequentialFileWritingBenchmark {
+public class SequentialFileWritingBenchmark extends AbstractDiskIoBenchmark {
 
-    private static final String FILE_NAME = "write-benchmark.unsorted";
     private static final int NUMBER_OF_TESTING_PAIRS = 400_000;
-    private static final TypeDescriptor<String> TYPE_DESCRIPTOR_STRING = new TypeDescriptorString();
-    private static final TypeDescriptor<Long> TYPE_DESCRIPTOR_LONG = new TypeDescriptorLong();
-
-    @Param({ "1024", "4096", "32768" })
-    private int diskIoBufferSizeBytes;
-
-    private File tempDir;
-    private Directory directory;
-    private UnsortedDataFile<String, Long> testFile;
     private String[] keys;
     private Long[] values;
 
-    @Setup(Level.Trial)
-    public void setup() throws IOException {
-        tempDir = DiskIoBenchmarkSupport.createTempDir("hestia-jmh-seq-write");
-        directory = new FsDirectory(tempDir);
-        testFile = getDataFile(diskIoBufferSizeBytes);
+    @Override
+    protected String tempDirPrefix() {
+        return "hestia-jmh-seq-write";
+    }
+
+    @Override
+    protected String fileName() {
+        return "write-benchmark.unsorted";
+    }
+
+    @Override
+    protected void prepareBenchmarkData() {
         keys = new String[NUMBER_OF_TESTING_PAIRS];
         values = new Long[NUMBER_OF_TESTING_PAIRS];
         for (int index = 0; index < NUMBER_OF_TESTING_PAIRS; index++) {
-            keys[index] = DiskIoBenchmarkSupport.buildSequentialKey(index);
-            values[index] = DiskIoBenchmarkSupport.buildLongValue(index);
+            keys[index] = DiskIoDataSupport.buildSequentialKey(index);
+            values[index] = DiskIoDataSupport.buildLongValue(index);
         }
     }
 
@@ -73,30 +59,6 @@ public class SequentialFileWritingBenchmark {
             }
         });
         return NUMBER_OF_TESTING_PAIRS;
-    }
-
-    @TearDown(Level.Trial)
-    public void tearDown() {
-        testFile = null;
-        values = null;
-        keys = null;
-        directory = null;
-        if (tempDir != null) {
-            DiskIoBenchmarkSupport.deleteRecursively(tempDir);
-            tempDir = null;
-        }
-    }
-
-    private UnsortedDataFile<String, Long> getDataFile(final int bufferSize) {
-        return UnsortedDataFile.<String, Long>builder()//
-                .withDirectory(directory)//
-                .withFileName(FILE_NAME)//
-                .withKeyWriter(TYPE_DESCRIPTOR_STRING.getTypeWriter())//
-                .withKeyReader(TYPE_DESCRIPTOR_STRING.getTypeReader())//
-                .withValueWriter(TYPE_DESCRIPTOR_LONG.getTypeWriter())//
-                .withValueReader(TYPE_DESCRIPTOR_LONG.getTypeReader())//
-                .withDiskIoBufferSize(bufferSize)//
-                .build();
     }
 
 }

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/write/sequential/SequentialFileWritingBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/diskio/write/sequential/SequentialFileWritingBenchmark.java
@@ -1,0 +1,102 @@
+package org.hestiastore.benchmark.diskio.write.sequential;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.benchmark.diskio.DiskIoBenchmarkSupport;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.datatype.TypeDescriptorLong;
+import org.hestiastore.index.datatype.TypeDescriptorString;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.FsDirectory;
+import org.hestiastore.index.unsorteddatafile.UnsortedDataFile;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Measures the cost of rewriting one filesystem-backed unsorted data file.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+public class SequentialFileWritingBenchmark {
+
+    private static final String FILE_NAME = "write-benchmark.unsorted";
+    private static final int NUMBER_OF_TESTING_PAIRS = 400_000;
+    private static final TypeDescriptor<String> TYPE_DESCRIPTOR_STRING = new TypeDescriptorString();
+    private static final TypeDescriptor<Long> TYPE_DESCRIPTOR_LONG = new TypeDescriptorLong();
+
+    @Param({ "1024", "4096", "32768" })
+    private int diskIoBufferSizeBytes;
+
+    private File tempDir;
+    private Directory directory;
+    private UnsortedDataFile<String, Long> testFile;
+    private String[] keys;
+    private Long[] values;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        tempDir = DiskIoBenchmarkSupport.createTempDir("hestia-jmh-seq-write");
+        directory = new FsDirectory(tempDir);
+        testFile = getDataFile(diskIoBufferSizeBytes);
+        keys = new String[NUMBER_OF_TESTING_PAIRS];
+        values = new Long[NUMBER_OF_TESTING_PAIRS];
+        for (int index = 0; index < NUMBER_OF_TESTING_PAIRS; index++) {
+            keys[index] = DiskIoBenchmarkSupport.buildSequentialKey(index);
+            values[index] = DiskIoBenchmarkSupport.buildLongValue(index);
+        }
+    }
+
+    @Benchmark
+    public int writeSequentialFile() {
+        testFile.openWriterTx().execute(writer -> {
+            for (int index = 0; index < NUMBER_OF_TESTING_PAIRS; index++) {
+                writer.write(keys[index], values[index]);
+            }
+        });
+        return NUMBER_OF_TESTING_PAIRS;
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        testFile = null;
+        values = null;
+        keys = null;
+        directory = null;
+        if (tempDir != null) {
+            DiskIoBenchmarkSupport.deleteRecursively(tempDir);
+            tempDir = null;
+        }
+    }
+
+    private UnsortedDataFile<String, Long> getDataFile(final int bufferSize) {
+        return UnsortedDataFile.<String, Long>builder()//
+                .withDirectory(directory)//
+                .withFileName(FILE_NAME)//
+                .withKeyWriter(TYPE_DESCRIPTOR_STRING.getTypeWriter())//
+                .withKeyReader(TYPE_DESCRIPTOR_STRING.getTypeReader())//
+                .withValueWriter(TYPE_DESCRIPTOR_LONG.getTypeWriter())//
+                .withValueReader(TYPE_DESCRIPTOR_LONG.getTypeReader())//
+                .withDiskIoBufferSize(bufferSize)//
+                .build();
+    }
+
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java
@@ -5,12 +5,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
 import java.util.function.IntFunction;
 
+import org.hestiastore.benchmark.BenchmarkFileSupport;
 import org.hestiastore.index.chunkstore.ChunkFilterCrc32Validation;
 import org.hestiastore.index.chunkstore.ChunkFilterCrc32Writing;
 import org.hestiastore.index.chunkstore.ChunkFilterMagicNumberValidation;
@@ -27,16 +25,12 @@ final class SegmentIndexBenchmarkSupport {
 
     static final TypeDescriptorInteger KEY_DESCRIPTOR = new TypeDescriptorInteger();
     static final TypeDescriptorShortString VALUE_DESCRIPTOR = new TypeDescriptorShortString();
-    private static final Comparator<File> REVERSE_FILE_ORDER = Comparator
-            .comparing(File::getAbsolutePath).reversed();
-    private static final Path JMH_TEMP_ROOT = Path.of("target", "jmh-temp");
 
     private SegmentIndexBenchmarkSupport() {
     }
 
     static File createTempDir(final String prefix) throws IOException {
-        Files.createDirectories(JMH_TEMP_ROOT);
-        return Files.createTempDirectory(JMH_TEMP_ROOT, prefix).toFile();
+        return BenchmarkFileSupport.createTempDir(prefix);
     }
 
     static IndexConfigurationBuilder<Integer, String> baseBuilder(
@@ -91,41 +85,12 @@ final class SegmentIndexBenchmarkSupport {
     }
 
     static void deleteRecursively(final File file) {
-        if (file == null || !file.exists()) {
-            return;
-        }
-        final File[] children = file.listFiles();
-        if (children != null) {
-            java.util.Arrays.sort(children, REVERSE_FILE_ORDER);
-            for (final File child : children) {
-                deleteRecursively(child);
-            }
-        }
-        if (!file.delete()) {
-            throw new IllegalStateException(
-                    "Unable to delete benchmark temp path: "
-                            + file.getAbsolutePath());
-        }
+        BenchmarkFileSupport.deleteRecursively(file);
     }
 
-    static void awaitCondition(final BooleanSupplier condition,
+    static void awaitCondition(final java.util.function.BooleanSupplier condition,
             final long timeoutMillis, final String message) {
-        final long deadline = System.nanoTime()
-                + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
-        while (System.nanoTime() < deadline) {
-            if (condition.getAsBoolean()) {
-                return;
-            }
-            try {
-                Thread.sleep(10L);
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(message, e);
-            }
-        }
-        if (!condition.getAsBoolean()) {
-            throw new IllegalStateException(message);
-        }
+        BenchmarkFileSupport.awaitCondition(condition, timeoutMillis, message);
     }
 
     static void copyDirectory(final Path source, final Path target)

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
@@ -45,6 +45,13 @@ class BenchmarkProfileContractTest {
             "segment-index-hot-partition-put",
             "segment-index-mixed-drain",
             "segment-index-mixed-split-heavy");
+    private static final Set<String> REQUIRED_NIGHTLY_DISKIO_LABELS = Set.of(
+            "diskio-sequential-write-1k",
+            "diskio-sequential-write-4k",
+            "diskio-sequential-write-32k",
+            "diskio-sequential-read-1k",
+            "diskio-sequential-read-4k",
+            "diskio-sequential-read-32k");
 
     @Test
     void allBenchmarkProfilesUseUniqueLabelsAndResolvableBenchmarkClasses()
@@ -87,6 +94,7 @@ class BenchmarkProfileContractTest {
                 profilesByName.get("segment-index-pr-smoke"));
         assertCanonicalNightlySegmentIndexProfile(
                 profilesByName.get("segment-index-nightly"));
+        assertCanonicalDiskIoNightlyProfile(profilesByName.get("diskio-nightly"));
     }
 
     @Test
@@ -176,6 +184,37 @@ class BenchmarkProfileContractTest {
         assertEntry(byLabel.get("segment-index-mixed-split-heavy"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
                 Map.of("workloadMode", "splitHeavy"));
+    }
+
+    private void assertCanonicalDiskIoNightlyProfile(
+            final BenchmarkProfile profile) {
+        assertNotNull(profile, "Missing canonical diskio nightly profile");
+        final Map<String, BenchmarkEntry> byLabel = new LinkedHashMap<>();
+        for (final BenchmarkEntry benchmark : profile.benchmarks()) {
+            byLabel.put(benchmark.label(), benchmark);
+        }
+        assertEquals(REQUIRED_NIGHTLY_DISKIO_LABELS, byLabel.keySet(),
+                () -> "Unexpected benchmark labels in profile "
+                        + profile.profile());
+
+        assertEntry(byLabel.get("diskio-sequential-write-1k"),
+                "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "1024"));
+        assertEntry(byLabel.get("diskio-sequential-write-4k"),
+                "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "4096"));
+        assertEntry(byLabel.get("diskio-sequential-write-32k"),
+                "org.hestiastore.benchmark.diskio.write.sequential.SequentialFileWritingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "32768"));
+        assertEntry(byLabel.get("diskio-sequential-read-1k"),
+                "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "1024"));
+        assertEntry(byLabel.get("diskio-sequential-read-4k"),
+                "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "4096"));
+        assertEntry(byLabel.get("diskio-sequential-read-32k"),
+                "org.hestiastore.benchmark.diskio.read.sequential.SequentialFileReadingBenchmark",
+                Map.of("diskIoBufferSizeBytes", "32768"));
     }
 
     private void assertEntry(final BenchmarkEntry entry, final String include,


### PR DESCRIPTION
## Summary
- add deterministic filesystem-backed sequential read/write JMH benchmarks for canonical automation
- add a nightly-only \ profile plus contract coverage and docs
- run the disk I/O profile on scheduled benchmark compares while keeping PR smoke coverage unchanged

## Testing
- mvn -q -pl benchmarks -am -DskipTests=false -Dtest=BenchmarkProfileContractTest,BenchmarkHistoryScriptsSmokeTest -Dsurefire.failIfNoSpecifiedTests=false test
- python3 benchmarks/scripts/run_jmh_profile.py --repo-root . --profile diskio-nightly --output-dir /tmp/hestia-bench/diskio-nightly-verify --skip-build
