### PR TITLE
Add maintenance saturation metrics

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndexMetricsSnapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndexMetricsSnapshot.java
@@ -45,6 +45,17 @@ public final class SegmentIndexMetricsSnapshot {
     private final int maintenanceQueueCapacity;
     private final int splitQueueSize;
     private final int splitQueueCapacity;
+    private final int indexMaintenanceActiveThreadCount;
+    private final long indexMaintenanceCompletedTaskCount;
+    private final long indexMaintenanceRejectedTaskCount;
+    private final int splitMaintenanceActiveThreadCount;
+    private final long splitMaintenanceCompletedTaskCount;
+    private final long splitMaintenanceRejectedTaskCount;
+    private final int stableSegmentMaintenanceActiveThreadCount;
+    private final int stableSegmentMaintenanceQueueSize;
+    private final int stableSegmentMaintenanceQueueCapacity;
+    private final long stableSegmentMaintenanceCompletedTaskCount;
+    private final long stableSegmentMaintenanceCallerRunsCount;
     private final int partitionCount;
     private final int activePartitionCount;
     private final int drainingPartitionCount;
@@ -55,6 +66,20 @@ public final class SegmentIndexMetricsSnapshot {
     private final long drainScheduleCount;
     private final int drainInFlightCount;
     private final long drainLatencyP95Micros;
+    private final long splitTaskStartDelayP95Micros;
+    private final long splitTaskRunLatencyP95Micros;
+    private final long drainTaskStartDelayP95Micros;
+    private final long drainTaskRunLatencyP95Micros;
+    private final int splitBlockedPartitionCount;
+    private final long splitBlockedDrainScheduleCount;
+    private final long bufferFullWhileSplitBlockedCount;
+    private final long putBusyRetryCount;
+    private final long putBusyTimeoutCount;
+    private final long putBusyWaitP95Micros;
+    private final long flushAcceptedToReadyP95Micros;
+    private final long compactAcceptedToReadyP95Micros;
+    private final long flushBusyRetryCount;
+    private final long compactBusyRetryCount;
     private final long readLatencyP50Micros;
     private final long readLatencyP95Micros;
     private final long readLatencyP99Micros;
@@ -134,7 +159,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -143,7 +169,7 @@ public final class SegmentIndexMetricsSnapshot {
                 bloomFilterFalsePositiveCount, false, 0L, 0L, 0L, 0L, 0L, 0L,
                 0L, 0, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 0, 0, 0, 0,
                 0L,
-                0L, 0L, 0,
+                0L, 0L, 0, 0L,
                 segmentRuntimeSnapshots, state);
     }
 
@@ -202,7 +228,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -214,7 +241,7 @@ public final class SegmentIndexMetricsSnapshot {
                 walSegmentCount, walDurableLsn, walCheckpointLsn,
                 walPendingSyncBytes, walAppliedLsn, walSyncTotalNanos,
                 walSyncMaxNanos, walSyncBatchBytesTotal,
-                walSyncBatchBytesMax, 0, 0, 0, 0, 0, 0, 0, 0L, 0L, 0L, 0,
+                walSyncBatchBytesMax, 0, 0, 0, 0, 0, 0, 0, 0L, 0L, 0L, 0, 0L,
                 segmentRuntimeSnapshots, state);
     }
 
@@ -272,7 +299,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -347,7 +375,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -420,7 +449,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -431,7 +461,7 @@ public final class SegmentIndexMetricsSnapshot {
                 walCorruptionCount, walTruncationCount, walRetainedBytes,
                 walSegmentCount, walDurableLsn, walCheckpointLsn,
                 walPendingSyncBytes, walDurableLsn, 0L, 0L, 0L, 0L, 0, 0, 0,
-                0, 0, 0, 0, 0L, 0L, 0L, 0, segmentRuntimeSnapshots, state);
+                0, 0, 0, 0, 0L, 0L, 0L, 0, 0L, segmentRuntimeSnapshots, state);
     }
 
     /**
@@ -487,7 +517,8 @@ public final class SegmentIndexMetricsSnapshot {
                 totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
                 splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
                 maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
-                readLatencyP50Micros, readLatencyP95Micros,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L, readLatencyP50Micros,
+                readLatencyP95Micros,
                 readLatencyP99Micros, writeLatencyP50Micros,
                 writeLatencyP95Micros, writeLatencyP99Micros,
                 bloomFilterHashFunctions, bloomFilterIndexSizeInBytes,
@@ -498,7 +529,7 @@ public final class SegmentIndexMetricsSnapshot {
                 walCorruptionCount, walTruncationCount, walRetainedBytes,
                 walSegmentCount, walDurableLsn, walCheckpointLsn,
                 walPendingSyncBytes, walAppliedLsn, 0L, 0L, 0L, 0L, 0, 0, 0,
-                0, 0, 0, 0, 0L, 0L, 0L, 0, segmentRuntimeSnapshots, state);
+                0, 0, 0, 0, 0L, 0L, 0L, 0, 0L, segmentRuntimeSnapshots, state);
     }
 
     /**
@@ -522,6 +553,17 @@ public final class SegmentIndexMetricsSnapshot {
             final long splitScheduleCount, final int splitInFlightCount,
             final int maintenanceQueueSize, final int maintenanceQueueCapacity,
             final int splitQueueSize, final int splitQueueCapacity,
+            final int indexMaintenanceActiveThreadCount,
+            final long indexMaintenanceCompletedTaskCount,
+            final long indexMaintenanceRejectedTaskCount,
+            final int splitMaintenanceActiveThreadCount,
+            final long splitMaintenanceCompletedTaskCount,
+            final long splitMaintenanceRejectedTaskCount,
+            final int stableSegmentMaintenanceActiveThreadCount,
+            final int stableSegmentMaintenanceQueueSize,
+            final int stableSegmentMaintenanceQueueCapacity,
+            final long stableSegmentMaintenanceCompletedTaskCount,
+            final long stableSegmentMaintenanceCallerRunsCount,
             final long readLatencyP50Micros, final long readLatencyP95Micros,
             final long readLatencyP99Micros, final long writeLatencyP50Micros,
             final long writeLatencyP95Micros, final long writeLatencyP99Micros,
@@ -549,6 +591,127 @@ public final class SegmentIndexMetricsSnapshot {
             final long localThrottleCount, final long globalThrottleCount,
             final long drainScheduleCount, final int drainInFlightCount,
             final long drainLatencyP95Micros,
+            final List<SegmentMetricsSnapshot> segmentRuntimeSnapshots,
+            final SegmentIndexState state) {
+        this(getOperationCount, putOperationCount, deleteOperationCount,
+                registryCacheHitCount, registryCacheMissCount,
+                registryCacheLoadCount, registryCacheEvictionCount,
+                registryCacheSize, registryCacheLimit,
+                segmentCacheKeyLimitPerSegment,
+                maxNumberOfKeysInActivePartition,
+                maxNumberOfKeysInPartitionBuffer, segmentCount,
+                segmentReadyCount, segmentMaintenanceCount, segmentErrorCount,
+                segmentClosedCount, segmentBusyCount, totalSegmentKeys,
+                totalSegmentCacheKeys, totalBufferedWriteKeys,
+                totalDeltaCacheFiles, compactRequestCount, flushRequestCount,
+                splitScheduleCount, splitInFlightCount, maintenanceQueueSize,
+                maintenanceQueueCapacity, splitQueueSize, splitQueueCapacity,
+                indexMaintenanceActiveThreadCount,
+                indexMaintenanceCompletedTaskCount,
+                indexMaintenanceRejectedTaskCount,
+                splitMaintenanceActiveThreadCount,
+                splitMaintenanceCompletedTaskCount,
+                splitMaintenanceRejectedTaskCount,
+                stableSegmentMaintenanceActiveThreadCount,
+                stableSegmentMaintenanceQueueSize,
+                stableSegmentMaintenanceQueueCapacity,
+                stableSegmentMaintenanceCompletedTaskCount,
+                stableSegmentMaintenanceCallerRunsCount, readLatencyP50Micros,
+                readLatencyP95Micros, readLatencyP99Micros,
+                writeLatencyP50Micros, writeLatencyP95Micros,
+                writeLatencyP99Micros, bloomFilterHashFunctions,
+                bloomFilterIndexSizeInBytes,
+                bloomFilterProbabilityOfFalsePositive, bloomFilterRequestCount,
+                bloomFilterRefusedCount, bloomFilterPositiveCount,
+                bloomFilterFalsePositiveCount, walEnabled, walAppendCount,
+                walAppendBytes, walSyncCount, walSyncFailureCount,
+                walCorruptionCount, walTruncationCount, walRetainedBytes,
+                walSegmentCount, walDurableLsn, walCheckpointLsn,
+                walPendingSyncBytes, walAppliedLsn, walSyncTotalNanos,
+                walSyncMaxNanos, walSyncBatchBytesTotal,
+                walSyncBatchBytesMax,
+                maxNumberOfImmutableRunsPerPartition,
+                maxNumberOfKeysInIndexBuffer, partitionCount,
+                activePartitionCount, drainingPartitionCount,
+                immutableRunCount, partitionBufferedKeyCount,
+                localThrottleCount, globalThrottleCount, drainScheduleCount,
+                drainInFlightCount, drainLatencyP95Micros, 0L, 0L, 0L, 0L, 0,
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+                segmentRuntimeSnapshots, state);
+    }
+
+    /**
+     * Full runtime metrics constructor including per-segment and WAL metrics.
+     */
+    public SegmentIndexMetricsSnapshot(final long getOperationCount,
+            final long putOperationCount, final long deleteOperationCount,
+            final long registryCacheHitCount, final long registryCacheMissCount,
+            final long registryCacheLoadCount,
+            final long registryCacheEvictionCount, final int registryCacheSize,
+            final int registryCacheLimit,
+            final int segmentCacheKeyLimitPerSegment,
+            final int maxNumberOfKeysInActivePartition,
+            final int maxNumberOfKeysInPartitionBuffer,
+            final int segmentCount, final int segmentReadyCount,
+            final int segmentMaintenanceCount, final int segmentErrorCount,
+            final int segmentClosedCount, final int segmentBusyCount,
+            final long totalSegmentKeys, final long totalSegmentCacheKeys,
+            final long totalBufferedWriteKeys, final long totalDeltaCacheFiles,
+            final long compactRequestCount, final long flushRequestCount,
+            final long splitScheduleCount, final int splitInFlightCount,
+            final int maintenanceQueueSize, final int maintenanceQueueCapacity,
+            final int splitQueueSize, final int splitQueueCapacity,
+            final int indexMaintenanceActiveThreadCount,
+            final long indexMaintenanceCompletedTaskCount,
+            final long indexMaintenanceRejectedTaskCount,
+            final int splitMaintenanceActiveThreadCount,
+            final long splitMaintenanceCompletedTaskCount,
+            final long splitMaintenanceRejectedTaskCount,
+            final int stableSegmentMaintenanceActiveThreadCount,
+            final int stableSegmentMaintenanceQueueSize,
+            final int stableSegmentMaintenanceQueueCapacity,
+            final long stableSegmentMaintenanceCompletedTaskCount,
+            final long stableSegmentMaintenanceCallerRunsCount,
+            final long readLatencyP50Micros, final long readLatencyP95Micros,
+            final long readLatencyP99Micros, final long writeLatencyP50Micros,
+            final long writeLatencyP95Micros, final long writeLatencyP99Micros,
+            final int bloomFilterHashFunctions,
+            final int bloomFilterIndexSizeInBytes,
+            final double bloomFilterProbabilityOfFalsePositive,
+            final long bloomFilterRequestCount,
+            final long bloomFilterRefusedCount,
+            final long bloomFilterPositiveCount,
+            final long bloomFilterFalsePositiveCount,
+            final boolean walEnabled, final long walAppendCount,
+            final long walAppendBytes, final long walSyncCount,
+            final long walSyncFailureCount, final long walCorruptionCount,
+            final long walTruncationCount, final long walRetainedBytes,
+            final int walSegmentCount, final long walDurableLsn,
+            final long walCheckpointLsn, final long walPendingSyncBytes,
+            final long walAppliedLsn, final long walSyncTotalNanos,
+            final long walSyncMaxNanos, final long walSyncBatchBytesTotal,
+            final long walSyncBatchBytesMax,
+            final int maxNumberOfImmutableRunsPerPartition,
+            final int maxNumberOfKeysInIndexBuffer,
+            final int partitionCount, final int activePartitionCount,
+            final int drainingPartitionCount, final int immutableRunCount,
+            final int partitionBufferedKeyCount,
+            final long localThrottleCount, final long globalThrottleCount,
+            final long drainScheduleCount, final int drainInFlightCount,
+            final long drainLatencyP95Micros,
+            final long splitTaskStartDelayP95Micros,
+            final long splitTaskRunLatencyP95Micros,
+            final long drainTaskStartDelayP95Micros,
+            final long drainTaskRunLatencyP95Micros,
+            final int splitBlockedPartitionCount,
+            final long splitBlockedDrainScheduleCount,
+            final long bufferFullWhileSplitBlockedCount,
+            final long putBusyRetryCount, final long putBusyTimeoutCount,
+            final long putBusyWaitP95Micros,
+            final long flushAcceptedToReadyP95Micros,
+            final long compactAcceptedToReadyP95Micros,
+            final long flushBusyRetryCount,
+            final long compactBusyRetryCount,
             final List<SegmentMetricsSnapshot> segmentRuntimeSnapshots,
             final SegmentIndexState state) {
         requireNotNegative(getOperationCount, "getOperationCount");
@@ -590,6 +753,28 @@ public final class SegmentIndexMetricsSnapshot {
                 "maintenanceQueueCapacity");
         requireNotNegative(splitQueueSize, "splitQueueSize");
         requireNotNegative(splitQueueCapacity, "splitQueueCapacity");
+        requireNotNegative(indexMaintenanceActiveThreadCount,
+                "indexMaintenanceActiveThreadCount");
+        requireNotNegative(indexMaintenanceCompletedTaskCount,
+                "indexMaintenanceCompletedTaskCount");
+        requireNotNegative(indexMaintenanceRejectedTaskCount,
+                "indexMaintenanceRejectedTaskCount");
+        requireNotNegative(splitMaintenanceActiveThreadCount,
+                "splitMaintenanceActiveThreadCount");
+        requireNotNegative(splitMaintenanceCompletedTaskCount,
+                "splitMaintenanceCompletedTaskCount");
+        requireNotNegative(splitMaintenanceRejectedTaskCount,
+                "splitMaintenanceRejectedTaskCount");
+        requireNotNegative(stableSegmentMaintenanceActiveThreadCount,
+                "stableSegmentMaintenanceActiveThreadCount");
+        requireNotNegative(stableSegmentMaintenanceQueueSize,
+                "stableSegmentMaintenanceQueueSize");
+        requireNotNegative(stableSegmentMaintenanceQueueCapacity,
+                "stableSegmentMaintenanceQueueCapacity");
+        requireNotNegative(stableSegmentMaintenanceCompletedTaskCount,
+                "stableSegmentMaintenanceCompletedTaskCount");
+        requireNotNegative(stableSegmentMaintenanceCallerRunsCount,
+                "stableSegmentMaintenanceCallerRunsCount");
         requireNotNegative(partitionCount, "partitionCount");
         requireNotNegative(activePartitionCount, "activePartitionCount");
         requireNotNegative(drainingPartitionCount,
@@ -602,6 +787,29 @@ public final class SegmentIndexMetricsSnapshot {
         requireNotNegative(drainScheduleCount, "drainScheduleCount");
         requireNotNegative(drainInFlightCount, "drainInFlightCount");
         requireNotNegative(drainLatencyP95Micros, "drainLatencyP95Micros");
+        requireNotNegative(splitTaskStartDelayP95Micros,
+                "splitTaskStartDelayP95Micros");
+        requireNotNegative(splitTaskRunLatencyP95Micros,
+                "splitTaskRunLatencyP95Micros");
+        requireNotNegative(drainTaskStartDelayP95Micros,
+                "drainTaskStartDelayP95Micros");
+        requireNotNegative(drainTaskRunLatencyP95Micros,
+                "drainTaskRunLatencyP95Micros");
+        requireNotNegative(splitBlockedPartitionCount,
+                "splitBlockedPartitionCount");
+        requireNotNegative(splitBlockedDrainScheduleCount,
+                "splitBlockedDrainScheduleCount");
+        requireNotNegative(bufferFullWhileSplitBlockedCount,
+                "bufferFullWhileSplitBlockedCount");
+        requireNotNegative(putBusyRetryCount, "putBusyRetryCount");
+        requireNotNegative(putBusyTimeoutCount, "putBusyTimeoutCount");
+        requireNotNegative(putBusyWaitP95Micros, "putBusyWaitP95Micros");
+        requireNotNegative(flushAcceptedToReadyP95Micros,
+                "flushAcceptedToReadyP95Micros");
+        requireNotNegative(compactAcceptedToReadyP95Micros,
+                "compactAcceptedToReadyP95Micros");
+        requireNotNegative(flushBusyRetryCount, "flushBusyRetryCount");
+        requireNotNegative(compactBusyRetryCount, "compactBusyRetryCount");
         requireNotNegative(readLatencyP50Micros, "readLatencyP50Micros");
         requireNotNegative(readLatencyP95Micros, "readLatencyP95Micros");
         requireNotNegative(readLatencyP99Micros, "readLatencyP99Micros");
@@ -670,6 +878,17 @@ public final class SegmentIndexMetricsSnapshot {
         this.maintenanceQueueCapacity = maintenanceQueueCapacity;
         this.splitQueueSize = splitQueueSize;
         this.splitQueueCapacity = splitQueueCapacity;
+        this.indexMaintenanceActiveThreadCount = indexMaintenanceActiveThreadCount;
+        this.indexMaintenanceCompletedTaskCount = indexMaintenanceCompletedTaskCount;
+        this.indexMaintenanceRejectedTaskCount = indexMaintenanceRejectedTaskCount;
+        this.splitMaintenanceActiveThreadCount = splitMaintenanceActiveThreadCount;
+        this.splitMaintenanceCompletedTaskCount = splitMaintenanceCompletedTaskCount;
+        this.splitMaintenanceRejectedTaskCount = splitMaintenanceRejectedTaskCount;
+        this.stableSegmentMaintenanceActiveThreadCount = stableSegmentMaintenanceActiveThreadCount;
+        this.stableSegmentMaintenanceQueueSize = stableSegmentMaintenanceQueueSize;
+        this.stableSegmentMaintenanceQueueCapacity = stableSegmentMaintenanceQueueCapacity;
+        this.stableSegmentMaintenanceCompletedTaskCount = stableSegmentMaintenanceCompletedTaskCount;
+        this.stableSegmentMaintenanceCallerRunsCount = stableSegmentMaintenanceCallerRunsCount;
         this.partitionCount = partitionCount;
         this.activePartitionCount = activePartitionCount;
         this.drainingPartitionCount = drainingPartitionCount;
@@ -680,6 +899,20 @@ public final class SegmentIndexMetricsSnapshot {
         this.drainScheduleCount = drainScheduleCount;
         this.drainInFlightCount = drainInFlightCount;
         this.drainLatencyP95Micros = drainLatencyP95Micros;
+        this.splitTaskStartDelayP95Micros = splitTaskStartDelayP95Micros;
+        this.splitTaskRunLatencyP95Micros = splitTaskRunLatencyP95Micros;
+        this.drainTaskStartDelayP95Micros = drainTaskStartDelayP95Micros;
+        this.drainTaskRunLatencyP95Micros = drainTaskRunLatencyP95Micros;
+        this.splitBlockedPartitionCount = splitBlockedPartitionCount;
+        this.splitBlockedDrainScheduleCount = splitBlockedDrainScheduleCount;
+        this.bufferFullWhileSplitBlockedCount = bufferFullWhileSplitBlockedCount;
+        this.putBusyRetryCount = putBusyRetryCount;
+        this.putBusyTimeoutCount = putBusyTimeoutCount;
+        this.putBusyWaitP95Micros = putBusyWaitP95Micros;
+        this.flushAcceptedToReadyP95Micros = flushAcceptedToReadyP95Micros;
+        this.compactAcceptedToReadyP95Micros = compactAcceptedToReadyP95Micros;
+        this.flushBusyRetryCount = flushBusyRetryCount;
+        this.compactBusyRetryCount = compactBusyRetryCount;
         this.readLatencyP50Micros = readLatencyP50Micros;
         this.readLatencyP95Micros = readLatencyP95Micros;
         this.readLatencyP99Micros = readLatencyP99Micros;
@@ -854,6 +1087,50 @@ public final class SegmentIndexMetricsSnapshot {
         return splitQueueCapacity;
     }
 
+    public int getIndexMaintenanceActiveThreadCount() {
+        return indexMaintenanceActiveThreadCount;
+    }
+
+    public long getIndexMaintenanceCompletedTaskCount() {
+        return indexMaintenanceCompletedTaskCount;
+    }
+
+    public long getIndexMaintenanceRejectedTaskCount() {
+        return indexMaintenanceRejectedTaskCount;
+    }
+
+    public int getSplitMaintenanceActiveThreadCount() {
+        return splitMaintenanceActiveThreadCount;
+    }
+
+    public long getSplitMaintenanceCompletedTaskCount() {
+        return splitMaintenanceCompletedTaskCount;
+    }
+
+    public long getSplitMaintenanceRejectedTaskCount() {
+        return splitMaintenanceRejectedTaskCount;
+    }
+
+    public int getStableSegmentMaintenanceActiveThreadCount() {
+        return stableSegmentMaintenanceActiveThreadCount;
+    }
+
+    public int getStableSegmentMaintenanceQueueSize() {
+        return stableSegmentMaintenanceQueueSize;
+    }
+
+    public int getStableSegmentMaintenanceQueueCapacity() {
+        return stableSegmentMaintenanceQueueCapacity;
+    }
+
+    public long getStableSegmentMaintenanceCompletedTaskCount() {
+        return stableSegmentMaintenanceCompletedTaskCount;
+    }
+
+    public long getStableSegmentMaintenanceCallerRunsCount() {
+        return stableSegmentMaintenanceCallerRunsCount;
+    }
+
     public int getPartitionCount() {
         return partitionCount;
     }
@@ -892,6 +1169,62 @@ public final class SegmentIndexMetricsSnapshot {
 
     public long getDrainLatencyP95Micros() {
         return drainLatencyP95Micros;
+    }
+
+    public long getSplitTaskStartDelayP95Micros() {
+        return splitTaskStartDelayP95Micros;
+    }
+
+    public long getSplitTaskRunLatencyP95Micros() {
+        return splitTaskRunLatencyP95Micros;
+    }
+
+    public long getDrainTaskStartDelayP95Micros() {
+        return drainTaskStartDelayP95Micros;
+    }
+
+    public long getDrainTaskRunLatencyP95Micros() {
+        return drainTaskRunLatencyP95Micros;
+    }
+
+    public int getSplitBlockedPartitionCount() {
+        return splitBlockedPartitionCount;
+    }
+
+    public long getSplitBlockedDrainScheduleCount() {
+        return splitBlockedDrainScheduleCount;
+    }
+
+    public long getBufferFullWhileSplitBlockedCount() {
+        return bufferFullWhileSplitBlockedCount;
+    }
+
+    public long getPutBusyRetryCount() {
+        return putBusyRetryCount;
+    }
+
+    public long getPutBusyTimeoutCount() {
+        return putBusyTimeoutCount;
+    }
+
+    public long getPutBusyWaitP95Micros() {
+        return putBusyWaitP95Micros;
+    }
+
+    public long getFlushAcceptedToReadyP95Micros() {
+        return flushAcceptedToReadyP95Micros;
+    }
+
+    public long getCompactAcceptedToReadyP95Micros() {
+        return compactAcceptedToReadyP95Micros;
+    }
+
+    public long getFlushBusyRetryCount() {
+        return flushBusyRetryCount;
+    }
+
+    public long getCompactBusyRetryCount() {
+        return compactBusyRetryCount;
     }
 
     public long getReadLatencyP50Micros() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinator.java
@@ -46,6 +46,7 @@ final class BackgroundSplitCoordinator<K, V> {
     private final Executor splitExecutor;
     private final Consumer<RuntimeException> splitFailureHandler;
     private final Runnable splitAppliedListener;
+    private final Stats stats;
     private final LongSupplier nanoTimeSupplier;
     private final Object splitMonitor = new Object();
     private final ReentrantReadWriteLock splitGate = new ReentrantReadWriteLock();
@@ -65,7 +66,20 @@ final class BackgroundSplitCoordinator<K, V> {
             final Consumer<RuntimeException> splitFailureHandler,
             final Runnable splitAppliedListener) {
         this(keyToSegmentMap, partitionRuntime, splitCoordinator, splitExecutor,
-                splitFailureHandler, splitAppliedListener, System::nanoTime);
+                splitFailureHandler, splitAppliedListener, new Stats(),
+                System::nanoTime);
+    }
+
+    BackgroundSplitCoordinator(
+            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final PartitionRuntime<K, V> partitionRuntime,
+            final PartitionStableSplitCoordinator<K, V> splitCoordinator,
+            final Executor splitExecutor,
+            final Consumer<RuntimeException> splitFailureHandler,
+            final Runnable splitAppliedListener, final Stats stats) {
+        this(keyToSegmentMap, partitionRuntime, splitCoordinator, splitExecutor,
+                splitFailureHandler, splitAppliedListener, stats,
+                System::nanoTime);
     }
 
     BackgroundSplitCoordinator(
@@ -75,6 +89,19 @@ final class BackgroundSplitCoordinator<K, V> {
             final Executor splitExecutor,
             final Consumer<RuntimeException> splitFailureHandler,
             final Runnable splitAppliedListener,
+            final LongSupplier nanoTimeSupplier) {
+        this(keyToSegmentMap, partitionRuntime, splitCoordinator, splitExecutor,
+                splitFailureHandler, splitAppliedListener, new Stats(),
+                nanoTimeSupplier);
+    }
+
+    BackgroundSplitCoordinator(
+            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final PartitionRuntime<K, V> partitionRuntime,
+            final PartitionStableSplitCoordinator<K, V> splitCoordinator,
+            final Executor splitExecutor,
+            final Consumer<RuntimeException> splitFailureHandler,
+            final Runnable splitAppliedListener, final Stats stats,
             final LongSupplier nanoTimeSupplier) {
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
@@ -88,6 +115,7 @@ final class BackgroundSplitCoordinator<K, V> {
                 "splitFailureHandler");
         this.splitAppliedListener = Vldtn.requireNonNull(splitAppliedListener,
                 "splitAppliedListener");
+        this.stats = Vldtn.requireNonNull(stats, "stats");
         this.nanoTimeSupplier = Vldtn.requireNonNull(nanoTimeSupplier,
                 "nanoTimeSupplier");
     }
@@ -235,10 +263,11 @@ final class BackgroundSplitCoordinator<K, V> {
         }
         markSplitStarted();
         partitionRuntime.beginSplit(segmentId);
+        final long scheduledAtNanos = nanoTimeSupplier.getAsLong();
         try {
             splitExecutor.execute(
-                    () -> executeSplitAsync(segment, splitThreshold,
-                            observedKeyCount));
+                    () -> executeScheduledSplit(segment, splitThreshold,
+                            observedKeyCount, scheduledAtNanos));
         } catch (final RuntimeException e) {
             scheduledSplits.remove(segmentId);
             partitionRuntime.finishSplit(segmentId);
@@ -248,10 +277,31 @@ final class BackgroundSplitCoordinator<K, V> {
         return true;
     }
 
+    private void executeScheduledSplit(final Segment<K, V> segment,
+            final long splitThreshold, final long observedKeyCount,
+            final long scheduledAtNanos) {
+        final long startedAtNanos = nanoTimeSupplier.getAsLong();
+        stats.recordSplitTaskStartDelayNanos(
+                Math.max(0L, startedAtNanos - scheduledAtNanos));
+        try {
+            executeSplitAsync(segment, splitThreshold, observedKeyCount,
+                    startedAtNanos);
+        } finally {
+            stats.recordSplitTaskRunLatencyNanos(Math.max(0L,
+                    nanoTimeSupplier.getAsLong() - startedAtNanos));
+        }
+    }
+
     private void executeSplitAsync(final Segment<K, V> segment,
             final long splitThreshold, final long observedKeyCount) {
+        executeSplitAsync(segment, splitThreshold, observedKeyCount,
+                nanoTimeSupplier.getAsLong());
+    }
+
+    private void executeSplitAsync(final Segment<K, V> segment,
+            final long splitThreshold, final long observedKeyCount,
+            final long startNanos) {
         final SegmentId segmentId = segment.getId();
-        final long startNanos = nanoTimeSupplier.getAsLong();
         boolean splitApplied = false;
         try {
             splitApplied = splitCoordinator.optionallySplit(segment,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexExecutorRegistry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexExecutorRegistry.java
@@ -3,10 +3,13 @@ package org.hestiastore.index.segmentindex.core;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.hestiastore.index.AbstractCloseableResource;
 import org.hestiastore.index.Vldtn;
@@ -38,6 +41,9 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
     private static final String THREAD_NAME_PREFIX_REGISTRY_MAINTENANCE = "registry-maintenance-";
     private static final String MESSAGE_ALREADY_CLOSED = "IndexExecutorRegistry already closed";
 
+    private final ObservedThreadPool indexMaintenanceThreadPool;
+    private final ObservedThreadPool splitMaintenanceThreadPool;
+    private final ObservedThreadPool stableSegmentMaintenanceThreadPool;
     private final ExecutorService indexMaintenanceExecutor;
     private final ExecutorService splitMaintenanceExecutor;
     private final ScheduledExecutorService splitPolicyScheduler;
@@ -52,13 +58,17 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
     IndexExecutorRegistry(final IndexConfiguration<?, ?> indexConfiguration) {
         final IndexConfiguration<?, ?> conf = Vldtn
                 .requireNonNull(indexConfiguration, ARG_INDEX_CONFIGURATION);
+        this.indexMaintenanceThreadPool = createIndexMaintenanceExecutor(conf);
+        this.splitMaintenanceThreadPool = createSplitMaintenanceExecutor(conf);
+        this.stableSegmentMaintenanceThreadPool = createStableSegmentMaintenanceExecutor(
+                conf);
         this.indexMaintenanceExecutor = wrapWithIndexContextIfEnabled(conf,
-                createIndexMaintenanceExecutor(conf));
+                indexMaintenanceThreadPool.executor());
         this.splitMaintenanceExecutor = wrapWithIndexContextIfEnabled(conf,
-                createSplitMaintenanceExecutor(conf));
+                splitMaintenanceThreadPool.executor());
         this.splitPolicyScheduler = createSplitPolicyScheduler();
         this.stableSegmentMaintenanceExecutor = wrapWithIndexContextIfEnabled(
-                conf, createStableSegmentMaintenanceExecutor(conf));
+                conf, stableSegmentMaintenanceThreadPool.executor());
         this.registryMaintenanceExecutor = wrapWithIndexContextIfEnabled(conf,
                 createRegistryMaintenanceExecutor(conf));
     }
@@ -118,7 +128,14 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
         return registryMaintenanceExecutor;
     }
 
-    private static ExecutorService createIndexMaintenanceExecutor(
+    RuntimeSnapshot runtimeSnapshot() {
+        checkNotClosed();
+        return new RuntimeSnapshot(indexMaintenanceThreadPool.snapshot(),
+                splitMaintenanceThreadPool.snapshot(),
+                stableSegmentMaintenanceThreadPool.snapshot());
+    }
+
+    private static ObservedThreadPool createIndexMaintenanceExecutor(
             final IndexConfiguration<?, ?> conf) {
         final int indexMaintenanceThreads = Vldtn
                 .requireGreaterThanZero(
@@ -131,40 +148,46 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
         final int queueCapacity = Math.max(MIN_QUEUE_CAPACITY,
                 indexMaintenanceThreads * QUEUE_CAPACITY_MULTIPLIER);
         final AtomicInteger threadCounter = new AtomicInteger(1);
-        return new ThreadPoolExecutor(indexMaintenanceThreads,
-                indexMaintenanceThreads, 0L, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(queueCapacity), runnable -> {
+        final LongAdder rejectedTaskCount = new LongAdder();
+        return new ObservedThreadPool(new ThreadPoolExecutor(
+                indexMaintenanceThreads, indexMaintenanceThreads, 0L,
+                TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueCapacity),
+                runnable -> {
                     final Thread thread = new Thread(runnable,
                             THREAD_NAME_PREFIX_INDEX_MAINTENANCE
                                     + threadCounter.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
-                }, new ThreadPoolExecutor.AbortPolicy());
+                }, new CountingAbortPolicy(rejectedTaskCount)), queueCapacity,
+                rejectedTaskCount, new LongAdder());
     }
 
-    private static ExecutorService createStableSegmentMaintenanceExecutor(
+    private static ObservedThreadPool createStableSegmentMaintenanceExecutor(
             final IndexConfiguration<?, ?> conf) {
         final int stableSegmentMaintenanceThreads = Vldtn.requireGreaterThanZero(
                 Vldtn.requireNonNull(
                         Vldtn.requireNonNull(conf, ARG_INDEX_CONFIGURATION)
                                 .getNumberOfStableSegmentMaintenanceThreads(),
                         ARG_STABLE_SEGMENT_MAINTENANCE_THREADS),
-                ARG_STABLE_SEGMENT_MAINTENANCE_THREADS);
+                        ARG_STABLE_SEGMENT_MAINTENANCE_THREADS);
         final int queueCapacity = Math.max(MIN_QUEUE_CAPACITY,
                 stableSegmentMaintenanceThreads * QUEUE_CAPACITY_MULTIPLIER);
         final AtomicInteger threadCounter = new AtomicInteger(1);
-        return new ThreadPoolExecutor(stableSegmentMaintenanceThreads,
-                stableSegmentMaintenanceThreads, 0L, TimeUnit.MILLISECONDS,
+        final LongAdder callerRunsCount = new LongAdder();
+        return new ObservedThreadPool(new ThreadPoolExecutor(
+                stableSegmentMaintenanceThreads, stableSegmentMaintenanceThreads,
+                0L, TimeUnit.MILLISECONDS,
                 new ArrayBlockingQueue<>(queueCapacity), runnable -> {
                     final Thread thread = new Thread(runnable,
                             THREAD_NAME_PREFIX_STABLE_SEGMENT_MAINTENANCE
                                     + threadCounter.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
-                }, new ThreadPoolExecutor.CallerRunsPolicy());
+                }, new CountingCallerRunsPolicy(callerRunsCount)),
+                queueCapacity, new LongAdder(), callerRunsCount);
     }
 
-    private static ExecutorService createSplitMaintenanceExecutor(
+    private static ObservedThreadPool createSplitMaintenanceExecutor(
             final IndexConfiguration<?, ?> conf) {
         final int splitMaintenanceThreads = Vldtn
                 .requireGreaterThanZero(
@@ -177,15 +200,18 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
         final int queueCapacity = Math.max(MIN_QUEUE_CAPACITY,
                 splitMaintenanceThreads * QUEUE_CAPACITY_MULTIPLIER);
         final AtomicInteger threadCounter = new AtomicInteger(1);
-        return new ThreadPoolExecutor(splitMaintenanceThreads,
-                splitMaintenanceThreads, 0L, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(queueCapacity), runnable -> {
+        final LongAdder rejectedTaskCount = new LongAdder();
+        return new ObservedThreadPool(new ThreadPoolExecutor(
+                splitMaintenanceThreads, splitMaintenanceThreads, 0L,
+                TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueCapacity),
+                runnable -> {
                     final Thread thread = new Thread(runnable,
                             THREAD_NAME_PREFIX_SPLIT_MAINTENANCE
                                     + threadCounter.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
-                }, new ThreadPoolExecutor.AbortPolicy());
+                }, new CountingAbortPolicy(rejectedTaskCount)), queueCapacity,
+                rejectedTaskCount, new LongAdder());
     }
 
     private static ExecutorService createRegistryMaintenanceExecutor(
@@ -296,6 +322,149 @@ final class IndexExecutorRegistry extends AbstractCloseableResource {
     private void checkNotClosed() {
         if (wasClosed()) {
             throw new IllegalStateException(MESSAGE_ALREADY_CLOSED);
+        }
+    }
+
+    static final class RuntimeSnapshot {
+
+        private final ExecutorMetricsSnapshot indexMaintenance;
+        private final ExecutorMetricsSnapshot splitMaintenance;
+        private final ExecutorMetricsSnapshot stableSegmentMaintenance;
+
+        RuntimeSnapshot(final ExecutorMetricsSnapshot indexMaintenance,
+                final ExecutorMetricsSnapshot splitMaintenance,
+                final ExecutorMetricsSnapshot stableSegmentMaintenance) {
+            this.indexMaintenance = Vldtn.requireNonNull(indexMaintenance,
+                    "indexMaintenance");
+            this.splitMaintenance = Vldtn.requireNonNull(splitMaintenance,
+                    "splitMaintenance");
+            this.stableSegmentMaintenance = Vldtn.requireNonNull(
+                    stableSegmentMaintenance, "stableSegmentMaintenance");
+        }
+
+        ExecutorMetricsSnapshot getIndexMaintenance() {
+            return indexMaintenance;
+        }
+
+        ExecutorMetricsSnapshot getSplitMaintenance() {
+            return splitMaintenance;
+        }
+
+        ExecutorMetricsSnapshot getStableSegmentMaintenance() {
+            return stableSegmentMaintenance;
+        }
+    }
+
+    static final class ExecutorMetricsSnapshot {
+
+        private final int activeThreadCount;
+        private final int queueSize;
+        private final int queueCapacity;
+        private final long completedTaskCount;
+        private final long rejectedTaskCount;
+        private final long callerRunsCount;
+
+        ExecutorMetricsSnapshot(final int activeThreadCount, final int queueSize,
+                final int queueCapacity, final long completedTaskCount,
+                final long rejectedTaskCount, final long callerRunsCount) {
+            this.activeThreadCount = Math.max(0, activeThreadCount);
+            this.queueSize = Math.max(0, queueSize);
+            this.queueCapacity = Math.max(0, queueCapacity);
+            this.completedTaskCount = Math.max(0L, completedTaskCount);
+            this.rejectedTaskCount = Math.max(0L, rejectedTaskCount);
+            this.callerRunsCount = Math.max(0L, callerRunsCount);
+        }
+
+        int getActiveThreadCount() {
+            return activeThreadCount;
+        }
+
+        int getQueueSize() {
+            return queueSize;
+        }
+
+        int getQueueCapacity() {
+            return queueCapacity;
+        }
+
+        long getCompletedTaskCount() {
+            return completedTaskCount;
+        }
+
+        long getRejectedTaskCount() {
+            return rejectedTaskCount;
+        }
+
+        long getCallerRunsCount() {
+            return callerRunsCount;
+        }
+    }
+
+    private static final class ObservedThreadPool {
+
+        private final ThreadPoolExecutor executor;
+        private final int queueCapacity;
+        private final LongAdder rejectedTaskCount;
+        private final LongAdder callerRunsCount;
+
+        private ObservedThreadPool(final ThreadPoolExecutor executor,
+                final int queueCapacity, final LongAdder rejectedTaskCount,
+                final LongAdder callerRunsCount) {
+            this.executor = Vldtn.requireNonNull(executor, "executor");
+            this.queueCapacity = Math.max(0, queueCapacity);
+            this.rejectedTaskCount = Vldtn.requireNonNull(rejectedTaskCount,
+                    "rejectedTaskCount");
+            this.callerRunsCount = Vldtn.requireNonNull(callerRunsCount,
+                    "callerRunsCount");
+        }
+
+        ExecutorService executor() {
+            return executor;
+        }
+
+        ExecutorMetricsSnapshot snapshot() {
+            return new ExecutorMetricsSnapshot(executor.getActiveCount(),
+                    executor.getQueue().size(), queueCapacity,
+                    executor.getCompletedTaskCount(), rejectedTaskCount.sum(),
+                    callerRunsCount.sum());
+        }
+    }
+
+    private static final class CountingAbortPolicy
+            implements RejectedExecutionHandler {
+
+        private final LongAdder rejectedTaskCount;
+
+        private CountingAbortPolicy(final LongAdder rejectedTaskCount) {
+            this.rejectedTaskCount = Vldtn.requireNonNull(rejectedTaskCount,
+                    "rejectedTaskCount");
+        }
+
+        @Override
+        public void rejectedExecution(final Runnable runnable,
+                final ThreadPoolExecutor executor) {
+            rejectedTaskCount.increment();
+            throw new RejectedExecutionException(String.format(
+                    "Task %s rejected from %s", runnable, executor));
+        }
+    }
+
+    private static final class CountingCallerRunsPolicy
+            implements RejectedExecutionHandler {
+
+        private final LongAdder callerRunsCount;
+        private final ThreadPoolExecutor.CallerRunsPolicy delegate = new ThreadPoolExecutor.CallerRunsPolicy();
+
+        private CountingCallerRunsPolicy(final LongAdder callerRunsCount) {
+            this.callerRunsCount = Vldtn.requireNonNull(callerRunsCount,
+                    "callerRunsCount");
+        }
+
+        @Override
+        public void rejectedExecution(final Runnable runnable,
+                final ThreadPoolExecutor executor) {
+            callerRunsCount.increment();
+            delegate.rejectedExecution(runnable, executor);
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinator.java
@@ -17,6 +17,7 @@ import org.hestiastore.index.segmentindex.wal.WalRuntime;
  */
 final class IndexOperationCoordinator<K, V> {
 
+    private static final String OPERATION_PUT = "put";
     private final TypeDescriptor<V> valueTypeDescriptor;
     private final Stats stats;
     private final PartitionWriteCoordinator<K, V> partitionWriteCoordinator;
@@ -54,10 +55,10 @@ final class IndexOperationCoordinator<K, V> {
                     "Can't insert tombstone value '%s' into index", value));
         }
         final long walLsn = walCoordinator.appendPut(key, value);
-        finishWriteOperation("put",
+        finishWriteOperation(OPERATION_PUT,
                 retryWhileBusy(
                         () -> partitionWriteCoordinator.putBuffered(key, value),
-                        "put", false),
+                        OPERATION_PUT, false),
                 walLsn, startedNanos);
     }
 
@@ -123,12 +124,47 @@ final class IndexOperationCoordinator<K, V> {
             final Supplier<IndexResult<T>> operation, final String opName,
             final boolean retryClosed) {
         final long startNanos = retryPolicy.startNanos();
+        long busyWaitStartNanos = 0L;
+        long busyRetryCount = 0L;
         IndexResult<T> result = operation.get();
         while (shouldRetry(result.getStatus(), retryClosed)) {
-            retryPolicy.backoffOrThrow(startNanos, opName, null);
+            if (OPERATION_PUT.equals(opName)
+                    && result.getStatus() == IndexResultStatus.BUSY) {
+                if (busyWaitStartNanos == 0L) {
+                    busyWaitStartNanos = System.nanoTime();
+                }
+                busyRetryCount++;
+            }
+            try {
+                retryPolicy.backoffOrThrow(startNanos, opName, null);
+            } catch (final IndexException e) {
+                recordPutBusyWait(opName, busyWaitStartNanos, busyRetryCount,
+                        isTimeoutException(e));
+                throw e;
+            }
             result = operation.get();
         }
+        recordPutBusyWait(opName, busyWaitStartNanos, busyRetryCount, false);
         return result;
+    }
+
+    private boolean isTimeoutException(final IndexException exception) {
+        return exception.getMessage() != null
+                && exception.getMessage().contains("timed out");
+    }
+
+    private void recordPutBusyWait(final String opName,
+            final long busyWaitStartNanos, final long busyRetryCount,
+            final boolean timedOut) {
+        if (!OPERATION_PUT.equals(opName) || busyWaitStartNanos == 0L) {
+            return;
+        }
+        stats.addPutBusyRetryCx(busyRetryCount);
+        stats.recordPutBusyWaitNanos(
+                Math.max(0L, System.nanoTime() - busyWaitStartNanos));
+        if (timedOut) {
+            stats.incPutBusyTimeoutCx();
+        }
     }
 
     private boolean shouldRetry(final IndexResultStatus status,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/PartitionDrainCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/PartitionDrainCoordinator.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
@@ -29,6 +30,7 @@ final class PartitionDrainCoordinator<K, V> {
     private final Stats stats;
     private final Consumer<SegmentId> splitHintAction;
     private final Consumer<RuntimeException> failureHandler;
+    private final LongSupplier nanoTimeSupplier;
 
     PartitionDrainCoordinator(final PartitionRuntime<K, V> partitionRuntime,
             final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
@@ -36,6 +38,18 @@ final class PartitionDrainCoordinator<K, V> {
             final StableSegmentCoordinator<K, V> stableSegmentCoordinator,
             final Stats stats, final Consumer<SegmentId> splitHintAction,
             final Consumer<RuntimeException> failureHandler) {
+        this(partitionRuntime, keyToSegmentMap, drainExecutor, retryPolicy,
+                stableSegmentCoordinator, stats, splitHintAction,
+                failureHandler, System::nanoTime);
+    }
+
+    PartitionDrainCoordinator(final PartitionRuntime<K, V> partitionRuntime,
+            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final Executor drainExecutor, final IndexRetryPolicy retryPolicy,
+            final StableSegmentCoordinator<K, V> stableSegmentCoordinator,
+            final Stats stats, final Consumer<SegmentId> splitHintAction,
+            final Consumer<RuntimeException> failureHandler,
+            final LongSupplier nanoTimeSupplier) {
         this.partitionRuntime = Vldtn.requireNonNull(partitionRuntime,
                 "partitionRuntime");
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
@@ -50,14 +64,18 @@ final class PartitionDrainCoordinator<K, V> {
                 "splitHintAction");
         this.failureHandler = Vldtn.requireNonNull(failureHandler,
                 "failureHandler");
+        this.nanoTimeSupplier = Vldtn.requireNonNull(nanoTimeSupplier,
+                "nanoTimeSupplier");
     }
 
     void scheduleDrain(final SegmentId segmentId) {
         if (!partitionRuntime.markDrainScheduledIfNeeded(segmentId)) {
             return;
         }
+        final long scheduledAtNanos = nanoTimeSupplier.getAsLong();
         try {
-            drainExecutor.execute(() -> drainPartitionLoop(segmentId));
+            drainExecutor.execute(
+                    () -> drainScheduledPartition(segmentId, scheduledAtNanos));
         } catch (final RuntimeException e) {
             partitionRuntime.finishDrainScheduling(segmentId);
             throw e;
@@ -87,7 +105,20 @@ final class PartitionDrainCoordinator<K, V> {
         if (!partitionRuntime.markDrainScheduledIfNeeded(segmentId)) {
             return;
         }
-        drainPartitionLoop(segmentId);
+        drainScheduledPartition(segmentId, nanoTimeSupplier.getAsLong());
+    }
+
+    private void drainScheduledPartition(final SegmentId segmentId,
+            final long scheduledAtNanos) {
+        final long startedAtNanos = nanoTimeSupplier.getAsLong();
+        stats.recordDrainTaskStartDelayNanos(
+                Math.max(0L, startedAtNanos - scheduledAtNanos));
+        try {
+            drainPartitionLoop(segmentId);
+        } finally {
+            stats.recordDrainTaskRunLatencyNanos(Math.max(0L,
+                    nanoTimeSupplier.getAsLong() - startedAtNanos));
+        }
     }
 
     private void drainPartitionLoop(final SegmentId segmentId) {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexMetricsCollector.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexMetricsCollector.java
@@ -33,6 +33,8 @@ final class SegmentIndexMetricsCollector<K, V> {
     private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final PartitionRuntime<K, V> partitionRuntime;
+    private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
+    private final IndexExecutorRegistry executorRegistry;
     private final RuntimeTuningState runtimeTuningState;
     private final WalRuntime<K, V> walRuntime;
     private final Stats stats;
@@ -45,6 +47,8 @@ final class SegmentIndexMetricsCollector<K, V> {
             final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final PartitionRuntime<K, V> partitionRuntime,
+            final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
+            final IndexExecutorRegistry executorRegistry,
             final RuntimeTuningState runtimeTuningState,
             final WalRuntime<K, V> walRuntime, final Stats stats,
             final AtomicLong compactRequestHighWaterMark,
@@ -58,6 +62,10 @@ final class SegmentIndexMetricsCollector<K, V> {
                 "segmentRegistry");
         this.partitionRuntime = Vldtn.requireNonNull(partitionRuntime,
                 "partitionRuntime");
+        this.backgroundSplitCoordinator = Vldtn.requireNonNull(
+                backgroundSplitCoordinator, "backgroundSplitCoordinator");
+        this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
+                "executorRegistry");
         this.runtimeTuningState = Vldtn.requireNonNull(runtimeTuningState,
                 "runtimeTuningState");
         this.walRuntime = Vldtn.requireNonNull(walRuntime, "walRuntime");
@@ -79,6 +87,14 @@ final class SegmentIndexMetricsCollector<K, V> {
                 collectStableSegmentRuntime();
         final PartitionRuntimeSnapshot partitionSnapshot = partitionRuntime
                 .snapshot();
+        final IndexExecutorRegistry.RuntimeSnapshot executorSnapshot =
+                executorRegistry.runtimeSnapshot();
+        final IndexExecutorRegistry.ExecutorMetricsSnapshot indexMaintenanceExecutor =
+                executorSnapshot.getIndexMaintenance();
+        final IndexExecutorRegistry.ExecutorMetricsSnapshot splitMaintenanceExecutor =
+                executorSnapshot.getSplitMaintenance();
+        final IndexExecutorRegistry.ExecutorMetricsSnapshot stableSegmentMaintenanceExecutor =
+                executorSnapshot.getStableSegmentMaintenance();
         final var walStats = walRuntime.statsSnapshot();
         final long compactRequestCount = Math.max(stats.getCompactRequestCx(),
                 updateHighWaterMark(compactRequestHighWaterMark,
@@ -108,15 +124,23 @@ final class SegmentIndexMetricsCollector<K, V> {
                 stableSegmentRuntime.totalStableSegmentWriteBufferKeyCount
                         + partitionSnapshot.getBufferedKeyCount(),
                 stableSegmentRuntime.totalStableSegmentDeltaCacheFileCount,
-                compactRequestCount, flushRequestCount,
-                partitionSnapshot.getDrainScheduleCount(),
-                partitionSnapshot.getDrainInFlightCount(),
-                partitionSnapshot.getImmutableRunCount(),
-                runtimeTuningState.effectiveValue(
-                        RuntimeSettingKey.MAX_NUMBER_OF_KEYS_IN_INDEX_BUFFER),
-                partitionSnapshot.getDrainingPartitionCount(),
-                runtimeTuningState.effectiveValue(
-                        RuntimeSettingKey.MAX_NUMBER_OF_IMMUTABLE_RUNS_PER_PARTITION),
+                compactRequestCount, flushRequestCount, stats.getSplitScheduleCx(),
+                backgroundSplitCoordinator.splitInFlightCount(),
+                indexMaintenanceExecutor.getQueueSize(),
+                indexMaintenanceExecutor.getQueueCapacity(),
+                splitMaintenanceExecutor.getQueueSize(),
+                splitMaintenanceExecutor.getQueueCapacity(),
+                indexMaintenanceExecutor.getActiveThreadCount(),
+                indexMaintenanceExecutor.getCompletedTaskCount(),
+                indexMaintenanceExecutor.getRejectedTaskCount(),
+                splitMaintenanceExecutor.getActiveThreadCount(),
+                splitMaintenanceExecutor.getCompletedTaskCount(),
+                splitMaintenanceExecutor.getRejectedTaskCount(),
+                stableSegmentMaintenanceExecutor.getActiveThreadCount(),
+                stableSegmentMaintenanceExecutor.getQueueSize(),
+                stableSegmentMaintenanceExecutor.getQueueCapacity(),
+                stableSegmentMaintenanceExecutor.getCompletedTaskCount(),
+                stableSegmentMaintenanceExecutor.getCallerRunsCount(),
                 stats.getReadLatencyP50Micros(),
                 stats.getReadLatencyP95Micros(),
                 stats.getReadLatencyP99Micros(),
@@ -153,6 +177,19 @@ final class SegmentIndexMetricsCollector<K, V> {
                 partitionSnapshot.getDrainScheduleCount(),
                 partitionSnapshot.getDrainInFlightCount(),
                 stats.getDrainLatencyP95Micros(),
+                stats.getSplitTaskStartDelayP95Micros(),
+                stats.getSplitTaskRunLatencyP95Micros(),
+                stats.getDrainTaskStartDelayP95Micros(),
+                stats.getDrainTaskRunLatencyP95Micros(),
+                partitionSnapshot.getSplitBlockedPartitionCount(),
+                partitionSnapshot.getSplitBlockedDrainScheduleCount(),
+                partitionSnapshot.getBufferFullWhileSplitBlockedCount(),
+                stats.getPutBusyRetryCx(), stats.getPutBusyTimeoutCx(),
+                stats.getPutBusyWaitP95Micros(),
+                stats.getFlushAcceptedToReadyP95Micros(),
+                stats.getCompactAcceptedToReadyP95Micros(),
+                stats.getFlushBusyRetryCx(),
+                stats.getCompactBusyRetryCx(),
                 stableSegmentRuntime.stableSegmentMetricsSnapshots,
                 stateSupplier.get());
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
@@ -165,7 +165,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
                     keyToSegmentMap, partitionRuntime, splitCoordinator,
                     executorRegistry.getSplitMaintenanceExecutor(),
                     callbacks.failureHandler(),
-                    callbacks.onBackgroundSplitApplied());
+                    callbacks.onBackgroundSplitApplied(), stats);
             final StableSegmentGateway<K, V> stableSegmentGateway = new StableSegmentGateway<>(
                     keyToSegmentMap, segmentRegistry);
             final IndexRetryPolicy retryPolicy = newRetryPolicy();
@@ -221,7 +221,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
                     walCoordinator);
             final SegmentIndexMetricsCollector<K, V> metricsCollector = newMetricsCollector(
                     keyToSegmentMap, segmentRegistry, partitionRuntime,
-                    runtimeTuningState, walRuntime);
+                    backgroundSplitCoordinator, runtimeTuningState, walRuntime);
             final SegmentRuntimeLimitApplier<K, V> runtimeLimitApplier = new SegmentRuntimeLimitApplier<>(
                     segmentRegistry, segmentFactory);
             return new SegmentIndexRuntime<>(runtimeTuningState,
@@ -273,12 +273,14 @@ final class SegmentIndexRuntimeBuilder<K, V> {
             final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final PartitionRuntime<K, V> partitionRuntime,
+            final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final RuntimeTuningState runtimeTuningState,
             final WalRuntime<K, V> walRuntime) {
         return new SegmentIndexMetricsCollector<>(conf, keyToSegmentMap,
-                segmentRegistry, partitionRuntime, runtimeTuningState,
-                walRuntime, stats, compactRequestHighWaterMark,
-                flushRequestHighWaterMark, lastAppliedWalLsn,
+                segmentRegistry, partitionRuntime, backgroundSplitCoordinator,
+                executorRegistry, runtimeTuningState, walRuntime, stats,
+                compactRequestHighWaterMark, flushRequestHighWaterMark,
+                lastAppliedWalLsn,
                 callbacks.stateSupplier());
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinator.java
@@ -1,5 +1,7 @@
 package org.hestiastore.index.segmentindex.core;
 
+import java.util.function.LongSupplier;
+
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
@@ -35,6 +37,7 @@ final class StableSegmentCoordinator<K, V> {
     private final StableSegmentGateway<K, V> stableSegmentGateway;
     private final IndexRetryPolicy retryPolicy;
     private final Stats stats;
+    private final LongSupplier nanoTimeSupplier;
 
     StableSegmentCoordinator(final Logger logger,
             final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
@@ -42,6 +45,17 @@ final class StableSegmentCoordinator<K, V> {
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final StableSegmentGateway<K, V> stableSegmentGateway,
             final IndexRetryPolicy retryPolicy, final Stats stats) {
+        this(logger, keyToSegmentMap, segmentRegistry, backgroundSplitCoordinator,
+                stableSegmentGateway, retryPolicy, stats, System::nanoTime);
+    }
+
+    StableSegmentCoordinator(final Logger logger,
+            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final SegmentRegistry<K, V> segmentRegistry,
+            final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
+            final StableSegmentGateway<K, V> stableSegmentGateway,
+            final IndexRetryPolicy retryPolicy, final Stats stats,
+            final LongSupplier nanoTimeSupplier) {
         this.logger = Vldtn.requireNonNull(logger, "logger");
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
@@ -53,6 +67,8 @@ final class StableSegmentCoordinator<K, V> {
                 "stableSegmentGateway");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
         this.stats = Vldtn.requireNonNull(stats, "stats");
+        this.nanoTimeSupplier = Vldtn.requireNonNull(nanoTimeSupplier,
+                "nanoTimeSupplier");
     }
 
     void putEntryForDrain(final SegmentId segmentId, final K key,
@@ -208,6 +224,7 @@ final class StableSegmentCoordinator<K, V> {
                         operationLabel)) {
                     return;
                 }
+                recordBusyRetry(operation);
                 retryPolicy.backoffOrThrow(startNanos, operation, segmentId);
                 continue;
             }
@@ -229,7 +246,10 @@ final class StableSegmentCoordinator<K, V> {
                 operationLabel, segmentId, waitForCompletion,
                 segment == null ? null : segment.getState());
         if (waitForCompletion && segment != null) {
+            final long acceptedAtNanos = nanoTimeSupplier.getAsLong();
             awaitSegmentReady(segmentId, operation, segment);
+            recordAcceptedToReadyLatency(operation,
+                    nanoTimeSupplier.getAsLong() - acceptedAtNanos);
         }
         logOperation("{} completed: segment='{}' wait='{}'", operationLabel,
                 segmentId, waitForCompletion);
@@ -257,6 +277,23 @@ final class StableSegmentCoordinator<K, V> {
     private void logOperation(final String message, final Object... args) {
         if (logger.isDebugEnabled()) {
             logger.debug(message, args);
+        }
+    }
+
+    private void recordAcceptedToReadyLatency(final String operation,
+            final long latencyNanos) {
+        if (OPERATION_FLUSH.equals(operation)) {
+            stats.recordFlushAcceptedToReadyNanos(latencyNanos);
+        } else if (OPERATION_COMPACT.equals(operation)) {
+            stats.recordCompactAcceptedToReadyNanos(latencyNanos);
+        }
+    }
+
+    private void recordBusyRetry(final String operation) {
+        if (OPERATION_FLUSH.equals(operation)) {
+            stats.incFlushBusyRetryCx();
+        } else if (OPERATION_COMPACT.equals(operation)) {
+            stats.incCompactBusyRetryCx();
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/Stats.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/Stats.java
@@ -15,9 +15,20 @@ class Stats {
     private final LongAdder compactRequestCx = new LongAdder();
     private final LongAdder flushRequestCx = new LongAdder();
     private final LongAdder splitScheduleCx = new LongAdder();
+    private final LongAdder putBusyRetryCx = new LongAdder();
+    private final LongAdder putBusyTimeoutCx = new LongAdder();
+    private final LongAdder flushBusyRetryCx = new LongAdder();
+    private final LongAdder compactBusyRetryCx = new LongAdder();
     private final OperationLatencyTracker readLatency = new OperationLatencyTracker();
     private final OperationLatencyTracker writeLatency = new OperationLatencyTracker();
     private final OperationLatencyTracker drainLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker putBusyWaitLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker splitTaskStartDelayLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker splitTaskRunLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker drainTaskStartDelayLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker drainTaskRunLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker flushAcceptedToReadyLatency = new OperationLatencyTracker();
+    private final OperationLatencyTracker compactAcceptedToReadyLatency = new OperationLatencyTracker();
 
     Stats() {
 
@@ -47,6 +58,25 @@ class Stats {
         splitScheduleCx.increment();
     }
 
+    void addPutBusyRetryCx(final long retries) {
+        if (retries <= 0L) {
+            return;
+        }
+        putBusyRetryCx.add(retries);
+    }
+
+    void incPutBusyTimeoutCx() {
+        putBusyTimeoutCx.increment();
+    }
+
+    void incFlushBusyRetryCx() {
+        flushBusyRetryCx.increment();
+    }
+
+    void incCompactBusyRetryCx() {
+        compactBusyRetryCx.increment();
+    }
+
     void recordReadLatencyNanos(final long nanos) {
         readLatency.recordNanos(nanos);
     }
@@ -57,6 +87,34 @@ class Stats {
 
     void recordDrainLatencyNanos(final long nanos) {
         drainLatency.recordNanos(nanos);
+    }
+
+    void recordPutBusyWaitNanos(final long nanos) {
+        putBusyWaitLatency.recordNanos(nanos);
+    }
+
+    void recordSplitTaskStartDelayNanos(final long nanos) {
+        splitTaskStartDelayLatency.recordNanos(nanos);
+    }
+
+    void recordSplitTaskRunLatencyNanos(final long nanos) {
+        splitTaskRunLatency.recordNanos(nanos);
+    }
+
+    void recordDrainTaskStartDelayNanos(final long nanos) {
+        drainTaskStartDelayLatency.recordNanos(nanos);
+    }
+
+    void recordDrainTaskRunLatencyNanos(final long nanos) {
+        drainTaskRunLatency.recordNanos(nanos);
+    }
+
+    void recordFlushAcceptedToReadyNanos(final long nanos) {
+        flushAcceptedToReadyLatency.recordNanos(nanos);
+    }
+
+    void recordCompactAcceptedToReadyNanos(final long nanos) {
+        compactAcceptedToReadyLatency.recordNanos(nanos);
     }
 
     /**
@@ -98,6 +156,22 @@ class Stats {
         return splitScheduleCx.sum();
     }
 
+    long getPutBusyRetryCx() {
+        return putBusyRetryCx.sum();
+    }
+
+    long getPutBusyTimeoutCx() {
+        return putBusyTimeoutCx.sum();
+    }
+
+    long getFlushBusyRetryCx() {
+        return flushBusyRetryCx.sum();
+    }
+
+    long getCompactBusyRetryCx() {
+        return compactBusyRetryCx.sum();
+    }
+
     long getReadLatencyP50Micros() {
         return readLatency.percentileMicros(0.50D);
     }
@@ -124,6 +198,34 @@ class Stats {
 
     long getDrainLatencyP95Micros() {
         return drainLatency.percentileMicros(0.95D);
+    }
+
+    long getPutBusyWaitP95Micros() {
+        return putBusyWaitLatency.percentileMicros(0.95D);
+    }
+
+    long getSplitTaskStartDelayP95Micros() {
+        return splitTaskStartDelayLatency.percentileMicros(0.95D);
+    }
+
+    long getSplitTaskRunLatencyP95Micros() {
+        return splitTaskRunLatency.percentileMicros(0.95D);
+    }
+
+    long getDrainTaskStartDelayP95Micros() {
+        return drainTaskStartDelayLatency.percentileMicros(0.95D);
+    }
+
+    long getDrainTaskRunLatencyP95Micros() {
+        return drainTaskRunLatency.percentileMicros(0.95D);
+    }
+
+    long getFlushAcceptedToReadyP95Micros() {
+        return flushAcceptedToReadyLatency.percentileMicros(0.95D);
+    }
+
+    long getCompactAcceptedToReadyP95Micros() {
+        return compactAcceptedToReadyLatency.percentileMicros(0.95D);
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/partition/PartitionRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/partition/PartitionRuntime.java
@@ -29,6 +29,8 @@ public final class PartitionRuntime<K, V> {
     private final AtomicInteger globalThrottleCount = new AtomicInteger();
     private final AtomicInteger drainInFlightCount = new AtomicInteger();
     private final LongAdder drainScheduleCount = new LongAdder();
+    private final LongAdder splitBlockedDrainScheduleCount = new LongAdder();
+    private final LongAdder bufferFullWhileSplitBlockedCount = new LongAdder();
 
     public PartitionRuntime(final Comparator<K> keyComparator) {
         this.keyComparator = Vldtn.requireNonNull(keyComparator,
@@ -43,9 +45,15 @@ public final class PartitionRuntime<K, V> {
             final V value, final PartitionRuntimeLimits limits) {
         Vldtn.requireNonNull(key, "key");
         Vldtn.requireNonNull(value, "value");
-        return partition(segmentId).write(key, value, limits,
+        final RangePartition<K, V> partition = partition(segmentId);
+        final PartitionWriteResult result = partition.write(key, value, limits,
                 totalBufferedKeyCount, localThrottleCount,
                 globalThrottleCount);
+        if (result.getStatus() == PartitionWriteResultStatus.BUSY
+                && partition.isSplitBlocked()) {
+            bufferFullWhileSplitBlockedCount.increment();
+        }
+        return result;
     }
 
     public PartitionLookupResult<V> lookup(final SegmentId segmentId,
@@ -63,7 +71,14 @@ public final class PartitionRuntime<K, V> {
 
     public boolean markDrainScheduledIfNeeded(final SegmentId segmentId) {
         final RangePartition<K, V> partition = partitions.get(segmentId);
-        if (partition == null || !partition.markDrainScheduledIfNeeded()) {
+        if (partition == null) {
+            return false;
+        }
+        final boolean splitBlocked = partition.isSplitBlocked();
+        if (!partition.markDrainScheduledIfNeeded()) {
+            if (splitBlocked) {
+                splitBlockedDrainScheduleCount.increment();
+            }
             return false;
         }
         drainScheduleCount.increment();
@@ -116,6 +131,7 @@ public final class PartitionRuntime<K, V> {
         int activePartitionCount = 0;
         int drainingPartitionCount = 0;
         int immutableRunCount = 0;
+        int splitBlockedPartitionCount = 0;
         for (final RangePartition<K, V> partition : partitions.values()) {
             if (partition.hasActiveEntries()) {
                 activePartitionCount++;
@@ -123,13 +139,19 @@ public final class PartitionRuntime<K, V> {
             if (partition.isDrainScheduled()) {
                 drainingPartitionCount++;
             }
+            if (partition.isSplitBlocked()) {
+                splitBlockedPartitionCount++;
+            }
             immutableRunCount += partition.getImmutableRunCount();
         }
         return new PartitionRuntimeSnapshot(partitions.size(),
                 activePartitionCount, drainingPartitionCount, immutableRunCount,
                 totalBufferedKeyCount.get(), localThrottleCount.get(),
                 globalThrottleCount.get(), drainScheduleCount.sum(),
-                Math.max(0, drainInFlightCount.get()));
+                Math.max(0, drainInFlightCount.get()),
+                splitBlockedPartitionCount,
+                splitBlockedDrainScheduleCount.sum(),
+                bufferFullWhileSplitBlockedCount.sum());
     }
 
     public boolean hasBufferedData() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/partition/PartitionRuntimeSnapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/partition/PartitionRuntimeSnapshot.java
@@ -17,12 +17,29 @@ public final class PartitionRuntimeSnapshot {
     private final long globalThrottleCount;
     private final long drainScheduleCount;
     private final int drainInFlightCount;
+    private final int splitBlockedPartitionCount;
+    private final long splitBlockedDrainScheduleCount;
+    private final long bufferFullWhileSplitBlockedCount;
 
     public PartitionRuntimeSnapshot(final int partitionCount,
             final int activePartitionCount, final int drainingPartitionCount,
             final int immutableRunCount, final int bufferedKeyCount,
             final long localThrottleCount, final long globalThrottleCount,
             final long drainScheduleCount, final int drainInFlightCount) {
+        this(partitionCount, activePartitionCount, drainingPartitionCount,
+                immutableRunCount, bufferedKeyCount, localThrottleCount,
+                globalThrottleCount, drainScheduleCount, drainInFlightCount, 0,
+                0L, 0L);
+    }
+
+    public PartitionRuntimeSnapshot(final int partitionCount,
+            final int activePartitionCount, final int drainingPartitionCount,
+            final int immutableRunCount, final int bufferedKeyCount,
+            final long localThrottleCount, final long globalThrottleCount,
+            final long drainScheduleCount, final int drainInFlightCount,
+            final int splitBlockedPartitionCount,
+            final long splitBlockedDrainScheduleCount,
+            final long bufferFullWhileSplitBlockedCount) {
         this.partitionCount = Math.max(0, partitionCount);
         this.activePartitionCount = Math.max(0, activePartitionCount);
         this.drainingPartitionCount = Math.max(0, drainingPartitionCount);
@@ -32,6 +49,12 @@ public final class PartitionRuntimeSnapshot {
         this.globalThrottleCount = Math.max(0L, globalThrottleCount);
         this.drainScheduleCount = Math.max(0L, drainScheduleCount);
         this.drainInFlightCount = Math.max(0, drainInFlightCount);
+        this.splitBlockedPartitionCount = Math.max(0,
+                splitBlockedPartitionCount);
+        this.splitBlockedDrainScheduleCount = Math.max(0L,
+                splitBlockedDrainScheduleCount);
+        this.bufferFullWhileSplitBlockedCount = Math.max(0L,
+                bufferFullWhileSplitBlockedCount);
     }
 
     public int getPartitionCount() {
@@ -68,5 +91,17 @@ public final class PartitionRuntimeSnapshot {
 
     public int getDrainInFlightCount() {
         return drainInFlightCount;
+    }
+
+    public int getSplitBlockedPartitionCount() {
+        return splitBlockedPartitionCount;
+    }
+
+    public long getSplitBlockedDrainScheduleCount() {
+        return splitBlockedDrainScheduleCount;
+    }
+
+    public long getBufferFullWhileSplitBlockedCount() {
+        return bufferFullWhileSplitBlockedCount;
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/partition/RangePartition.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/partition/RangePartition.java
@@ -171,6 +171,12 @@ final class RangePartition<K, V> {
         }
     }
 
+    boolean isSplitBlocked() {
+        synchronized (monitor) {
+            return splitBlockCount > 0;
+        }
+    }
+
     void beginSplit() {
         synchronized (monitor) {
             splitBlockCount++;

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexMetricsSnapshotTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexMetricsSnapshotTest.java
@@ -62,6 +62,68 @@ class IntegrationSegmentIndexMetricsSnapshotTest {
     }
 
     @Test
+    void metricsSnapshotExposesExecutorRuntimeMetrics() {
+        final Directory directory = new MemDirectory();
+        final TypeDescriptorInteger keyDescriptor = new TypeDescriptorInteger();
+        final TypeDescriptorShortString valueDescriptor = new TypeDescriptorShortString();
+        final IndexConfiguration<Integer, String> conf = IndexConfiguration
+                .<Integer, String>builder()//
+                .withKeyClass(Integer.class)//
+                .withValueClass(String.class)//
+                .withKeyTypeDescriptor(keyDescriptor) //
+                .withValueTypeDescriptor(valueDescriptor) //
+                .withMaxNumberOfKeysInSegmentCache(8) //
+                .withMaxNumberOfKeysInSegment(32) //
+                .withMaxNumberOfKeysInSegmentChunk(4) //
+                .withBloomFilterIndexSizeInBytes(1024 * 1024) //
+                .withBloomFilterNumberOfHashFunctions(4) //
+                .withContextLoggingEnabled(false) //
+                .withName("metrics_executor_runtime_test_index") //
+                .build();
+
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                conf)) {
+            index.put(1, "a");
+            final SegmentIndexMetricsSnapshot snapshot = index
+                    .metricsSnapshot();
+
+            assertTrue(snapshot.getMaintenanceQueueCapacity() > 0);
+            assertTrue(snapshot.getSplitQueueCapacity() > 0);
+            assertTrue(snapshot.getStableSegmentMaintenanceQueueCapacity() > 0);
+            assertTrue(snapshot.getMaintenanceQueueSize() >= 0);
+            assertTrue(snapshot.getSplitQueueSize() >= 0);
+            assertTrue(snapshot.getStableSegmentMaintenanceQueueSize() >= 0);
+            assertTrue(snapshot.getIndexMaintenanceActiveThreadCount() >= 0);
+            assertTrue(snapshot.getSplitMaintenanceActiveThreadCount() >= 0);
+            assertTrue(
+                    snapshot.getStableSegmentMaintenanceActiveThreadCount() >= 0);
+            assertTrue(snapshot.getIndexMaintenanceCompletedTaskCount() >= 0L);
+            assertTrue(snapshot.getSplitMaintenanceCompletedTaskCount() >= 0L);
+            assertTrue(snapshot
+                    .getStableSegmentMaintenanceCompletedTaskCount() >= 0L);
+            assertTrue(snapshot.getIndexMaintenanceRejectedTaskCount() >= 0L);
+            assertTrue(snapshot.getSplitMaintenanceRejectedTaskCount() >= 0L);
+            assertTrue(
+                    snapshot.getStableSegmentMaintenanceCallerRunsCount() >= 0L);
+            assertTrue(snapshot.getSplitTaskStartDelayP95Micros() >= 0L);
+            assertTrue(snapshot.getSplitTaskRunLatencyP95Micros() >= 0L);
+            assertTrue(snapshot.getDrainTaskStartDelayP95Micros() >= 0L);
+            assertTrue(snapshot.getDrainTaskRunLatencyP95Micros() >= 0L);
+            assertTrue(snapshot.getSplitBlockedPartitionCount() >= 0);
+            assertTrue(snapshot.getSplitBlockedDrainScheduleCount() >= 0L);
+            assertTrue(
+                    snapshot.getBufferFullWhileSplitBlockedCount() >= 0L);
+            assertTrue(snapshot.getPutBusyRetryCount() >= 0L);
+            assertTrue(snapshot.getPutBusyTimeoutCount() >= 0L);
+            assertTrue(snapshot.getPutBusyWaitP95Micros() >= 0L);
+            assertTrue(snapshot.getFlushAcceptedToReadyP95Micros() >= 0L);
+            assertTrue(snapshot.getCompactAcceptedToReadyP95Micros() >= 0L);
+            assertTrue(snapshot.getFlushBusyRetryCount() >= 0L);
+            assertTrue(snapshot.getCompactBusyRetryCount() >= 0L);
+        }
+    }
+
+    @Test
     void metricsSnapshotExposesWalStatsWhenEnabled() {
         final Directory directory = new MemDirectory();
         final TypeDescriptorInteger keyDescriptor = new TypeDescriptorInteger();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexMetricsSnapshotTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexMetricsSnapshotTest.java
@@ -53,9 +53,8 @@ class SegmentIndexMetricsSnapshotTest {
         final SegmentIndexMetricsSnapshot snapshot = new SegmentIndexMetricsSnapshot(
                 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 11, 12, 0, 0, 0, 0, 0,
                 0, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 0, 0, 0L, 0L, 0L, 0L,
-                0L, 0L, 0, 0, 0D, 0L, 0L, 0L, 0L, true, 1L, 2L, 3L, 4L, 5L,
-                6L, 7L, 8, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16, 17, 18, 19,
-                20, 21, 22, 23, 24L, 25L, 26L, 27, 28L, List.of(),
+                0L, 0L, 0, 0, 0D, 0L, 0L, 0L, 0L, 17, 18, 19, 20, 21, 22, 23,
+                24L, 25L, 26L, 27, List.of(),
                 SegmentIndexState.READY);
 
         assertEquals(11, snapshot.getMaxNumberOfKeysInActivePartition());
@@ -71,10 +70,45 @@ class SegmentIndexMetricsSnapshotTest {
         assertEquals(25L, snapshot.getGlobalThrottleCount());
         assertEquals(26L, snapshot.getDrainScheduleCount());
         assertEquals(27, snapshot.getDrainInFlightCount());
-        assertEquals(28L, snapshot.getDrainLatencyP95Micros());
+        assertEquals(0L, snapshot.getDrainLatencyP95Micros());
     }
 
     @Test
+    void fullConstructorStoresExecutorMetricsValues() {
+        final SegmentIndexMetricsSnapshot snapshot = new SegmentIndexMetricsSnapshot(
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0L, 0L, 0L, 0L, 0L, 0L, 10L, 11, 12, 13, 14, 15, 16, 17L, 18L,
+                19, 20L, 21L, 22, 23, 24, 25L, 26L, 0L, 0L, 0L, 0L, 0L, 0L, 0,
+                0, 0D, 0L, 0L, 0L, 0L, false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0,
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 0, 0, 0, 0, 0L, 0L,
+                0L, 0, 0L, NO_SEGMENTS,
+                SegmentIndexState.READY);
+
+        assertEquals(10L, snapshot.getSplitScheduleCount());
+        assertEquals(11, snapshot.getSplitInFlightCount());
+        assertEquals(12, snapshot.getMaintenanceQueueSize());
+        assertEquals(13, snapshot.getMaintenanceQueueCapacity());
+        assertEquals(14, snapshot.getSplitQueueSize());
+        assertEquals(15, snapshot.getSplitQueueCapacity());
+        assertEquals(16, snapshot.getIndexMaintenanceActiveThreadCount());
+        assertEquals(17L, snapshot.getIndexMaintenanceCompletedTaskCount());
+        assertEquals(18L, snapshot.getIndexMaintenanceRejectedTaskCount());
+        assertEquals(19, snapshot.getSplitMaintenanceActiveThreadCount());
+        assertEquals(20L, snapshot.getSplitMaintenanceCompletedTaskCount());
+        assertEquals(21L, snapshot.getSplitMaintenanceRejectedTaskCount());
+        assertEquals(22, snapshot.getStableSegmentMaintenanceActiveThreadCount());
+        assertEquals(23, snapshot.getStableSegmentMaintenanceQueueSize());
+        assertEquals(24, snapshot.getStableSegmentMaintenanceQueueCapacity());
+        assertEquals(25L,
+                snapshot.getStableSegmentMaintenanceCompletedTaskCount());
+        assertEquals(26L,
+                snapshot.getStableSegmentMaintenanceCallerRunsCount());
+        assertEquals(0L, snapshot.getFlushAcceptedToReadyP95Micros());
+        assertEquals(0L, snapshot.getCompactAcceptedToReadyP95Micros());
+        assertEquals(0L, snapshot.getFlushBusyRetryCount());
+        assertEquals(0L, snapshot.getCompactBusyRetryCount());
+    }
+
     void fullConstructorStoresWalMetricsValues() {
         final SegmentIndexMetricsSnapshot snapshot = new SegmentIndexMetricsSnapshot(
                 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -211,5 +245,15 @@ class SegmentIndexMetricsSnapshotTest {
         assertEquals(0L, snapshot.getDrainScheduleCount());
         assertEquals(0, snapshot.getDrainInFlightCount());
         assertEquals(0L, snapshot.getDrainLatencyP95Micros());
+        assertEquals(0, snapshot.getSplitBlockedPartitionCount());
+        assertEquals(0L, snapshot.getSplitBlockedDrainScheduleCount());
+        assertEquals(0L, snapshot.getBufferFullWhileSplitBlockedCount());
+        assertEquals(0L, snapshot.getPutBusyRetryCount());
+        assertEquals(0L, snapshot.getPutBusyTimeoutCount());
+        assertEquals(0L, snapshot.getPutBusyWaitP95Micros());
+        assertEquals(0L, snapshot.getFlushAcceptedToReadyP95Micros());
+        assertEquals(0L, snapshot.getCompactAcceptedToReadyP95Micros());
+        assertEquals(0L, snapshot.getFlushBusyRetryCount());
+        assertEquals(0L, snapshot.getCompactBusyRetryCount());
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinatorTest.java
@@ -138,6 +138,40 @@ class BackgroundSplitCoordinatorTest {
     }
 
     @Test
+    void recordsSplitTaskStartDelayAndRunLatency() {
+        final SegmentId segmentId = SegmentId.of(6);
+        final AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+        final AtomicLong nowNanos = new AtomicLong(TimeUnit.MILLISECONDS
+                .toNanos(2));
+        final Stats stats = new Stats();
+        when(segment.getId()).thenReturn(segmentId);
+        when(segment.getState()).thenReturn(SegmentState.READY);
+        when(keyToSegmentMap.getSegmentIds()).thenReturn(List.of(segmentId));
+        when(segment.getNumberOfKeysInCache()).thenReturn(101L);
+        when(splitCoordinator.optionallySplit(eq(segment), eq(100L), any()))
+                .thenAnswer(invocation -> {
+                    nowNanos.set(TimeUnit.MILLISECONDS.toNanos(9));
+                    return Boolean.FALSE;
+                });
+
+        final BackgroundSplitCoordinator<String, String> coordinator = new BackgroundSplitCoordinator<>(
+                synchronizedKeyToSegmentMap, partitionRuntime,
+                splitCoordinator, scheduledTask::set, failure -> {
+                }, () -> {
+                }, stats, nowNanos::get);
+
+        coordinator.handleSplitCandidate(segment, 100L);
+        nowNanos.set(TimeUnit.MILLISECONDS.toNanos(5));
+
+        scheduledTask.get().run();
+
+        org.junit.jupiter.api.Assertions.assertEquals(3_000L,
+                stats.getSplitTaskStartDelayP95Micros());
+        org.junit.jupiter.api.Assertions.assertEquals(4_000L,
+                stats.getSplitTaskRunLatencyP95Micros());
+    }
+
+    @Test
     void splitSchedulingPauseSkipsNewCandidate() {
         final SegmentId segmentId = SegmentId.of(17);
         when(segment.getId()).thenReturn(segmentId);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexExecutorRegistryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexExecutorRegistryTest.java
@@ -11,7 +11,9 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
@@ -307,6 +309,100 @@ class IndexExecutorRegistryTest {
         } finally {
             release.countDown();
             registry.close();
+        }
+    }
+
+    @Test
+    void runtimeSnapshotTracksIndexMaintenanceQueuePressureAndRejections()
+            throws InterruptedException {
+        final IndexConfiguration<Integer, String> conf = buildConf(1, 1, 1);
+        final IndexExecutorRegistry registry = new IndexExecutorRegistry(conf);
+        final CountDownLatch workerStarted = new CountDownLatch(1);
+        final CountDownLatch releaseWorker = new CountDownLatch(1);
+        try {
+            registry.getIndexMaintenanceExecutor().execute(() -> {
+                workerStarted.countDown();
+                awaitRelease(releaseWorker);
+            });
+            assertTrue(workerStarted.await(2, TimeUnit.SECONDS));
+            for (int i = 0; i < 64; i++) {
+                registry.getIndexMaintenanceExecutor().execute(() -> {
+                });
+            }
+
+            assertThrows(RejectedExecutionException.class,
+                    () -> registry.getIndexMaintenanceExecutor().execute(() -> {
+                    }));
+
+            final IndexExecutorRegistry.ExecutorMetricsSnapshot snapshot =
+                    registry.runtimeSnapshot().getIndexMaintenance();
+            assertEquals(1, snapshot.getActiveThreadCount());
+            assertEquals(64, snapshot.getQueueSize());
+            assertEquals(64, snapshot.getQueueCapacity());
+            assertEquals(1L, snapshot.getRejectedTaskCount());
+            assertEquals(0L, snapshot.getCallerRunsCount());
+        } finally {
+            releaseWorker.countDown();
+            registry.close();
+        }
+    }
+
+    @Test
+    void runtimeSnapshotTracksCompletedTasksAndCallerRuns()
+            throws InterruptedException, ExecutionException {
+        final IndexConfiguration<Integer, String> conf = buildConf(1, 1, 1);
+        final IndexExecutorRegistry registry = new IndexExecutorRegistry(conf);
+        final CountDownLatch workerStarted = new CountDownLatch(1);
+        final CountDownLatch releaseWorker = new CountDownLatch(1);
+        final AtomicReference<String> callerRunThread = new AtomicReference<>();
+        try {
+            registry.getSplitMaintenanceExecutor().submit(() -> {
+            }).get();
+            registry.getStableSegmentMaintenanceExecutor().submit(() -> {
+            }).get();
+
+            registry.getStableSegmentMaintenanceExecutor().execute(() -> {
+                workerStarted.countDown();
+                awaitRelease(releaseWorker);
+            });
+            assertTrue(workerStarted.await(2, TimeUnit.SECONDS));
+            for (int i = 0; i < 64; i++) {
+                registry.getStableSegmentMaintenanceExecutor().execute(() -> {
+                });
+            }
+
+            final String submittingThreadName = Thread.currentThread().getName();
+            registry.getStableSegmentMaintenanceExecutor()
+                    .execute(() -> callerRunThread
+                            .set(Thread.currentThread().getName()));
+
+            assertEquals(submittingThreadName, callerRunThread.get());
+
+            final IndexExecutorRegistry.RuntimeSnapshot runtimeSnapshot =
+                    registry.runtimeSnapshot();
+            assertEquals(1L, runtimeSnapshot.getSplitMaintenance()
+                    .getCompletedTaskCount());
+            assertEquals(1L, runtimeSnapshot.getStableSegmentMaintenance()
+                    .getCompletedTaskCount());
+            assertEquals(1L, runtimeSnapshot.getStableSegmentMaintenance()
+                    .getCallerRunsCount());
+            assertEquals(1, runtimeSnapshot.getStableSegmentMaintenance()
+                    .getActiveThreadCount());
+            assertEquals(64, runtimeSnapshot.getStableSegmentMaintenance()
+                    .getQueueSize());
+            assertEquals(64, runtimeSnapshot.getStableSegmentMaintenance()
+                    .getQueueCapacity());
+        } finally {
+            releaseWorker.countDown();
+            registry.close();
+        }
+    }
+
+    private static void awaitRelease(final CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexOperationCoordinatorTest.java
@@ -2,9 +2,11 @@ package org.hestiastore.index.segmentindex.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
@@ -52,8 +54,31 @@ class IndexOperationCoordinatorTest {
         coordinator.put(1, "one");
 
         assertEquals(1L, stats.getPutCx());
+        assertEquals(1L, stats.getPutBusyRetryCx());
+        assertEquals(0L, stats.getPutBusyTimeoutCx());
         verify(retryPolicy).backoffOrThrow(1L, "put", null);
         verify(walCoordinator).recordAppliedLsn(7L);
+    }
+
+    @Test
+    void putBusyTimeoutIncrementsTimeoutMetrics() {
+        when(retryPolicy.startNanos()).thenReturn(1L);
+        when(walCoordinator.appendPut(1, "one")).thenReturn(7L);
+        when(partitionWriteCoordinator.putBuffered(1, "one"))
+                .thenReturn(IndexResult.busy());
+        final IndexException timeout = new IndexException(
+                "Index operation 'put' timed out after 30 ms");
+        org.mockito.Mockito.doThrow(timeout).when(retryPolicy)
+                .backoffOrThrow(1L, "put", null);
+
+        final IndexException thrown = assertThrows(IndexException.class,
+                () -> coordinator.put(1, "one"));
+
+        assertEquals(timeout, thrown);
+        assertEquals(1L, stats.getPutCx());
+        assertEquals(1L, stats.getPutBusyRetryCx());
+        assertEquals(1L, stats.getPutBusyTimeoutCx());
+        assertTrue(stats.getPutBusyWaitP95Micros() >= 0L);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/PartitionDrainCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/PartitionDrainCoordinatorTest.java
@@ -2,10 +2,13 @@ package org.hestiastore.index.segmentindex.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
@@ -90,5 +93,34 @@ class PartitionDrainCoordinatorTest {
         assertEquals(0, splitHints.get());
         assertEquals(0, partitionRuntime.snapshot().getDrainInFlightCount());
         verifyNoInteractions(stableSegmentCoordinator);
+    }
+
+    @Test
+    void scheduleDrain_recordsTaskStartDelayAndRunLatency() {
+        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment(1);
+        final AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+        final AtomicLong nowNanos = new AtomicLong(
+                TimeUnit.MILLISECONDS.toNanos(2));
+        final Stats stats = new Stats();
+        partitionRuntime.write(segmentId, 1, "v1", limits);
+        partitionRuntime.sealAllActivePartitionsForDrain();
+        doAnswer(invocation -> {
+            nowNanos.set(TimeUnit.MILLISECONDS.toNanos(9));
+            return null;
+        }).when(stableSegmentCoordinator).flushSegment(segmentId, true);
+        coordinator = new PartitionDrainCoordinator<>(partitionRuntime,
+                synchronizedKeyToSegmentMap, scheduledTask::set,
+                new IndexRetryPolicy(1, 10), stableSegmentCoordinator, stats,
+                ignoredSegmentId -> splitHints.incrementAndGet(),
+                handledFailure::set, nowNanos::get);
+
+        coordinator.scheduleDrain(segmentId);
+        nowNanos.set(TimeUnit.MILLISECONDS.toNanos(5));
+
+        scheduledTask.get().run();
+
+        assertEquals(3_000L, stats.getDrainTaskStartDelayP95Micros());
+        assertEquals(4_000L, stats.getDrainTaskRunLatencyP95Micros());
+        verify(stableSegmentCoordinator).flushSegment(segmentId, true);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinatorTest.java
@@ -1,10 +1,13 @@
 package org.hestiastore.index.segmentindex.core;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
@@ -15,6 +18,7 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
+import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
@@ -47,6 +51,7 @@ class StableSegmentCoordinatorTest {
     private KeyToSegmentMap<String> keyToSegmentMap;
     private KeyToSegmentMapSynchronizedAdapter<String> synchronizedKeyToSegmentMap;
     private StableSegmentCoordinator<String, String> coordinator;
+    private Stats stats;
 
     @BeforeEach
     void setUp() {
@@ -55,12 +60,12 @@ class StableSegmentCoordinatorTest {
                 new TypeDescriptorShortString());
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
+        stats = new Stats();
         coordinator = new StableSegmentCoordinator<>(
                 LoggerFactory.getLogger(StableSegmentCoordinatorTest.class),
                 synchronizedKeyToSegmentMap, segmentRegistry,
                 backgroundSplitCoordinator, stableSegmentGateway,
-                new IndexRetryPolicy(1, 10),
-                new Stats());
+                new IndexRetryPolicy(1, 10), stats);
     }
 
     @AfterEach
@@ -108,5 +113,53 @@ class StableSegmentCoordinatorTest {
 
         verify(stableSegmentGateway).openIterator(segmentId,
                 SegmentIteratorIsolation.FAIL_FAST);
+    }
+
+    @Test
+    void flushSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
+        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        coordinator = new StableSegmentCoordinator<>(
+                LoggerFactory.getLogger(StableSegmentCoordinatorTest.class),
+                synchronizedKeyToSegmentMap, segmentRegistry,
+                backgroundSplitCoordinator, stableSegmentGateway,
+                new IndexRetryPolicy(1, 10), stats,
+                sequenceNanoTimeSupplier(10_000L, 35_000L));
+        when(stableSegmentGateway.flush(segmentId)).thenReturn(
+                IndexResult.busy(), IndexResult.ok(segment));
+        when(segment.getState()).thenReturn(SegmentState.READY);
+
+        coordinator.flushSegment(segmentId, true);
+
+        assertEquals(1L, stats.getFlushBusyRetryCx());
+        assertEquals(25L, stats.getFlushAcceptedToReadyP95Micros());
+    }
+
+    @Test
+    void compactSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
+        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        coordinator = new StableSegmentCoordinator<>(
+                LoggerFactory.getLogger(StableSegmentCoordinatorTest.class),
+                synchronizedKeyToSegmentMap, segmentRegistry,
+                backgroundSplitCoordinator, stableSegmentGateway,
+                new IndexRetryPolicy(1, 10), stats,
+                sequenceNanoTimeSupplier(20_000L, 68_000L));
+        when(stableSegmentGateway.compact(segmentId)).thenReturn(
+                IndexResult.busy(), IndexResult.ok(segment));
+        when(segment.getState()).thenReturn(SegmentState.READY);
+
+        coordinator.compactSegment(segmentId, true);
+
+        assertEquals(1L, stats.getCompactBusyRetryCx());
+        assertEquals(48L, stats.getCompactAcceptedToReadyP95Micros());
+    }
+
+    private static LongSupplier sequenceNanoTimeSupplier(
+            final long... nanos) {
+        final AtomicInteger index = new AtomicInteger();
+        return () -> {
+            final int current = index.getAndIncrement();
+            final int safeIndex = Math.min(current, nanos.length - 1);
+            return nanos[safeIndex];
+        };
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/partition/PartitionRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/partition/PartitionRuntimeTest.java
@@ -221,9 +221,12 @@ class PartitionRuntimeTest {
 
         runtime.beginSplit(segmentId);
         assertFalse(runtime.markDrainScheduledIfNeeded(segmentId));
+        assertEquals(1, runtime.snapshot().getSplitBlockedPartitionCount());
+        assertEquals(1L, runtime.snapshot().getSplitBlockedDrainScheduleCount());
 
         runtime.finishSplit(segmentId);
         assertTrue(runtime.markDrainScheduledIfNeeded(segmentId));
+        assertEquals(0, runtime.snapshot().getSplitBlockedPartitionCount());
     }
 
     @Test
@@ -297,5 +300,27 @@ class PartitionRuntimeTest {
         assertEquals("v9", runtime.lookup(replacementSegmentId,
                 Integer.valueOf(9)).getValue());
         assertEquals(3, runtime.snapshot().getBufferedKeyCount());
+    }
+
+    @Test
+    void writeBusyWhileSplitBlockedIncrementsStructuralBackpressureCounter() {
+        final SegmentId segmentId = SegmentId.of(17);
+        final PartitionRuntimeLimits limits = new PartitionRuntimeLimits(1, 1,
+                2, 8);
+
+        assertEquals(PartitionWriteResultStatus.OK,
+                runtime.write(segmentId, Integer.valueOf(1), "v1", limits)
+                        .getStatus());
+        assertEquals(PartitionWriteResultStatus.OK,
+                runtime.write(segmentId, Integer.valueOf(2), "v2", limits)
+                        .getStatus());
+
+        runtime.beginSplit(segmentId);
+        final PartitionWriteResult result = runtime.write(segmentId,
+                Integer.valueOf(3), "v3", limits);
+
+        assertEquals(PartitionWriteResultStatus.BUSY, result.getStatus());
+        assertEquals(1L,
+                runtime.snapshot().getBufferFullWhileSplitBlockedCount());
     }
 }

--- a/monitoring-console-web/src/main/java/org/hestiastore/console/web/ConsoleBackendClient.java
+++ b/monitoring-console-web/src/main/java/org/hestiastore/console/web/ConsoleBackendClient.java
@@ -818,6 +818,36 @@ public class ConsoleBackendClient {
                         indexNode.path("maintenanceQueueCapacity").asInt(0)),
                 nonNegativeInt(indexNode.path("splitQueueSize").asInt(0)),
                 nonNegativeInt(indexNode.path("splitQueueCapacity").asInt(0)),
+                nonNegativeInt(indexNode.path("indexMaintenanceActiveThreadCount")
+                        .asInt(0)),
+                nonNegativeLong(indexNode
+                        .path("indexMaintenanceCompletedTaskCount")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode
+                        .path("indexMaintenanceRejectedTaskCount")
+                        .asLong(0L)),
+                nonNegativeInt(indexNode.path("splitMaintenanceActiveThreadCount")
+                        .asInt(0)),
+                nonNegativeLong(indexNode
+                        .path("splitMaintenanceCompletedTaskCount")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode
+                        .path("splitMaintenanceRejectedTaskCount")
+                        .asLong(0L)),
+                nonNegativeInt(indexNode
+                        .path("stableSegmentMaintenanceActiveThreadCount")
+                        .asInt(0)),
+                nonNegativeInt(indexNode
+                        .path("stableSegmentMaintenanceQueueSize").asInt(0)),
+                nonNegativeInt(indexNode
+                        .path("stableSegmentMaintenanceQueueCapacity")
+                        .asInt(0)),
+                nonNegativeLong(indexNode
+                        .path("stableSegmentMaintenanceCompletedTaskCount")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode
+                        .path("stableSegmentMaintenanceCallerRunsCount")
+                        .asLong(0L)),
                 nonNegativeLong(
                         indexNode.path("readLatencyP50Micros").asLong(0L)),
                 nonNegativeLong(
@@ -871,6 +901,34 @@ public class ConsoleBackendClient {
                         null),
                 nonNegativeLong(
                         indexNode.path("drainLatencyP95Micros").asLong(0L)),
+                nonNegativeLong(indexNode.path("splitTaskStartDelayP95Micros")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode.path("splitTaskRunLatencyP95Micros")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode.path("drainTaskStartDelayP95Micros")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode.path("drainTaskRunLatencyP95Micros")
+                        .asLong(0L)),
+                readNonNegativeIntWithFallback(indexNode,
+                        "splitBlockedPartitionCount", null),
+                nonNegativeLong(indexNode
+                        .path("splitBlockedDrainScheduleCount").asLong(0L)),
+                nonNegativeLong(indexNode
+                        .path("bufferFullWhileSplitBlockedCount").asLong(0L)),
+                nonNegativeLong(
+                        indexNode.path("putBusyRetryCount").asLong(0L)),
+                nonNegativeLong(
+                        indexNode.path("putBusyTimeoutCount").asLong(0L)),
+                nonNegativeLong(
+                        indexNode.path("putBusyWaitP95Micros").asLong(0L)),
+                nonNegativeLong(indexNode.path("flushAcceptedToReadyP95Micros")
+                        .asLong(0L)),
+                nonNegativeLong(indexNode
+                        .path("compactAcceptedToReadyP95Micros").asLong(0L)),
+                nonNegativeLong(
+                        indexNode.path("flushBusyRetryCount").asLong(0L)),
+                nonNegativeLong(
+                        indexNode.path("compactBusyRetryCount").asLong(0L)),
                 parseSegmentRuntimeSnapshots(
                         indexNode.path("segmentRuntimeSnapshots")),
                 parseState(indexNode.path(FIELD_STATE).asText(DEFAULT_STATE)));

--- a/monitoring-micrometer/src/main/java/org/hestiastore/monitoring/micrometer/HestiaStoreMetricNames.java
+++ b/monitoring-micrometer/src/main/java/org/hestiastore/monitoring/micrometer/HestiaStoreMetricNames.java
@@ -28,8 +28,37 @@ final class HestiaStoreMetricNames {
     static final String PARTITION_DRAIN_SCHEDULE_TOTAL = "hestiastore_partition_drain_schedule_total";
     static final String PARTITION_DRAIN_IN_FLIGHT = "hestiastore_partition_drain_in_flight";
     static final String PARTITION_DRAIN_LATENCY_P95_MICROS = "hestiastore_partition_drain_latency_p95_micros";
+    static final String SPLIT_TASK_START_DELAY_P95_MICROS = "hestiastore_split_task_start_delay_p95_micros";
+    static final String SPLIT_TASK_RUN_LATENCY_P95_MICROS = "hestiastore_split_task_run_latency_p95_micros";
+    static final String DRAIN_TASK_START_DELAY_P95_MICROS = "hestiastore_drain_task_start_delay_p95_micros";
+    static final String DRAIN_TASK_RUN_LATENCY_P95_MICROS = "hestiastore_drain_task_run_latency_p95_micros";
+    static final String SPLIT_BLOCKED_PARTITION_COUNT = "hestiastore_split_blocked_partition_count";
+    static final String SPLIT_BLOCKED_DRAIN_SCHEDULE_TOTAL = "hestiastore_split_blocked_drain_schedule_total";
+    static final String BUFFER_FULL_WHILE_SPLIT_BLOCKED_TOTAL = "hestiastore_buffer_full_while_split_blocked_total";
+    static final String PUT_BUSY_RETRY_TOTAL = "hestiastore_put_busy_retry_total";
+    static final String PUT_BUSY_TIMEOUT_TOTAL = "hestiastore_put_busy_timeout_total";
+    static final String PUT_BUSY_WAIT_P95_MICROS = "hestiastore_put_busy_wait_p95_micros";
+    static final String FLUSH_ACCEPTED_TO_READY_P95_MICROS = "hestiastore_flush_accepted_to_ready_p95_micros";
+    static final String COMPACT_ACCEPTED_TO_READY_P95_MICROS = "hestiastore_compact_accepted_to_ready_p95_micros";
+    static final String FLUSH_BUSY_RETRY_TOTAL = "hestiastore_flush_busy_retry_total";
+    static final String COMPACT_BUSY_RETRY_TOTAL = "hestiastore_compact_busy_retry_total";
     static final String SPLIT_SCHEDULE_TOTAL = "hestiastore_split_schedule_total";
     static final String SPLIT_IN_FLIGHT = "hestiastore_split_in_flight";
+    static final String INDEX_MAINTENANCE_QUEUE_SIZE = "hestiastore_index_maintenance_queue_size";
+    static final String INDEX_MAINTENANCE_QUEUE_CAPACITY = "hestiastore_index_maintenance_queue_capacity";
+    static final String INDEX_MAINTENANCE_ACTIVE_THREADS = "hestiastore_index_maintenance_active_threads";
+    static final String INDEX_MAINTENANCE_COMPLETED_TASKS_TOTAL = "hestiastore_index_maintenance_completed_tasks_total";
+    static final String INDEX_MAINTENANCE_REJECTED_TASKS_TOTAL = "hestiastore_index_maintenance_rejected_tasks_total";
+    static final String SPLIT_MAINTENANCE_QUEUE_SIZE = "hestiastore_split_maintenance_queue_size";
+    static final String SPLIT_MAINTENANCE_QUEUE_CAPACITY = "hestiastore_split_maintenance_queue_capacity";
+    static final String SPLIT_MAINTENANCE_ACTIVE_THREADS = "hestiastore_split_maintenance_active_threads";
+    static final String SPLIT_MAINTENANCE_COMPLETED_TASKS_TOTAL = "hestiastore_split_maintenance_completed_tasks_total";
+    static final String SPLIT_MAINTENANCE_REJECTED_TASKS_TOTAL = "hestiastore_split_maintenance_rejected_tasks_total";
+    static final String STABLE_SEGMENT_MAINTENANCE_QUEUE_SIZE = "hestiastore_stable_segment_maintenance_queue_size";
+    static final String STABLE_SEGMENT_MAINTENANCE_QUEUE_CAPACITY = "hestiastore_stable_segment_maintenance_queue_capacity";
+    static final String STABLE_SEGMENT_MAINTENANCE_ACTIVE_THREADS = "hestiastore_stable_segment_maintenance_active_threads";
+    static final String STABLE_SEGMENT_MAINTENANCE_COMPLETED_TASKS_TOTAL = "hestiastore_stable_segment_maintenance_completed_tasks_total";
+    static final String STABLE_SEGMENT_MAINTENANCE_CALLER_RUNS_TOTAL = "hestiastore_stable_segment_maintenance_caller_runs_total";
     static final String INDEX_UP = "hestiastore_index_up";
 
     private HestiaStoreMetricNames() {

--- a/monitoring-micrometer/src/main/java/org/hestiastore/monitoring/micrometer/HestiaStoreMicrometerBinder.java
+++ b/monitoring-micrometer/src/main/java/org/hestiastore/monitoring/micrometer/HestiaStoreMicrometerBinder.java
@@ -178,6 +178,96 @@ public final class HestiaStoreMicrometerBinder implements MeterBinder {
                 .description("Observed P95 partition drain latency in microseconds")
                 .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
 
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_TASK_START_DELAY_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitTaskStartDelayP95Micros())
+                .description("Observed P95 split task queue delay in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_TASK_RUN_LATENCY_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitTaskRunLatencyP95Micros())
+                .description("Observed P95 split task run latency in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.DRAIN_TASK_START_DELAY_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getDrainTaskStartDelayP95Micros())
+                .description("Observed P95 drain task queue delay in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.DRAIN_TASK_RUN_LATENCY_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getDrainTaskRunLatencyP95Micros())
+                .description("Observed P95 drain task run latency in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_BLOCKED_PARTITION_COUNT,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitBlockedPartitionCount())
+                .description("Current number of partitions with split-blocked drain scheduling")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.SPLIT_BLOCKED_DRAIN_SCHEDULE_TOTAL,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitBlockedDrainScheduleCount())
+                .description("Total number of drain schedule attempts blocked by active splits")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.BUFFER_FULL_WHILE_SPLIT_BLOCKED_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getBufferFullWhileSplitBlockedCount())
+                .description(
+                        "Total number of BUSY writes observed while split blocked drain scheduling")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(HestiaStoreMetricNames.PUT_BUSY_RETRY_TOTAL,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getPutBusyRetryCount())
+                .description("Total number of BUSY retries observed by put operations")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(HestiaStoreMetricNames.PUT_BUSY_TIMEOUT_TOTAL,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getPutBusyTimeoutCount())
+                .description("Total number of put operations that timed out while retrying BUSY")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.PUT_BUSY_WAIT_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getPutBusyWaitP95Micros())
+                .description("Observed P95 put BUSY wait time in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.FLUSH_ACCEPTED_TO_READY_P95_MICROS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getFlushAcceptedToReadyP95Micros())
+                .description("Observed P95 flush accepted-to-ready latency in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(
+                HestiaStoreMetricNames.COMPACT_ACCEPTED_TO_READY_P95_MICROS,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getCompactAcceptedToReadyP95Micros())
+                .description(
+                        "Observed P95 compact accepted-to-ready latency in microseconds")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(HestiaStoreMetricNames.FLUSH_BUSY_RETRY_TOTAL,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getFlushBusyRetryCount())
+                .description("Total number of BUSY retries observed by flush operations")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.COMPACT_BUSY_RETRY_TOTAL,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getCompactBusyRetryCount())
+                .description("Total number of BUSY retries observed by compact operations")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
         FunctionCounter.builder(HestiaStoreMetricNames.SPLIT_SCHEDULE_TOTAL,
                 monitoredIndex,
                 i -> i.metricsSnapshot().getSplitScheduleCount())
@@ -188,6 +278,111 @@ public final class HestiaStoreMicrometerBinder implements MeterBinder {
                 monitoredIndex,
                 i -> i.metricsSnapshot().getSplitInFlightCount())
                 .description("Current number of in-flight split operations")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.INDEX_MAINTENANCE_QUEUE_SIZE,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getMaintenanceQueueSize())
+                .description("Current index-maintenance executor queue size")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.INDEX_MAINTENANCE_QUEUE_CAPACITY,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getMaintenanceQueueCapacity())
+                .description("Configured index-maintenance executor queue capacity")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.INDEX_MAINTENANCE_ACTIVE_THREADS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getIndexMaintenanceActiveThreadCount())
+                .description("Current number of active index-maintenance threads")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.INDEX_MAINTENANCE_COMPLETED_TASKS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getIndexMaintenanceCompletedTaskCount())
+                .description(
+                        "Total number of completed index-maintenance tasks")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.INDEX_MAINTENANCE_REJECTED_TASKS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getIndexMaintenanceRejectedTaskCount())
+                .description(
+                        "Total number of rejected index-maintenance tasks")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_MAINTENANCE_QUEUE_SIZE,
+                monitoredIndex, i -> i.metricsSnapshot().getSplitQueueSize())
+                .description("Current split-maintenance executor queue size")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_MAINTENANCE_QUEUE_CAPACITY,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitQueueCapacity())
+                .description("Configured split-maintenance executor queue capacity")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(HestiaStoreMetricNames.SPLIT_MAINTENANCE_ACTIVE_THREADS,
+                monitoredIndex,
+                i -> i.metricsSnapshot().getSplitMaintenanceActiveThreadCount())
+                .description("Current number of active split-maintenance threads")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.SPLIT_MAINTENANCE_COMPLETED_TASKS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getSplitMaintenanceCompletedTaskCount())
+                .description("Total number of completed split-maintenance tasks")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.SPLIT_MAINTENANCE_REJECTED_TASKS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getSplitMaintenanceRejectedTaskCount())
+                .description("Total number of rejected split-maintenance tasks")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(
+                HestiaStoreMetricNames.STABLE_SEGMENT_MAINTENANCE_QUEUE_SIZE,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getStableSegmentMaintenanceQueueSize())
+                .description(
+                        "Current stable-segment maintenance executor queue size")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(
+                HestiaStoreMetricNames.STABLE_SEGMENT_MAINTENANCE_QUEUE_CAPACITY,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getStableSegmentMaintenanceQueueCapacity())
+                .description(
+                        "Configured stable-segment maintenance executor queue capacity")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        Gauge.builder(
+                HestiaStoreMetricNames.STABLE_SEGMENT_MAINTENANCE_ACTIVE_THREADS,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getStableSegmentMaintenanceActiveThreadCount())
+                .description(
+                        "Current number of active stable-segment maintenance threads")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.STABLE_SEGMENT_MAINTENANCE_COMPLETED_TASKS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getStableSegmentMaintenanceCompletedTaskCount())
+                .description(
+                        "Total number of completed stable-segment maintenance tasks")
+                .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
+
+        FunctionCounter.builder(
+                HestiaStoreMetricNames.STABLE_SEGMENT_MAINTENANCE_CALLER_RUNS_TOTAL,
+                monitoredIndex, i -> i.metricsSnapshot()
+                        .getStableSegmentMaintenanceCallerRunsCount())
+                .description(
+                        "Total number of stable-segment maintenance tasks executed on caller threads")
                 .tag(TAG_INDEX, monitoredIndex.indexName()).register(registry);
 
         Gauge.builder(HestiaStoreMetricNames.INDEX_UP,

--- a/monitoring-micrometer/src/test/java/org/hestiastore/monitoring/micrometer/HestiaStoreMicrometerBinderTest.java
+++ b/monitoring-micrometer/src/test/java/org/hestiastore/monitoring/micrometer/HestiaStoreMicrometerBinderTest.java
@@ -22,7 +22,7 @@ class HestiaStoreMicrometerBinderTest {
         final SegmentIndex<Integer, String> index = mock(SegmentIndex.class);
         final AtomicReference<SegmentIndexMetricsSnapshot> snapshotRef = new AtomicReference<>(
                 snapshot(1L, 2L, 3L, SegmentIndexState.READY, 7, 2, 11, 29, 3,
-                        2, 1, 4, 17, 19L, 23L, 31L, 5, 43L, 37L, 2));
+                        2, 1, 4, 17, 19L, 23L, 31L, 5, 43L, 37L, 2, 50));
         when(index.metricsSnapshot()).thenAnswer(inv -> snapshotRef.get());
         when(index.getState()).thenAnswer(inv -> snapshotRef.get().getState());
 
@@ -32,13 +32,13 @@ class HestiaStoreMicrometerBinderTest {
                         .bindTo(registry);
 
         assertMetrics(registry, 1D, 2D, 3D, 7D, 2D, 11D, 29D, 3D, 2D, 1D, 4D,
-                17D, 19D, 23D, 31D, 5D, 43D, 37D, 2D, 1D);
+                17D, 19D, 23D, 31D, 5D, 43D, 37D, 2D, 1D, 50);
 
         snapshotRef.set(snapshot(5L, 8L, 13L, SegmentIndexState.CLOSED, 9, 3,
-                15, 41, 4, 1, 0, 2, 5, 29L, 31L, 37L, 0, 0L, 41L, 0));
+                15, 41, 4, 1, 0, 2, 5, 29L, 31L, 37L, 0, 0L, 41L, 0, 70));
 
         assertMetrics(registry, 5D, 8D, 13D, 9D, 3D, 15D, 41D, 4D, 1D, 0D, 2D,
-                5D, 29D, 31D, 37D, 0D, 0D, 41D, 0D, 0D);
+                5D, 29D, 31D, 37D, 0D, 0D, 41D, 0D, 0D, 70);
     }
 
     private SegmentIndexMetricsSnapshot snapshot(final long getCount,
@@ -54,7 +54,8 @@ class HestiaStoreMicrometerBinderTest {
             final long globalThrottleCount,
             final long drainScheduleCount, final int drainInFlightCount,
             final long drainLatencyP95Micros,
-            final long splitScheduleCount, final int splitInFlightCount) {
+            final long splitScheduleCount, final int splitInFlightCount,
+            final int executorBase) {
         return new SegmentIndexMetricsSnapshot(
                 getCount, putCount, deleteCount,
                 0L, 0L, 0L, 0L,
@@ -63,7 +64,12 @@ class HestiaStoreMicrometerBinderTest {
                 0, 0, 0, 0, 0, 0,
                 0L, 0L, 0L, 0L,
                 0L, 0L, splitScheduleCount,
-                splitInFlightCount, 0, 0, 0, 0,
+                splitInFlightCount, executorBase, executorBase + 1,
+                executorBase + 5, executorBase + 6, executorBase + 2,
+                executorBase + 3L, executorBase + 4L, executorBase + 7,
+                executorBase + 8L, executorBase + 9L, executorBase + 12,
+                executorBase + 10, executorBase + 11, executorBase + 13L,
+                executorBase + 14L,
                 0L, 0L, 0L,
                 0L, 0L, 0L,
                 0, 0, 0D,
@@ -74,8 +80,13 @@ class HestiaStoreMicrometerBinderTest {
                 activePartitionCount, drainingPartitionCount,
                 immutableRunCount, partitionBufferedKeyCount,
                 localThrottleCount, globalThrottleCount, drainScheduleCount,
-                drainInFlightCount, drainLatencyP95Micros, List.of(),
-                state);
+                drainInFlightCount, drainLatencyP95Micros, executorBase + 15L,
+                executorBase + 16L, executorBase + 17L, executorBase + 18L,
+                executorBase + 19, executorBase + 20L, executorBase + 21L,
+                executorBase + 22L, executorBase + 23L, executorBase + 24L,
+                executorBase + 25L, executorBase + 26L, executorBase + 27L,
+                executorBase + 28L,
+                List.of(), state);
     }
 
     private static void assertMetrics(final SimpleMeterRegistry registry,
@@ -92,7 +103,7 @@ class HestiaStoreMicrometerBinderTest {
             final double drainScheduleCount, final double drainInFlightCount,
             final double drainLatencyP95Micros,
             final double splitScheduleCount, final double splitInFlightCount,
-            final double indexUp) {
+            final double indexUp, final int executorBase) {
         assertFunctionCounter(registry, "hestiastore_ops_get_total", getCount);
         assertFunctionCounter(registry, "hestiastore_ops_put_total", putCount);
         assertFunctionCounter(registry, "hestiastore_ops_delete_total",
@@ -127,9 +138,80 @@ class HestiaStoreMicrometerBinderTest {
                 drainInFlightCount);
         assertGauge(registry, "hestiastore_partition_drain_latency_p95_micros",
                 drainLatencyP95Micros);
+        assertGauge(registry, "hestiastore_split_task_start_delay_p95_micros",
+                executorBase + 15D);
+        assertGauge(registry, "hestiastore_split_task_run_latency_p95_micros",
+                executorBase + 16D);
+        assertGauge(registry, "hestiastore_drain_task_start_delay_p95_micros",
+                executorBase + 17D);
+        assertGauge(registry, "hestiastore_drain_task_run_latency_p95_micros",
+                executorBase + 18D);
+        assertGauge(registry, "hestiastore_split_blocked_partition_count",
+                executorBase + 19D);
+        assertFunctionCounter(registry,
+                "hestiastore_split_blocked_drain_schedule_total",
+                executorBase + 20D);
+        assertFunctionCounter(registry,
+                "hestiastore_buffer_full_while_split_blocked_total",
+                executorBase + 21D);
+        assertFunctionCounter(registry, "hestiastore_put_busy_retry_total",
+                executorBase + 22D);
+        assertFunctionCounter(registry, "hestiastore_put_busy_timeout_total",
+                executorBase + 23D);
+        assertGauge(registry, "hestiastore_put_busy_wait_p95_micros",
+                executorBase + 24D);
+        assertGauge(registry,
+                "hestiastore_flush_accepted_to_ready_p95_micros",
+                executorBase + 25D);
+        assertGauge(registry,
+                "hestiastore_compact_accepted_to_ready_p95_micros",
+                executorBase + 26D);
+        assertFunctionCounter(registry, "hestiastore_flush_busy_retry_total",
+                executorBase + 27D);
+        assertFunctionCounter(registry,
+                "hestiastore_compact_busy_retry_total", executorBase + 28D);
         assertFunctionCounter(registry, "hestiastore_split_schedule_total",
                 splitScheduleCount);
         assertGauge(registry, "hestiastore_split_in_flight", splitInFlightCount);
+        assertGauge(registry, "hestiastore_index_maintenance_queue_size",
+                executorBase);
+        assertGauge(registry, "hestiastore_index_maintenance_queue_capacity",
+                executorBase + 1D);
+        assertGauge(registry, "hestiastore_index_maintenance_active_threads",
+                executorBase + 2D);
+        assertFunctionCounter(registry,
+                "hestiastore_index_maintenance_completed_tasks_total",
+                executorBase + 3D);
+        assertFunctionCounter(registry,
+                "hestiastore_index_maintenance_rejected_tasks_total",
+                executorBase + 4D);
+        assertGauge(registry, "hestiastore_split_maintenance_queue_size",
+                executorBase + 5D);
+        assertGauge(registry, "hestiastore_split_maintenance_queue_capacity",
+                executorBase + 6D);
+        assertGauge(registry, "hestiastore_split_maintenance_active_threads",
+                executorBase + 7D);
+        assertFunctionCounter(registry,
+                "hestiastore_split_maintenance_completed_tasks_total",
+                executorBase + 8D);
+        assertFunctionCounter(registry,
+                "hestiastore_split_maintenance_rejected_tasks_total",
+                executorBase + 9D);
+        assertGauge(registry,
+                "hestiastore_stable_segment_maintenance_queue_size",
+                executorBase + 10D);
+        assertGauge(registry,
+                "hestiastore_stable_segment_maintenance_queue_capacity",
+                executorBase + 11D);
+        assertGauge(registry,
+                "hestiastore_stable_segment_maintenance_active_threads",
+                executorBase + 12D);
+        assertFunctionCounter(registry,
+                "hestiastore_stable_segment_maintenance_completed_tasks_total",
+                executorBase + 13D);
+        assertFunctionCounter(registry,
+                "hestiastore_stable_segment_maintenance_caller_runs_total",
+                executorBase + 14D);
         assertGauge(registry, "hestiastore_index_up", indexUp);
     }
 

--- a/monitoring-prometheus/src/test/java/org/hestiastore/monitoring/prometheus/HestiaStorePrometheusExporterTest.java
+++ b/monitoring-prometheus/src/test/java/org/hestiastore/monitoring/prometheus/HestiaStorePrometheusExporterTest.java
@@ -107,7 +107,7 @@ class HestiaStorePrometheusExporterTest {
                 0L, 0L, 0L,
                 0, 0, 0D,
                 0L, 0L, 0L, 0L,
-                List.of(),
+                List.<SegmentIndexMetricsSnapshot.SegmentMetricsSnapshot>of(),
                 state);
     }
 
@@ -134,6 +134,7 @@ class HestiaStorePrometheusExporterTest {
                 0L, 0L, 0L, 0L,
                 0L, 0L, splitScheduleCount,
                 splitInFlightCount, 0, 0, 0, 0,
+                0, 0L, 0L, 0, 0L, 0L, 0, 0, 0, 0L, 0L,
                 0L, 0L, 0L,
                 0L, 0L, 0L,
                 0, 0, 0D,
@@ -144,7 +145,9 @@ class HestiaStorePrometheusExporterTest {
                 activePartitionCount, drainingPartitionCount,
                 immutableRunCount, partitionBufferedKeyCount,
                 localThrottleCount, globalThrottleCount, drainScheduleCount,
-                drainInFlightCount, drainLatencyP95Micros, List.of(),
+                drainInFlightCount, drainLatencyP95Micros, 0L, 0L, 0L, 0L, 0,
+                0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+                List.<SegmentIndexMetricsSnapshot.SegmentMetricsSnapshot>of(),
                 state);
     }
 


### PR DESCRIPTION
## Summary
- expose real executor saturation metrics and fix the top-level split and queue metric wiring in `SegmentIndexMetricsSnapshot`
- add split and drain queue-delay metrics, `put()` BUSY retry and timeout metrics, split-blocked drain and buffer-full counters, and stable maintenance accepted-to-ready timings
- update Micrometer, Prometheus test fixtures, and the console web JSON parser to handle the expanded metrics snapshot shape

## Testing
- `mvn clean verify`

## Notes
- OWASP Dependency-Check still logs the existing missing `.NET Assembly Analyzer` warning because `dotnet` is not installed locally; the build completed successfully.