### PR TITLE
Initialize empty base segment during build

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentBuilder.java
@@ -413,6 +413,8 @@ public final class SegmentBuilder<K, V> {
             final SegmentCache<K, V> segmentCache = context
                     .createSegmentCache();
             deltaCacheController.setSegmentCache(segmentCache);
+            initializeEmptyPersistedBaseIfNeeded(context,
+                    deltaCacheController, segmentCache);
             final SegmentReadPath<K, V> readPath = new SegmentReadPath<>(
                     context.segmentFiles, context.segmentConf,
                     context.segmentResources, segmentSearcher, segmentCache,
@@ -445,6 +447,45 @@ public final class SegmentBuilder<K, V> {
     private SegmentBuildContext<K, V> prepareBuildContext(
             final SegmentDirectoryLayout layout) {
         return new SegmentBuildContext<>(this, layout);
+    }
+
+    private void initializeEmptyPersistedBaseIfNeeded(
+            final SegmentBuildContext<K, V> context,
+            final SegmentDeltaCacheController<K, V> deltaCacheController,
+            final SegmentCache<K, V> segmentCache) {
+        Vldtn.requireNonNull(context, "context");
+        Vldtn.requireNonNull(deltaCacheController, "deltaCacheController");
+        Vldtn.requireNonNull(segmentCache, "segmentCache");
+        if (!shouldInitializeEmptyPersistedBase(context)) {
+            return;
+        }
+        new SegmentFullWriterTx<>(context.segmentFiles,
+                context.segmentPropertiesManager,
+                context.segmentConf.getMaxNumberOfKeysInChunk(),
+                context.segmentResources, deltaCacheController)
+                        .execute(writer -> {
+                        });
+    }
+
+    private boolean shouldInitializeEmptyPersistedBase(
+            final SegmentBuildContext<K, V> context) {
+        final SegmentFiles<K, V> segmentFiles = context.segmentFiles;
+        final Directory directory = segmentFiles.getDirectory();
+        if (directory.isFileExists(segmentFiles.getIndexFileName())
+                || directory.isFileExists(segmentFiles.getScarceFileName())
+                || directory.isFileExists(segmentFiles.getBloomFilterFileName())) {
+            return false;
+        }
+        return context.segmentPropertiesManager.getDeltaFileCount() == 0
+                && segmentCacheFilesAbsent(context);
+    }
+
+    private boolean segmentCacheFilesAbsent(
+            final SegmentBuildContext<K, V> context) {
+        final SegmentFiles<K, V> segmentFiles = context.segmentFiles;
+        final Directory directory = segmentFiles.getDirectory();
+        return context.segmentPropertiesManager.getCacheDeltaFileNames().stream()
+                .noneMatch(directory::isFileExists);
     }
 
     private SegmentDirectoryLayout resolveLayout() {

--- a/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentTest.java
@@ -89,10 +89,12 @@ class IntegrationSegmentTest extends AbstractSegmentTest {
         verifyTestDataSet(seg);
 
         /**
-         * It's always 4 or 5 because only one or zero delta files could exists.
+         * Fresh segments now start with the persisted base files already
+         * materialized, so duplicate writes leave either two or three delta
+         * files on top of that base set.
          */
-        if (numberOfFilesInDirectory(directory) != 3
-                && numberOfFilesInDirectory(directory) != 4) {
+        if (numberOfFilesInDirectory(directory) != 6
+                && numberOfFilesInDirectory(directory) != 7) {
             fail("Invalid number of files "
                     + numberOfFilesInDirectory(directory));
         }
@@ -607,7 +609,7 @@ class IntegrationSegmentTest extends AbstractSegmentTest {
                                 ))//
                         .build().getValue(), //
                 1, // expectedNumberKeysInScarceIndex,
-                10 // expectedNumberOfFile
+                13 // expectedNumberOfFile
         ), arguments(tdi, tds, dir2, Segment.<Integer, String>builder(dir2)//
                 .withId(id2)//
                 .withKeyTypeDescriptor(tdi)//
@@ -631,7 +633,7 @@ class IntegrationSegmentTest extends AbstractSegmentTest {
                         ))//
                 .build().getValue(), //
                 9, // expectedNumberKeysInScarceIndex
-                10// expectedNumberOfFile
+                13// expectedNumberOfFile
         ), arguments(tdi, tds, dir3, Segment.<Integer, String>builder(dir3)//
                 .withId(id3)//
                 .withKeyTypeDescriptor(tdi)//
@@ -655,7 +657,7 @@ class IntegrationSegmentTest extends AbstractSegmentTest {
                         ))//
                 .build().getValue(), //
                 5, // expectedNumberKeysInScarceIndex
-                10 // expectedNumberOfFile
+                13 // expectedNumberOfFile
         ));
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentWriteConsistencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentWriteConsistencyTest.java
@@ -61,7 +61,7 @@ class IntegrationSegmentWriteConsistencyTest {
         segment.flush();
 
         verifySegmentData(segment, data);
-        verifyNumberOfFiles(directory, 2);
+        verifyNumberOfFiles(directory, 5);
     }
 
     @Test
@@ -71,7 +71,7 @@ class IntegrationSegmentWriteConsistencyTest {
 
         verifySegmentData(segment, data);
         // no data are flushed to disk
-        verifyNumberOfFiles(directory, 1);
+        verifyNumberOfFiles(directory, 4);
     }
 
     @Test
@@ -85,7 +85,7 @@ class IntegrationSegmentWriteConsistencyTest {
                 SEGMENT_ID_1);
         verifySegmentData(reopened, data);
         closeAndAwait(reopened);
-        verifyNumberOfFiles(directory, 2);
+        verifyNumberOfFiles(directory, 5);
     }
 
     @Test
@@ -103,7 +103,7 @@ class IntegrationSegmentWriteConsistencyTest {
         segment2.flush();
         verifySegmentData(segment2, updatedData);
         closeAndAwait(segment2);
-        verifyNumberOfFiles(directory, 3);
+        verifyNumberOfFiles(directory, 6);
     }
 
     private Segment<Integer, String> makeSegment(final Directory directory,

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentFlushOnlyReadRegressionTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentFlushOnlyReadRegressionTest.java
@@ -1,0 +1,79 @@
+package org.hestiastore.index.segment;
+
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.chunkstore.ChunkFilterCrc32Validation;
+import org.hestiastore.index.chunkstore.ChunkFilterCrc32Writing;
+import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
+import org.hestiastore.index.chunkstore.ChunkFilterMagicNumberValidation;
+import org.hestiastore.index.chunkstore.ChunkFilterMagicNumberWriting;
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.FsDirectory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SegmentFlushOnlyReadRegressionTest {
+
+    private static final TypeDescriptorInteger KEY_DESCRIPTOR = new TypeDescriptorInteger();
+    private static final TypeDescriptorShortString VALUE_DESCRIPTOR = new TypeDescriptorShortString();
+
+    @TempDir
+    private File tempDir;
+
+    @Test
+    void get_missing_key_after_flush_without_compaction_does_not_require_main_sst() {
+        final SegmentId segmentId = SegmentId.of(1);
+        final Directory rootDirectory = new FsDirectory(tempDir);
+        final Directory segmentDirectory = rootDirectory
+                .openSubDirectory(segmentId.getName());
+        final SegmentDirectoryLayout layout = new SegmentDirectoryLayout(
+                segmentId);
+        final Segment<Integer, String> segment = Segment
+                .<Integer, String>builder(segmentDirectory)//
+                .withId(segmentId)//
+                .withKeyTypeDescriptor(KEY_DESCRIPTOR)//
+                .withValueTypeDescriptor(VALUE_DESCRIPTOR)//
+                .withBloomFilterIndexSizeInBytes(0)//
+                .withMaxNumberOfKeysInSegmentChunk(4)//
+                .withDiskIoBufferSize(1024)//
+                .withMaintenancePolicy(SegmentMaintenancePolicy.none())//
+                .withEncodingChunkFilters(
+                        List.of(new ChunkFilterMagicNumberWriting(),
+                                new ChunkFilterCrc32Writing(),
+                                new ChunkFilterDoNothing()))//
+                .withDecodingChunkFilters(
+                        List.of(new ChunkFilterMagicNumberValidation(),
+                                new ChunkFilterCrc32Validation(),
+                                new ChunkFilterDoNothing()))//
+                .build().getValue();
+        try {
+            assertEquals(SegmentResultStatus.OK,
+                    segment.put(1, "one").getStatus());
+            assertEquals(SegmentResultStatus.OK,
+                    segment.put(2, "two").getStatus());
+            assertEquals(SegmentResultStatus.OK, segment.flush().getStatus());
+
+            assertTrue(segmentDirectory.isFileExists(layout.getIndexFileName()),
+                    "Freshly created segment should materialize an empty base SST.");
+
+            final SegmentResult<String> result = assertDoesNotThrow(
+                    () -> segment.get(99),
+                    "Missing-key lookup on a flush-only segment must not try to open a non-existent base SST.");
+
+            assertEquals(SegmentResultStatus.OK, result.getStatus());
+            assertNull(result.getValue());
+        } finally {
+            closeAndAwait(segment);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- initialize a valid empty persisted base segment during segment build when the segment is fresh
- add a regression test covering missing-key reads after flush on a newly created segment
- update segment integration tests to reflect the new base-file invariant

## Verification
- mvn -pl engine -Dtest=SegmentFlushOnlyReadRegressionTest test
- mvn clean verify