### PR TITLE
Refine key-to-segment map API

### DIFF
--- a/docs/architecture/recovery.md
+++ b/docs/architecture/recovery.md
@@ -71,7 +71,7 @@ Key classes:
   - Writes to a temporary file via `BloomFilterWriterTx.open()` and commits with `rename`; also updates the in‑memory hash snapshot on commit.
 
 - Key→segment map (`index.map`)
-  - Writer: `SortedDataFileWriterTx.execute(…)` inside `KeyToSegmentMap.optionalyFlush()`
+  - Writer: `SortedDataFileWriterTx.execute(…)` inside `KeyToSegmentMap.flushIfDirty()`
   - Ensures the map is replaced atomically.
 
 ## What Is Not Transactional

--- a/docs/architecture/segmentindex/caching.md
+++ b/docs/architecture/segmentindex/caching.md
@@ -106,7 +106,7 @@ Code:
   `SegmentDeltaCacheController.clear()`; rebuilt on demand from delta files.
 - Segment write cache: frozen snapshots are flushed to delta cache files and
   then retired by segment maintenance.
-- KeyToSegmentMap: persisted via `optionalyFlush()` when updated; survives
+- KeyToSegmentMap: persisted via `flushIfDirty()` when updated; survives
   process restarts by reading `index.map`.
 
 ## Configuration Knobs

--- a/docs/refactor-backlog.md
+++ b/docs/refactor-backlog.md
@@ -978,7 +978,7 @@
     - Ensure apply evicts old segment instance and closes it via
       `SegmentRegistryImpl.closeSegmentInstance(...)`.
     - Keep key-map flush outside registry freeze:
-      `keyToSegmentMap.optionalyFlush()` only after apply OK.
+      `keyToSegmentMap.flushIfDirty()` only after apply OK.
     - Delete old segment files only after apply succeeds and locks released.
 [x] 58.5 Split: test alignment (Risk: MEDIUM)
     - Add/update tests to assert no directory swap in split flow.

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinator.java
@@ -17,7 +17,7 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentState;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.split.RouteSplitCoordinator;
 
 /**
@@ -39,7 +39,7 @@ final class BackgroundSplitCoordinator<K, V> {
     private static final long SPLIT_COOLDOWN_SMOOTHING_WEIGHT_PREVIOUS = 3L;
     private static final long SPLIT_COOLDOWN_SMOOTHING_WEIGHT_OBSERVED = 1L;
 
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final RouteSplitCoordinator<K, V> routeSplitCoordinator;
     private final Executor splitExecutor;
     private final Consumer<RuntimeException> splitFailureHandler;
@@ -59,7 +59,7 @@ final class BackgroundSplitCoordinator<K, V> {
     private int splitInFlightCount;
 
     BackgroundSplitCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final RouteSplitCoordinator<K, V> routeSplitCoordinator,
             final Executor splitExecutor,
             final Consumer<RuntimeException> splitFailureHandler,
@@ -70,7 +70,7 @@ final class BackgroundSplitCoordinator<K, V> {
     }
 
     BackgroundSplitCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final RouteSplitCoordinator<K, V> routeSplitCoordinator,
             final Executor splitExecutor,
             final Consumer<RuntimeException> splitFailureHandler,
@@ -81,7 +81,7 @@ final class BackgroundSplitCoordinator<K, V> {
     }
 
     BackgroundSplitCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final RouteSplitCoordinator<K, V> routeSplitCoordinator,
             final Executor splitExecutor,
             final Consumer<RuntimeException> splitFailureHandler,
@@ -93,7 +93,7 @@ final class BackgroundSplitCoordinator<K, V> {
     }
 
     BackgroundSplitCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final RouteSplitCoordinator<K, V> routeSplitCoordinator,
             final Executor splitExecutor,
             final Consumer<RuntimeException> splitFailureHandler,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitPolicyLoop.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/BackgroundSplitPolicyLoop.java
@@ -18,7 +18,7 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -34,7 +34,7 @@ final class BackgroundSplitPolicyLoop<K, V> {
 
     private final IndexConfiguration<K, V> conf;
     private final RuntimeTuningState runtimeTuningState;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final Executor workerExecutor;
@@ -53,7 +53,7 @@ final class BackgroundSplitPolicyLoop<K, V> {
 
     BackgroundSplitPolicyLoop(final IndexConfiguration<K, V> conf,
             final RuntimeTuningState runtimeTuningState,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final Executor workerExecutor,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/DirectSegmentReadCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/DirectSegmentReadCoordinator.java
@@ -9,7 +9,7 @@ import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 
 /**
@@ -19,14 +19,14 @@ final class DirectSegmentReadCoordinator<K, V> {
 
     private static final String OPERATION_OPEN_FULL_ISOLATION_ITERATOR = "openFullIsolationIterator";
 
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final StableSegmentGateway<K, V> stableSegmentGateway;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final IndexRetryPolicy retryPolicy;
 
     DirectSegmentReadCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final StableSegmentGateway<K, V> stableSegmentGateway,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
@@ -68,13 +68,12 @@ final class DirectSegmentReadCoordinator<K, V> {
             final SegmentIteratorIsolation isolation) {
         final long startNanos = retryPolicy.startNanos();
         while (true) {
-            final KeyToSegmentMap.Snapshot<K> snapshot = keyToSegmentMap
-                    .snapshot();
+            final Snapshot<K> snapshot = keyToSegmentMap.snapshot();
             final List<SegmentId> segmentIds = snapshot
                     .getSegmentIds(resolvedWindows);
             final EntryIterator<K, V> iterator = openStableIterator(segmentIds,
                     isolation);
-            if (keyToSegmentMap.isVersion(snapshot.version())) {
+            if (keyToSegmentMap.isAtVersion(snapshot.version())) {
                 return iterator;
             }
             iterator.close();

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/DirectSegmentWriteCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/DirectSegmentWriteCoordinator.java
@@ -4,19 +4,19 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
 
 /**
  * Owns routed writes that go directly into stable segments.
  */
 final class DirectSegmentWriteCoordinator<K, V> {
 
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final StableSegmentGateway<K, V> stableSegmentGateway;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
 
     DirectSegmentWriteCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final StableSegmentGateway<K, V> stableSegmentGateway,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator) {
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
@@ -43,19 +43,18 @@ final class DirectSegmentWriteCoordinator<K, V> {
     }
 
     private IndexResult<SegmentId> resolveWriteSegmentId(final K key) {
-        final KeyToSegmentMap.Snapshot<K> snapshot = keyToSegmentMap.snapshot();
-        final SegmentId routedSegmentId = snapshot.findSegmentId(key);
+        final Snapshot<K> snapshot = keyToSegmentMap.snapshot();
+        final SegmentId routedSegmentId = snapshot.findSegmentIdForKey(key);
         if (routedSegmentId == null) {
             if (isTailRouteSplitBlocked(snapshot)
-                    || !keyToSegmentMap.tryExtendMaxKey(key, snapshot)) {
+                    || !keyToSegmentMap.extendMaxKeyIfNeeded(key)) {
                 return IndexResult.busy();
             }
         } else if (backgroundSplitCoordinator.isSplitBlocked(routedSegmentId)) {
             return IndexResult.busy();
         }
-        final KeyToSegmentMap.Snapshot<K> stableSnapshot = keyToSegmentMap
-                .snapshot();
-        final SegmentId segmentId = stableSnapshot.findSegmentId(key);
+        final Snapshot<K> stableSnapshot = keyToSegmentMap.snapshot();
+        final SegmentId segmentId = stableSnapshot.findSegmentIdForKey(key);
         if (segmentId == null
                 || backgroundSplitCoordinator.isSplitBlocked(segmentId)) {
             return IndexResult.busy();
@@ -63,8 +62,7 @@ final class DirectSegmentWriteCoordinator<K, V> {
         return IndexResult.ok(segmentId);
     }
 
-    private boolean isTailRouteSplitBlocked(
-            final KeyToSegmentMap.Snapshot<K> snapshot) {
+    private boolean isTailRouteSplitBlocked(final Snapshot<K> snapshot) {
         final var segmentIds = snapshot.getSegmentIds(SegmentWindow.unbounded());
         if (segmentIds.isEmpty()) {
             return false;

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexConsistencyChecker.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexConsistencyChecker.java
@@ -1,6 +1,5 @@
 package org.hestiastore.index.segmentindex.core;
 
-import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.hestiastore.index.EntryIterator;
@@ -14,7 +13,9 @@ import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segment.SegmentResultStatus;
 import org.hestiastore.index.segmentindex.IndexConfigurationContract;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
+import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -38,19 +39,18 @@ class IndexConsistencyChecker<K, V> {
             IndexConfigurationContract.DEFAULT_INDEX_BUSY_TIMEOUT_MILLIS);
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final SegmentRegistry<K, V> segmentRegistry;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
-    private final Comparator<K> keyComparator;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final Predicate<SegmentId> segmentFilter;
     private final IndexRetryPolicy retryPolicy;
 
-    IndexConsistencyChecker(final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+    IndexConsistencyChecker(final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final TypeDescriptor<K> keyTypeDescriptor) {
         this(keyToSegmentMap, segmentRegistry, keyTypeDescriptor,
                 segmentId -> true, DEFAULT_RETRY_POLICY);
     }
 
-    IndexConsistencyChecker(final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+    IndexConsistencyChecker(final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final TypeDescriptor<K> keyTypeDescriptor,
             final Predicate<SegmentId> segmentFilter) {
@@ -58,7 +58,7 @@ class IndexConsistencyChecker<K, V> {
                 segmentFilter, DEFAULT_RETRY_POLICY);
     }
 
-    IndexConsistencyChecker(final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+    IndexConsistencyChecker(final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final TypeDescriptor<K> keyTypeDescriptor,
             final Predicate<SegmentId> segmentFilter,
@@ -68,7 +68,6 @@ class IndexConsistencyChecker<K, V> {
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
         Vldtn.requireNonNull(keyTypeDescriptor, "keyTypeDescriptor");
-        this.keyComparator = keyTypeDescriptor.getComparator();
         this.segmentFilter = Vldtn.requireNonNull(segmentFilter,
                 "segmentFilter");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
@@ -84,12 +83,8 @@ class IndexConsistencyChecker<K, V> {
      * repair obvious corruption when possible.
      */
     public void checkAndRepairConsistency() {
-        keyToSegmentMap.getSegmentsAsStream().forEach(segmentPair -> {
-            final K segmentKey = segmentPair.getKey();
-            if (segmentKey == null) {
-                throw new IndexException(ERROR_MSG + "Segment key is null.");
-            }
-            final SegmentId segmentId = segmentPair.getValue();
+        final Snapshot<K> snapshot = keyToSegmentMap.snapshot();
+        snapshot.getSegmentIds(SegmentWindow.unbounded()).forEach(segmentId -> {
             if (segmentId == null) {
                 throw new IndexException(ERROR_MSG + "Segment id is null.");
             }
@@ -105,11 +100,12 @@ class IndexConsistencyChecker<K, V> {
                 removeEmptySegment(segmentId, segment);
                 return;
             }
-            if (keyComparator.compare(segmentKey, maxKey) < 0) {
+            final SegmentId routedSegmentId = snapshot.findSegmentIdForKey(
+                    maxKey);
+            if (!segmentId.equals(routedSegmentId)) {
                 throw new IndexException(String.format(ERROR_MSG
-                        + "Segment '%s' has a max key of '%s', "
-                        + "which is less than the max key '%s' from the index data.",
-                        segmentId, segmentKey, maxKey));
+                        + "Segment '%s' contains max key '%s', which routes to segment '%s' in the index map.",
+                        segmentId, maxKey, routedSegmentId));
             }
             logger.debug("Checking segment '{}' id done.", segmentId);
         });
@@ -122,8 +118,8 @@ class IndexConsistencyChecker<K, V> {
         }
         logger.warn("Segment '{}' is empty. Removing it from index map.",
                 segmentId);
-        keyToSegmentMap.removeSegment(segmentId);
-        keyToSegmentMap.optionalyFlush();
+        keyToSegmentMap.removeSegmentRoute(segmentId);
+        keyToSegmentMap.flushIfDirty();
         segmentRegistry.deleteSegment(segmentId);
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexConsistencyCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexConsistencyCoordinator.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.segment.SegmentId;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 
 /**
@@ -30,12 +30,12 @@ final class IndexConsistencyCoordinator<K, V> {
     private boolean startupSegmentLockValidationEnabled;
 
     IndexConsistencyCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final TypeDescriptor<K> keyTypeDescriptor,
             final IndexRecoveryCleanupCoordinator<K, V> recoveryCleanupCoordinator,
             final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop) {
-        this(keyToSegmentMap::checkUniqueSegmentIds,
+        this(keyToSegmentMap::validateUniqueSegmentIds,
                 segmentFilter -> new IndexConsistencyChecker<>(keyToSegmentMap,
                         segmentRegistry, keyTypeDescriptor, segmentFilter)
                                 .checkAndRepairConsistency(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexMaintenanceCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexMaintenanceCoordinator.java
@@ -1,7 +1,7 @@
 package org.hestiastore.index.segmentindex.core;
 
 import org.hestiastore.index.Vldtn;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 
 /**
  * Owns foreground flush and compaction orchestration across split and stable
@@ -9,14 +9,14 @@ import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAda
  */
 final class IndexMaintenanceCoordinator<K, V> {
 
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop;
     private final StableSegmentCoordinator<K, V> stableSegmentCoordinator;
     private final IndexWalCoordinator<K, V> walCoordinator;
 
     IndexMaintenanceCoordinator(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop,
             final StableSegmentCoordinator<K, V> stableSegmentCoordinator,
@@ -50,17 +50,17 @@ final class IndexMaintenanceCoordinator<K, V> {
         final long finalTopologyVersion = keyToSegmentMap.snapshot().version();
         backgroundSplitPolicyLoop.scheduleScanIfIdle();
         backgroundSplitPolicyLoop.awaitExhausted();
-        if (!keyToSegmentMap.isVersion(finalTopologyVersion)) {
+        if (!keyToSegmentMap.isAtVersion(finalTopologyVersion)) {
             stableSegmentCoordinator.compactMappedSegmentsAndFlush();
         }
-        keyToSegmentMap.optionalyFlush();
+        keyToSegmentMap.flushIfDirty();
         walCoordinator.checkpoint();
     }
 
     void flush() {
         backgroundSplitCoordinator.runWithSplitSchedulingPaused(
                 () -> stableSegmentCoordinator.flushSegments(false));
-        keyToSegmentMap.optionalyFlush();
+        keyToSegmentMap.flushIfDirty();
         backgroundSplitPolicyLoop.scheduleScanIfIdle();
     }
 
@@ -70,10 +70,10 @@ final class IndexMaintenanceCoordinator<K, V> {
         final long finalTopologyVersion = keyToSegmentMap.snapshot().version();
         backgroundSplitPolicyLoop.scheduleScanIfIdle();
         backgroundSplitPolicyLoop.awaitExhausted();
-        if (!keyToSegmentMap.isVersion(finalTopologyVersion)) {
+        if (!keyToSegmentMap.isAtVersion(finalTopologyVersion)) {
             stableSegmentCoordinator.flushMappedSegmentsAndWait();
         }
-        keyToSegmentMap.optionalyFlush();
+        keyToSegmentMap.flushIfDirty();
         walCoordinator.checkpoint();
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinator.java
@@ -12,7 +12,7 @@ import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.segment.SegmentDirectoryLayout;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
 import org.slf4j.Logger;
@@ -30,13 +30,13 @@ final class IndexRecoveryCleanupCoordinator<K, V> {
 
     private final Logger logger;
     private final Directory directoryFacade;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final IndexRetryPolicy retryPolicy;
 
     IndexRecoveryCleanupCoordinator(final Logger logger,
             final Directory directoryFacade,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final IndexRetryPolicy retryPolicy) {
         this.logger = Vldtn.requireNonNull(logger, "logger");

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexImpl.java
@@ -16,7 +16,7 @@ import org.hestiastore.index.segmentindex.SegmentIndexMetricsSnapshot;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -278,7 +278,7 @@ public abstract class SegmentIndexImpl<K, V> extends AbstractCloseableResource
         runtime.awaitSplitsIdle(conf.getIndexBusyTimeoutMillis());
     }
 
-    final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap() {
+    final KeyToSegmentMap<K> keyToSegmentMap() {
         return runtime.keyToSegmentMap();
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexMetricsCollector.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexMetricsCollector.java
@@ -16,7 +16,7 @@ import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexMetricsSnapshot;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryCacheStats;
@@ -28,7 +28,7 @@ import org.hestiastore.index.segmentregistry.SegmentRegistryCacheStats;
 final class SegmentIndexMetricsCollector<K, V> {
 
     private final IndexConfiguration<K, V> conf;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final IndexExecutorRegistry executorRegistry;
@@ -41,7 +41,7 @@ final class SegmentIndexMetricsCollector<K, V> {
     private final Supplier<SegmentIndexState> stateSupplier;
 
     SegmentIndexMetricsCollector(final IndexConfiguration<K, V> conf,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final IndexExecutorRegistry executorRegistry,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntime.java
@@ -14,7 +14,7 @@ import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.IndexRuntimeConfiguration;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.slf4j.Logger;
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 final class SegmentIndexRuntime<K, V> {
 
     private final RuntimeTuningState runtimeTuningState;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop;
@@ -47,7 +47,7 @@ final class SegmentIndexRuntime<K, V> {
     @SuppressWarnings("java:S107")
     SegmentIndexRuntime(
             final RuntimeTuningState runtimeTuningState,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final BackgroundSplitPolicyLoop<K, V> backgroundSplitPolicyLoop,
@@ -110,7 +110,7 @@ final class SegmentIndexRuntime<K, V> {
         return runtimeTuningState;
     }
 
-    KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap() {
+    KeyToSegmentMap<K> keyToSegmentMap() {
         return keyToSegmentMap;
     }
 
@@ -197,7 +197,7 @@ final class SegmentIndexRuntime<K, V> {
                 () -> backgroundSplitCoordinator
                         .runWithSplitSchedulingPaused(() -> stableSegmentCoordinator
                                 .flushSegments(true)),
-                segmentRegistry::close, keyToSegmentMap::optionalyFlush,
+                segmentRegistry::close, keyToSegmentMap::flushIfDirty,
                 walCoordinator::checkpoint, getReadCount, getWriteCount,
                 getDeleteCount, finishCloseTransition, walRuntime::close);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilder.java
@@ -11,6 +11,7 @@ import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.IndexRuntimeConfiguration;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentindex.split.RouteSplitCoordinator;
@@ -33,7 +34,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
     interface BuildObserver<K, V> {
 
         default void onKeyToSegmentMapCreated(
-                final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap) {
+                final KeyToSegmentMap<K> keyToSegmentMap) {
         }
 
         default void onSegmentRegistryCreated(
@@ -141,13 +142,13 @@ final class SegmentIndexRuntimeBuilder<K, V> {
     }
 
     SegmentIndexRuntime<K, V> build() {
-        KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap = null;
+        KeyToSegmentMap<K> keyToSegmentMap = null;
         SegmentRegistry<K, V> segmentRegistry = null;
         WalRuntime<K, V> walRuntime = null;
         try {
             final RuntimeTuningState runtimeTuningState = RuntimeTuningState
                     .fromConfiguration(conf);
-            final KeyToSegmentMap<K> keyToSegmentMapDelegate = new KeyToSegmentMap<>(
+            final KeyToSegmentMapImpl<K> keyToSegmentMapDelegate = new KeyToSegmentMapImpl<>(
                     directoryFacade, keyTypeDescriptor);
             keyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                     keyToSegmentMapDelegate);
@@ -190,14 +191,14 @@ final class SegmentIndexRuntimeBuilder<K, V> {
             walRuntime = WalRuntime.open(directoryFacade, conf.getWal(),
                     keyTypeDescriptor, valueTypeDescriptor);
             buildObserver.onWalRuntimeCreated(walRuntime);
-            final KeyToSegmentMapSynchronizedAdapter<K> builtKeyToSegmentMap = keyToSegmentMap;
+            final KeyToSegmentMap<K> builtKeyToSegmentMap = keyToSegmentMap;
             final IndexWalCoordinator<K, V> walCoordinator = new IndexWalCoordinator<>(
                     logger, conf, walRuntime, retryPolicy,
                     () -> {
                     },
                     () -> {
                         stableSegmentCoordinator.flushSegments(true);
-                        builtKeyToSegmentMap.optionalyFlush();
+                        builtKeyToSegmentMap.flushIfDirty();
                     }, callbacks.stateSupplier(), callbacks.failureHandler(),
                     lastAppliedWalLsn);
             final IndexOperationCoordinator<K, V> operationCoordinator = new IndexOperationCoordinator<>(
@@ -258,7 +259,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
     }
 
     private SegmentIndexMetricsCollector<K, V> newMetricsCollector(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final RuntimeTuningState runtimeTuningState,
@@ -274,7 +275,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
     private RuntimeException cleanupFailedBuild(final RuntimeException failure,
             final WalRuntime<K, V> walRuntime,
             final SegmentRegistry<K, V> segmentRegistry,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap) {
+            final KeyToSegmentMap<K> keyToSegmentMap) {
         closeWalRuntime(walRuntime, failure);
         closeSegmentRegistry(segmentRegistry, failure);
         closeKeyToSegmentMap(keyToSegmentMap, failure);
@@ -319,7 +320,7 @@ final class SegmentIndexRuntimeBuilder<K, V> {
     }
 
     private void closeKeyToSegmentMap(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final RuntimeException failure) {
         if (keyToSegmentMap == null || keyToSegmentMap.wasClosed()) {
             return;

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinator.java
@@ -12,7 +12,7 @@ import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segment.SegmentResultStatus;
 import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -31,7 +31,7 @@ final class StableSegmentCoordinator<K, V> {
     private static final String OPERATION_LABEL_FLUSH = "Flush";
 
     private final Logger logger;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator;
     private final StableSegmentGateway<K, V> stableSegmentGateway;
@@ -40,7 +40,7 @@ final class StableSegmentCoordinator<K, V> {
     private final LongSupplier nanoTimeSupplier;
 
     StableSegmentCoordinator(final Logger logger,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final StableSegmentGateway<K, V> stableSegmentGateway,
@@ -50,7 +50,7 @@ final class StableSegmentCoordinator<K, V> {
     }
 
     StableSegmentCoordinator(final Logger logger,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final BackgroundSplitCoordinator<K, V> backgroundSplitCoordinator,
             final StableSegmentGateway<K, V> stableSegmentGateway,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentGateway.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/StableSegmentGateway.java
@@ -10,7 +10,7 @@ import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segment.SegmentResultStatus;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -23,11 +23,11 @@ final class StableSegmentGateway<K, V> {
 
     private static final String SEGMENT_ID_ARG = "segmentId";
 
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
 
     StableSegmentGateway(
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry) {
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
@@ -36,8 +36,8 @@ final class StableSegmentGateway<K, V> {
     }
 
     IndexResult<V> get(final K key) {
-        final KeyToSegmentMap.Snapshot<K> snapshot = keyToSegmentMap.snapshot();
-        final SegmentId segmentId = snapshot.findSegmentId(key);
+        final Snapshot<K> snapshot = keyToSegmentMap.snapshot();
+        final SegmentId segmentId = snapshot.findSegmentIdForKey(key);
         if (segmentId == null) {
             return IndexResult.ok(null);
         }
@@ -56,8 +56,8 @@ final class StableSegmentGateway<K, V> {
         }
         final SegmentResult<V> result = loaded.getValue().get(key);
         if (result.getStatus() == SegmentResultStatus.OK) {
-            if (!keyToSegmentMap.isMappingValid(key, segmentId,
-                    expectedTopologyVersion)) {
+            if (!keyToSegmentMap
+                    .isSnapshotVersionCurrent(expectedTopologyVersion)) {
                 return IndexResult.busy();
             }
             return IndexResult.ok(result.getValue());

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMap.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMap.java
@@ -1,445 +1,47 @@
 package org.hestiastore.index.segmentindex.mapping;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
 
-import org.hestiastore.index.AbstractCloseableResource;
-import org.hestiastore.index.Entry;
-import org.hestiastore.index.EntryIterator;
-import org.hestiastore.index.Vldtn;
-import org.hestiastore.index.datatype.TypeDescriptor;
-import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.CloseableResource;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.split.RouteSplitPlan;
-import org.hestiastore.index.sorteddatafile.SortedDataFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Class holds and maintain {@code map<key, segmentId>}. Key is max in in given
+ * Holds {@code map<key, segmentId>} where each key is the max key in a given
  * segment.
- * 
+ *
  * Provide information about keys and particular segment files. Each key
- * represents one segment. All keys segment are equal or smaller to given key.
- * Last key represents higher key in index. When new value in index is entered
- * it should be called {@link #insertKeyToSegment(Object)}. This method update
- * higher key value when it's necessary.
+ * represents one segment. All keys in that segment are equal or smaller than
+ * the given key. The last key represents the highest key in the index. When a
+ * new value outside current routing is entered, the max key must be extended so
+ * routing still covers the whole key space.
  *
  * Note that this is similar to scarce index, but still different.
  *
- * This class is not thread-safe. Use {@link KeyToSegmentMapSynchronizedAdapter}
- * when accessing from multiple threads.
- * 
- * @author honza
- *
- * @param <K>
+ * @param <K> key type
  */
-public final class KeyToSegmentMap<K> extends AbstractCloseableResource {
+public interface KeyToSegmentMap<K> extends CloseableResource {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private static final boolean DEBUG_SPLIT_LOSS = Boolean
-            .getBoolean("hestiastore.debugSplitLoss");
-    private static final TypeDescriptorSegmentId tdSegId = new TypeDescriptorSegmentId();
+    void validateUniqueSegmentIds();
 
-    private static final String FILE_NAME = "index.map";
+    SegmentId findSegmentIdForKey(K key);
 
-    /**
-     * When new index is created than this is id of first segment.
-     */
-    private static final SegmentId FIRST_SEGMENT_ID = SegmentId.of(0);
+    Snapshot<K> snapshot();
 
-    private TreeMap<K, SegmentId> list;
-    private volatile TreeMap<K, SegmentId> snapshot;
-    private final SortedDataFile<K, SegmentId> sdf;
-    private final Comparator<K> keyComparator;
-    private boolean isDirty = false;
-    private final AtomicLong version = new AtomicLong(0);
+    boolean isAtVersion(long expectedVersion);
 
-    public KeyToSegmentMap(final Directory directoryFacade,
-            final TypeDescriptor<K> keyTypeDescriptor) {
-        Vldtn.requireNonNull(directoryFacade, "directoryFacade");
-        Vldtn.requireNonNull(keyTypeDescriptor, "keyTypeDescriptor");
-        this.keyComparator = Vldtn.requireNonNull(
-                keyTypeDescriptor.getComparator(),
-                "keyTypeDescriptor.getComparator()");
-        this.sdf = SortedDataFile.<K, SegmentId>builder() //
-                .withDirectory(directoryFacade) //
-                .withFileName(FILE_NAME)//
-                .withKeyTypeDescriptor(keyTypeDescriptor) //
-                .withValueTypeDescriptor(tdSegId) //
-                .build();
+    boolean isSnapshotVersionCurrent(long expectedVersion);
 
-        this.list = new TreeMap<>(keyComparator);
-        try (EntryIterator<K, SegmentId> reader = sdf.openIterator()) {
-            while (reader.hasNext()) {
-                final Entry<K, SegmentId> entry = reader.next();
-                list.put(entry.getKey(), entry.getValue());
-            }
-        }
-        this.snapshot = new TreeMap<>(list);
-        checkUniqueSegmentIds();
-    }
+    boolean extendMaxKeyIfNeeded(K key);
 
-    /**
-     * Verify, that all segment ids are unique.
-     */
-    public void checkUniqueSegmentIds() {
-        ensureOpen();
-        final TreeMap<K, SegmentId> current = snapshot;
-        final HashMap<SegmentId, K> tmp = new HashMap<SegmentId, K>();
-        final AtomicBoolean fail = new AtomicBoolean(false);
-        current.forEach((key, segmentId) -> {
-            final K oldKey = tmp.get(segmentId);
-            if (oldKey == null) {
-                tmp.put(segmentId, key);
-            } else {
-                logger.error(String.format(
-                        "Segment id '%s' is used for segment with "
-                                + "key '%s' and segment with key '%s'.",
-                        segmentId, key, oldKey));
-                fail.set(true);
-            }
-        });
-        if (fail.get()) {
-            throw new IllegalStateException(
-                    "Unable to load scarce index, sanity check failed.");
-        }
-    }
+    boolean tryApplySplitPlan(RouteSplitPlan<K> plan);
 
-    /**
-     * Finds the segment id mapped to the provided key.
-     *
-     * @param key key to look up
-     * @return segment id or {@code null} when not mapped
-     */
-    public SegmentId findSegmentId(final K key) {
-        ensureOpen();
-        Vldtn.requireNonNull(key, "key");
-        final Entry<K, SegmentId> entry = localFindSegmentForKey(key, snapshot);
-        return entry == null ? null : entry.getValue();
-    }
+    void removeSegmentRoute(SegmentId segmentId);
 
-    public Snapshot<K> snapshot() {
-        return new Snapshot<>(snapshot, version.get());
-    }
+    List<SegmentId> getSegmentIds();
 
-    public boolean isVersion(final long expectedVersion) {
-        return version.get() == expectedVersion;
-    }
+    List<SegmentId> getSegmentIds(SegmentWindow segmentWindow);
 
-    public boolean isMappingValid(final K key,
-            final SegmentId expectedSegmentId, final long expectedVersion) {
-        Vldtn.requireNonNull(key, "key");
-        Vldtn.requireNonNull(expectedSegmentId, "expectedSegmentId");
-        return version.get() == expectedVersion;
-    }
-
-    public boolean isKeyMappedToSegment(final K key,
-            final SegmentId expectedSegmentId) {
-        Vldtn.requireNonNull(key, "key");
-        Vldtn.requireNonNull(expectedSegmentId, "expectedSegmentId");
-        final SegmentId current = findSegmentId(key);
-        return expectedSegmentId.equals(current);
-    }
-
-    public boolean tryExtendMaxKey(final K key, final Snapshot<K> snapshot) {
-        Vldtn.requireNonNull(key, "key");
-        Vldtn.requireNonNull(snapshot, "snapshot");
-        if (version.get() != snapshot.version()) {
-            return false;
-        }
-        if (list.isEmpty()) {
-            list.put(key, FIRST_SEGMENT_ID);
-            refreshSnapshot();
-            isDirty = true;
-            return true;
-        }
-        final Map.Entry<K, SegmentId> lastEntry = list.lastEntry();
-        if (keyComparator.compare(key, lastEntry.getKey()) > 0) {
-            list.remove(lastEntry.getKey());
-            list.put(key, lastEntry.getValue());
-            refreshSnapshot();
-            isDirty = true;
-        }
-        return true;
-    }
-
-    /**
-     * Inserts a mapping for the provided key, allocating a segment id when
-     * needed.
-     *
-     * @param key key to map
-     * @return segment id assigned to the key
-     */
-    public SegmentId insertKeyToSegment(final K key) {
-        ensureOpen();
-        Vldtn.requireNonNull(key, "key");
-        final Entry<K, SegmentId> entry = localFindSegmentForKey(key, list);
-        if (entry == null) {
-            /*
-             * Key is bigger that all key so it will at last segment. But key at
-             * last segment is smaller than adding one. Because of that key have
-             * to be upgraded.
-             */
-            isDirty = true;
-            return updateMaxKey(key);
-        } else {
-            return entry.getValue();
-        }
-    }
-
-    private Entry<K, SegmentId> localFindSegmentForKey(final K key,
-            final TreeMap<K, SegmentId> source) {
-        Vldtn.requireNonNull(key, "key");
-        final Map.Entry<K, SegmentId> ceilingEntry = source.ceilingEntry(key);
-        if (ceilingEntry == null) {
-            return null;
-        } else {
-            return Entry.of(ceilingEntry.getKey(), ceilingEntry.getValue());
-        }
-    }
-
-    private SegmentId updateMaxKey(final K key) {
-        if (list.size() == 0) {
-            list.put(key, FIRST_SEGMENT_ID);
-            refreshSnapshot();
-            return FIRST_SEGMENT_ID;
-        } else {
-            final Entry<K, SegmentId> max = Entry.of(list.lastEntry().getKey(),
-                    list.lastEntry().getValue());
-            list.remove(max.getKey());
-            final Entry<K, SegmentId> newMax = Entry.of(key, max.getValue());
-            list.put(newMax.getKey(), newMax.getValue());
-            refreshSnapshot();
-            return newMax.getValue();
-        }
-    }
-
-    /**
-     * Inserts or updates a mapping for the provided key and segment id.
-     *
-     * @param key       key to map
-     * @param segmentId segment id to associate
-     */
-    public void insertSegment(final K key, final SegmentId segmentId) {
-        ensureOpen();
-        Vldtn.requireNonNull(key, "key");
-        if (list.containsValue(segmentId)) {
-            throw new IllegalArgumentException(
-                    String.format("Segment id '%s' already exists", segmentId));
-        }
-        list.put(key, segmentId);
-        refreshSnapshot();
-        isDirty = true;
-    }
-
-    public void updateSegmentMaxKey(final SegmentId segmentId,
-            final K newMaxKey) {
-        Vldtn.requireNonNull(segmentId, "segmentId");
-        Vldtn.requireNonNull(newMaxKey, "newMaxKey");
-        Map.Entry<K, SegmentId> existing = null;
-        for (final Map.Entry<K, SegmentId> entry : list.entrySet()) {
-            if (segmentId.equals(entry.getValue())) {
-                existing = entry;
-                break;
-            }
-        }
-        if (existing == null) {
-            if (list.containsKey(newMaxKey)
-                    && !segmentId.equals(list.get(newMaxKey))) {
-                throw new IllegalStateException(String.format(
-                        "Segment max key '%s' is already bound to segment '%s'",
-                        newMaxKey, list.get(newMaxKey)));
-            }
-            list.put(newMaxKey, segmentId);
-            refreshSnapshot();
-            isDirty = true;
-            return;
-        }
-        if (list.containsKey(newMaxKey)
-                && !segmentId.equals(list.get(newMaxKey))) {
-            throw new IllegalStateException(String.format(
-                    "Segment max key '%s' is already bound to segment '%s'",
-                    newMaxKey, list.get(newMaxKey)));
-        }
-        list.remove(existing.getKey());
-        list.put(newMaxKey, segmentId);
-        refreshSnapshot();
-        isDirty = true;
-    }
-
-    /**
-     * Removes the mapping for the provided segment id.
-     *
-     * @param segmentId segment id to remove
-     */
-    public void removeSegment(final SegmentId segmentId) {
-        removeSegmentAndReturnMaxKey(segmentId);
-    }
-
-    private K removeSegmentAndReturnMaxKey(final SegmentId segmentId) {
-        ensureOpen();
-        Vldtn.requireNonNull(segmentId, "segmentId");
-        if (list.isEmpty()) {
-            return null;
-        }
-        boolean removed = false;
-        K removedKey = null;
-        final java.util.Iterator<Map.Entry<K, SegmentId>> iterator = list
-                .entrySet().iterator();
-        while (iterator.hasNext()) {
-            final Map.Entry<K, SegmentId> entry = iterator.next();
-            if (segmentId.equals(entry.getValue())) {
-                final K keyToRemove = entry.getKey();
-                iterator.remove();
-                removedKey = keyToRemove;
-                removed = true;
-            }
-        }
-        if (removed) {
-            refreshSnapshot();
-            isDirty = true;
-        }
-        return removedKey;
-    }
-
-    public boolean applyRouteSplit(final RouteSplitPlan<K> plan) {
-        Vldtn.requireNonNull(plan, "plan");
-        final SegmentId replacedSegmentId = plan.getReplacedSegmentId();
-        final SegmentId lowerSegmentId = plan.getLowerSegmentId();
-        final K upperMaxKey = removeSegmentAndReturnMaxKey(replacedSegmentId);
-        if (upperMaxKey == null) {
-            return false;
-        }
-        if (DEBUG_SPLIT_LOSS) {
-            logger.warn(
-                    "Split debug: map apply replacedSegmentId='{}', oldMaxKey='{}', lowerSegmentId='{}', lowerMaxKey='{}', splitMode='{}', upperSegmentId='{}'.",
-                    replacedSegmentId, upperMaxKey, lowerSegmentId,
-                    plan.getLowerMaxKey(), plan.getSplitMode(),
-                    plan.getUpperSegmentId().orElse(null));
-        }
-        insertSegment(plan.getLowerMaxKey(), lowerSegmentId);
-        if (plan.isSplit()) {
-            final SegmentId upperSegmentId = Vldtn.requireNonNull(
-                    plan.getUpperSegmentId().orElse(null), "upperSegmentId");
-            insertSegment(upperMaxKey, upperSegmentId);
-        }
-        return true;
-    }
-
-    /**
-     * Returns a stream of key-to-segment mappings.
-     *
-     * @return stream of entries
-     */
-    public Stream<Entry<K, SegmentId>> getSegmentsAsStream() {
-        ensureOpen();
-        return snapshotSegments().stream();
-    }
-
-    /**
-     * Returns the segment ids in key order.
-     *
-     * @return ordered list of segment ids
-     */
-    public List<SegmentId> getSegmentIds() {
-        ensureOpen();
-        return getSegmentIds(SegmentWindow.unbounded());
-    }
-
-    /**
-     * Returns the segment ids within the provided window.
-     *
-     * @param segmentWindow window to apply
-     * @return ordered list of segment ids
-     */
-    public List<SegmentId> getSegmentIds(SegmentWindow segmentWindow) {
-        ensureOpen();
-        return snapshot.entrySet().stream()//
-                .skip(segmentWindow.getIntOffset())//
-                .limit(segmentWindow.getIntLimit())//
-                .map(entry -> entry.getValue())//
-                .toList();
-    }
-
-    /**
-     * Flushes all changes to disk if there are any. This method is
-     * automatically called when this cache is closed.
-     */
-    public void optionallyFlush() {
-        ensureOpen();
-        flushIfDirty();
-    }
-
-    private void flushIfDirty() {
-        if (isDirty) {
-            sdf.openWriterTx().execute(writer -> {
-                list.forEach((k, v) -> writer.write(Entry.of(k, v)));
-            });
-        }
-        isDirty = false;
-    }
-
-    @Override
-    protected void doClose() {
-        flushIfDirty();
-    }
-
-    private List<Entry<K, SegmentId>> snapshotSegments() {
-        if (snapshot.isEmpty()) {
-            return List.of();
-        }
-        final List<Entry<K, SegmentId>> out = new ArrayList<>(snapshot.size());
-        snapshot.forEach((key, segmentId) -> out.add(Entry.of(key, segmentId)));
-        return out;
-    }
-
-    private void refreshSnapshot() {
-        snapshot = new TreeMap<>(list);
-        version.incrementAndGet();
-    }
-
-    private void ensureOpen() {
-        if (wasClosed()) {
-            throw new IllegalStateException(
-                    getClass().getSimpleName() + " already closed");
-        }
-    }
-
-    public static final class Snapshot<K> {
-        private final TreeMap<K, SegmentId> map;
-        private final long version;
-
-        private Snapshot(final TreeMap<K, SegmentId> map, final long version) {
-            this.map = map;
-            this.version = version;
-        }
-
-        public SegmentId findSegmentId(final K key) {
-            Vldtn.requireNonNull(key, "key");
-            final Map.Entry<K, SegmentId> ceilingEntry = map.ceilingEntry(key);
-            return ceilingEntry == null ? null : ceilingEntry.getValue();
-        }
-
-        public List<SegmentId> getSegmentIds(final SegmentWindow segmentWindow) {
-            Vldtn.requireNonNull(segmentWindow, "segmentWindow");
-            return map.entrySet().stream()//
-                    .skip(segmentWindow.getIntOffset())//
-                    .limit(segmentWindow.getIntLimit())//
-                    .map(entry -> entry.getValue())//
-                    .toList();
-        }
-
-        public long version() {
-            return version;
-        }
-    }
+    void flushIfDirty();
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
 public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private static final boolean DEBUG_SPLIT_LOSS = Boolean
-            .getBoolean("hestiastore.debugSplitLoss");
     private static final TypeDescriptorSegmentId tdSegId = new TypeDescriptorSegmentId();
 
     private static final String FILE_NAME = "index.map";
@@ -288,8 +286,8 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
         if (upperMaxKey == null) {
             return false;
         }
-        if (DEBUG_SPLIT_LOSS) {
-            logger.warn(
+        if (logger.isDebugEnabled()) {
+            logger.debug(
                     "Split debug: map apply replacedSegmentId='{}', oldMaxKey='{}', lowerSegmentId='{}', lowerMaxKey='{}', splitMode='{}', upperSegmentId='{}'.",
                     replacedSegmentId, upperMaxKey, lowerSegmentId,
                     plan.getLowerMaxKey(), plan.getSplitMode(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
@@ -1,0 +1,367 @@
+package org.hestiastore.index.segmentindex.mapping;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.hestiastore.index.AbstractCloseableResource;
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.segment.SegmentId;
+import org.hestiastore.index.segmentindex.SegmentWindow;
+import org.hestiastore.index.segmentindex.split.RouteSplitPlan;
+import org.hestiastore.index.sorteddatafile.SortedDataFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persistent non-thread-safe implementation backing
+ * {@link KeyToSegmentMapSynchronizedAdapter}.
+ *
+ * @param <K> key type
+ */
+public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final boolean DEBUG_SPLIT_LOSS = Boolean
+            .getBoolean("hestiastore.debugSplitLoss");
+    private static final TypeDescriptorSegmentId tdSegId = new TypeDescriptorSegmentId();
+
+    private static final String FILE_NAME = "index.map";
+
+    /**
+     * When new index is created than this is id of first segment.
+     */
+    private static final SegmentId FIRST_SEGMENT_ID = SegmentId.of(0);
+
+    private TreeMap<K, SegmentId> list;
+    private volatile TreeMap<K, SegmentId> snapshot;
+    private final SortedDataFile<K, SegmentId> sdf;
+    private final Comparator<K> keyComparator;
+    private boolean isDirty = false;
+    private final AtomicLong version = new AtomicLong(0);
+
+    public KeyToSegmentMapImpl(final Directory directoryFacade,
+            final TypeDescriptor<K> keyTypeDescriptor) {
+        Vldtn.requireNonNull(directoryFacade, "directoryFacade");
+        Vldtn.requireNonNull(keyTypeDescriptor, "keyTypeDescriptor");
+        this.keyComparator = Vldtn.requireNonNull(
+                keyTypeDescriptor.getComparator(),
+                "keyTypeDescriptor.getComparator()");
+        this.sdf = SortedDataFile.<K, SegmentId>builder() //
+                .withDirectory(directoryFacade) //
+                .withFileName(FILE_NAME)//
+                .withKeyTypeDescriptor(keyTypeDescriptor) //
+                .withValueTypeDescriptor(tdSegId) //
+                .build();
+
+        this.list = new TreeMap<>(keyComparator);
+        try (EntryIterator<K, SegmentId> reader = sdf.openIterator()) {
+            while (reader.hasNext()) {
+                final Entry<K, SegmentId> entry = reader.next();
+                list.put(entry.getKey(), entry.getValue());
+            }
+        }
+        this.snapshot = new TreeMap<>(list);
+        validateUniqueSegmentIds();
+    }
+
+    /**
+     * Verify, that all segment ids are unique.
+     */
+    void validateUniqueSegmentIds() {
+        ensureOpen();
+        final TreeMap<K, SegmentId> current = snapshot;
+        final HashMap<SegmentId, K> tmp = new HashMap<SegmentId, K>();
+        final AtomicBoolean fail = new AtomicBoolean(false);
+        current.forEach((key, segmentId) -> {
+            final K oldKey = tmp.get(segmentId);
+            if (oldKey == null) {
+                tmp.put(segmentId, key);
+            } else {
+                logger.error(String.format(
+                        "Segment id '%s' is used for segment with "
+                                + "key '%s' and segment with key '%s'.",
+                        segmentId, key, oldKey));
+                fail.set(true);
+            }
+        });
+        if (fail.get()) {
+            throw new IllegalStateException(
+                    "Unable to load scarce index, sanity check failed.");
+        }
+    }
+
+    /**
+     * Finds the segment id mapped to the provided key.
+     *
+     * @param key key to look up
+     * @return segment id or {@code null} when not mapped
+     */
+    SegmentId findSegmentIdForKey(final K key) {
+        ensureOpen();
+        Vldtn.requireNonNull(key, "key");
+        final Entry<K, SegmentId> entry = localFindSegmentForKey(key, snapshot);
+        return entry == null ? null : entry.getValue();
+    }
+
+    Snapshot<K> snapshot() {
+        return new Snapshot<>(snapshot, version.get());
+    }
+
+    boolean isAtVersion(final long expectedVersion) {
+        return version.get() == expectedVersion;
+    }
+
+    boolean isSnapshotVersionCurrent(final long expectedVersion) {
+        return version.get() == expectedVersion;
+    }
+
+    boolean extendMaxKeyIfNeeded(final K key) {
+        Vldtn.requireNonNull(key, "key");
+        if (list.isEmpty()) {
+            list.put(key, FIRST_SEGMENT_ID);
+            refreshSnapshot();
+            isDirty = true;
+            return true;
+        }
+        final Map.Entry<K, SegmentId> lastEntry = list.lastEntry();
+        if (keyComparator.compare(key, lastEntry.getKey()) > 0) {
+            list.remove(lastEntry.getKey());
+            list.put(key, lastEntry.getValue());
+            refreshSnapshot();
+            isDirty = true;
+        }
+        return true;
+    }
+
+    /**
+     * Inserts a mapping for the provided key, allocating a segment id when
+     * needed.
+     *
+     * @param key key to map
+     * @return segment id assigned to the key
+     */
+    SegmentId insertKeyToSegment(final K key) {
+        ensureOpen();
+        Vldtn.requireNonNull(key, "key");
+        final Entry<K, SegmentId> entry = localFindSegmentForKey(key, list);
+        if (entry == null) {
+            /*
+             * Key is bigger that all key so it will at last segment. But key at
+             * last segment is smaller than adding one. Because of that key have
+             * to be upgraded.
+             */
+            isDirty = true;
+            return updateMaxKey(key);
+        } else {
+            return entry.getValue();
+        }
+    }
+
+    private Entry<K, SegmentId> localFindSegmentForKey(final K key,
+            final TreeMap<K, SegmentId> source) {
+        Vldtn.requireNonNull(key, "key");
+        final Map.Entry<K, SegmentId> ceilingEntry = source.ceilingEntry(key);
+        if (ceilingEntry == null) {
+            return null;
+        } else {
+            return Entry.of(ceilingEntry.getKey(), ceilingEntry.getValue());
+        }
+    }
+
+    private SegmentId updateMaxKey(final K key) {
+        if (list.size() == 0) {
+            list.put(key, FIRST_SEGMENT_ID);
+            refreshSnapshot();
+            return FIRST_SEGMENT_ID;
+        } else {
+            final Entry<K, SegmentId> max = Entry.of(list.lastEntry().getKey(),
+                    list.lastEntry().getValue());
+            list.remove(max.getKey());
+            final Entry<K, SegmentId> newMax = Entry.of(key, max.getValue());
+            list.put(newMax.getKey(), newMax.getValue());
+            refreshSnapshot();
+            return newMax.getValue();
+        }
+    }
+
+    /**
+     * Inserts or updates a mapping for the provided key and segment id.
+     *
+     * @param key       key to map
+     * @param segmentId segment id to associate
+     */
+    void insertSegment(final K key, final SegmentId segmentId) {
+        ensureOpen();
+        Vldtn.requireNonNull(key, "key");
+        if (list.containsValue(segmentId)) {
+            throw new IllegalArgumentException(
+                    String.format("Segment id '%s' already exists", segmentId));
+        }
+        list.put(key, segmentId);
+        refreshSnapshot();
+        isDirty = true;
+    }
+
+    void updateSegmentMaxKey(final SegmentId segmentId, final K newMaxKey) {
+        Vldtn.requireNonNull(segmentId, "segmentId");
+        Vldtn.requireNonNull(newMaxKey, "newMaxKey");
+        Map.Entry<K, SegmentId> existing = null;
+        for (final Map.Entry<K, SegmentId> entry : list.entrySet()) {
+            if (segmentId.equals(entry.getValue())) {
+                existing = entry;
+                break;
+            }
+        }
+        if (existing == null) {
+            if (list.containsKey(newMaxKey)
+                    && !segmentId.equals(list.get(newMaxKey))) {
+                throw new IllegalStateException(String.format(
+                        "Segment max key '%s' is already bound to segment '%s'",
+                        newMaxKey, list.get(newMaxKey)));
+            }
+            list.put(newMaxKey, segmentId);
+            refreshSnapshot();
+            isDirty = true;
+            return;
+        }
+        if (list.containsKey(newMaxKey)
+                && !segmentId.equals(list.get(newMaxKey))) {
+            throw new IllegalStateException(String.format(
+                    "Segment max key '%s' is already bound to segment '%s'",
+                    newMaxKey, list.get(newMaxKey)));
+        }
+        list.remove(existing.getKey());
+        list.put(newMaxKey, segmentId);
+        refreshSnapshot();
+        isDirty = true;
+    }
+
+    /**
+     * Removes the mapping for the provided segment id.
+     *
+     * @param segmentId segment id to remove
+     */
+    public void removeSegmentRoute(final SegmentId segmentId) {
+        removeSegmentAndReturnMaxKey(segmentId);
+    }
+
+    private K removeSegmentAndReturnMaxKey(final SegmentId segmentId) {
+        ensureOpen();
+        Vldtn.requireNonNull(segmentId, "segmentId");
+        if (list.isEmpty()) {
+            return null;
+        }
+        boolean removed = false;
+        K removedKey = null;
+        final java.util.Iterator<Map.Entry<K, SegmentId>> iterator = list
+                .entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Map.Entry<K, SegmentId> entry = iterator.next();
+            if (segmentId.equals(entry.getValue())) {
+                final K keyToRemove = entry.getKey();
+                iterator.remove();
+                removedKey = keyToRemove;
+                removed = true;
+            }
+        }
+        if (removed) {
+            refreshSnapshot();
+            isDirty = true;
+        }
+        return removedKey;
+    }
+
+    boolean tryApplySplitPlan(final RouteSplitPlan<K> plan) {
+        Vldtn.requireNonNull(plan, "plan");
+        final SegmentId replacedSegmentId = plan.getReplacedSegmentId();
+        final SegmentId lowerSegmentId = plan.getLowerSegmentId();
+        final K upperMaxKey = removeSegmentAndReturnMaxKey(replacedSegmentId);
+        if (upperMaxKey == null) {
+            return false;
+        }
+        if (DEBUG_SPLIT_LOSS) {
+            logger.warn(
+                    "Split debug: map apply replacedSegmentId='{}', oldMaxKey='{}', lowerSegmentId='{}', lowerMaxKey='{}', splitMode='{}', upperSegmentId='{}'.",
+                    replacedSegmentId, upperMaxKey, lowerSegmentId,
+                    plan.getLowerMaxKey(), plan.getSplitMode(),
+                    plan.getUpperSegmentId().orElse(null));
+        }
+        insertSegment(plan.getLowerMaxKey(), lowerSegmentId);
+        if (plan.isSplit()) {
+            final SegmentId upperSegmentId = Vldtn.requireNonNull(
+                    plan.getUpperSegmentId().orElse(null), "upperSegmentId");
+            insertSegment(upperMaxKey, upperSegmentId);
+        }
+        return true;
+    }
+
+    /**
+     * Returns the segment ids in key order.
+     *
+     * @return ordered list of segment ids
+     */
+    public List<SegmentId> getSegmentIds() {
+        ensureOpen();
+        return getSegmentIds(SegmentWindow.unbounded());
+    }
+
+    /**
+     * Returns the segment ids within the provided window.
+     *
+     * @param segmentWindow window to apply
+     * @return ordered list of segment ids
+     */
+    List<SegmentId> getSegmentIds(final SegmentWindow segmentWindow) {
+        ensureOpen();
+        return snapshot.entrySet().stream()//
+                .skip(segmentWindow.getIntOffset())//
+                .limit(segmentWindow.getIntLimit())//
+                .map(entry -> entry.getValue())//
+                .toList();
+    }
+
+    /**
+     * Flushes all changes to disk if there are any. This method is
+     * automatically called when this cache is closed.
+     */
+    public void flushIfDirty() {
+        ensureOpen();
+        persistIfDirty();
+    }
+
+    private void persistIfDirty() {
+        if (isDirty) {
+            sdf.openWriterTx().execute(writer -> {
+                list.forEach((k, v) -> writer.write(Entry.of(k, v)));
+            });
+        }
+        isDirty = false;
+    }
+
+    @Override
+    protected void doClose() {
+        persistIfDirty();
+    }
+
+    private void refreshSnapshot() {
+        snapshot = new TreeMap<>(list);
+        version.incrementAndGet();
+    }
+
+    private void ensureOpen() {
+        if (wasClosed()) {
+            throw new IllegalStateException(
+                    getClass().getSimpleName() + " already closed");
+        }
+    }
+
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSynchronizedAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSynchronizedAdapter.java
@@ -3,38 +3,38 @@ package org.hestiastore.index.segmentindex.mapping;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Stream;
 
 import org.hestiastore.index.AbstractCloseableResource;
-import org.hestiastore.index.Entry;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.split.RouteSplitPlan;
 
 /**
- * Thread-safe adapter for {@link KeyToSegmentMap} backed by a read/write lock.
+ * Thread-safe adapter for {@link KeyToSegmentMapImpl} backed by a read/write
+ * lock.
  */
 public final class KeyToSegmentMapSynchronizedAdapter<K>
-        extends AbstractCloseableResource {
+        extends AbstractCloseableResource implements KeyToSegmentMap<K> {
 
-    private final KeyToSegmentMap<K> delegate;
+    private final KeyToSegmentMapImpl<K> delegate;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
 
     public KeyToSegmentMapSynchronizedAdapter(
-            final KeyToSegmentMap<K> delegate) {
+            final KeyToSegmentMapImpl<K> delegate) {
         this.delegate = Vldtn.requireNonNull(delegate, "delegate");
     }
 
     /**
      * Verifies that all segment ids are unique.
      */
-    public void checkUniqueSegmentIds() {
+    @Override
+    public void validateUniqueSegmentIds() {
         readLock.lock();
         try {
-            delegate.checkUniqueSegmentIds();
+            delegate.validateUniqueSegmentIds();
         } finally {
             readLock.unlock();
         }
@@ -46,36 +46,18 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
      * @param key key to look up
      * @return segment id or {@code null} when not mapped
      */
-    public SegmentId findSegmentId(final K key) {
+    @Override
+    public SegmentId findSegmentIdForKey(final K key) {
         readLock.lock();
         try {
-            return delegate.findSegmentId(key);
+            return delegate.findSegmentIdForKey(key);
         } finally {
             readLock.unlock();
         }
     }
 
-    public <T> T withWriteLock(final java.util.function.Supplier<T> action) {
-        Vldtn.requireNonNull(action, "action");
-        writeLock.lock();
-        try {
-            return action.get();
-        } finally {
-            writeLock.unlock();
-        }
-    }
-
-    public void withWriteLock(final Runnable action) {
-        Vldtn.requireNonNull(action, "action");
-        writeLock.lock();
-        try {
-            action.run();
-        } finally {
-            writeLock.unlock();
-        }
-    }
-
-    public KeyToSegmentMap.Snapshot<K> snapshot() {
+    @Override
+    public Snapshot<K> snapshot() {
         readLock.lock();
         try {
             return delegate.snapshot();
@@ -84,50 +66,43 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
         }
     }
 
-    public boolean isVersion(final long expectedVersion) {
+    @Override
+    public boolean isAtVersion(final long expectedVersion) {
         readLock.lock();
         try {
-            return delegate.isVersion(expectedVersion);
+            return delegate.isAtVersion(expectedVersion);
         } finally {
             readLock.unlock();
         }
     }
 
-    public boolean isMappingValid(final K key,
-            final SegmentId expectedSegmentId, final long expectedVersion) {
+    @Override
+    public boolean isSnapshotVersionCurrent(final long expectedVersion) {
         readLock.lock();
         try {
-            return delegate.isMappingValid(key, expectedSegmentId,
-                    expectedVersion);
+            return delegate.isSnapshotVersionCurrent(expectedVersion);
         } finally {
             readLock.unlock();
         }
     }
 
-    public boolean isKeyMappedToSegment(final K key,
-            final SegmentId expectedSegmentId) {
-        readLock.lock();
+    @Override
+    public boolean extendMaxKeyIfNeeded(final K key) {
+        writeLock.lock();
         try {
-            return delegate.isKeyMappedToSegment(key, expectedSegmentId);
+            return delegate.extendMaxKeyIfNeeded(key);
         } finally {
-            readLock.unlock();
+            writeLock.unlock();
         }
     }
 
-    public boolean tryExtendMaxKey(final K key,
-            final KeyToSegmentMap.Snapshot<K> snapshot) {
-        return withWriteLock(() -> delegate.tryExtendMaxKey(key, snapshot));
-    }
-
-    /**
-     * Inserts a mapping for the provided key, allocating a segment id when
-     * needed.
-     *
-     * @param key key to map
-     * @return segment id assigned to the key
-     */
-    public SegmentId insertKeyToSegment(final K key) {
-        return withWriteLock(() -> delegate.insertKeyToSegment(key));
+    SegmentId insertKeyToSegment(final K key) {
+        writeLock.lock();
+        try {
+            return delegate.insertKeyToSegment(key);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     /**
@@ -136,17 +111,32 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
      * @param key       key to map
      * @param segmentId segment id to associate
      */
-    public void insertSegment(final K key, final SegmentId segmentId) {
-        withWriteLock(() -> delegate.insertSegment(key, segmentId));
+    void insertSegment(final K key, final SegmentId segmentId) {
+        writeLock.lock();
+        try {
+            delegate.insertSegment(key, segmentId);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
-    public void updateSegmentMaxKey(final SegmentId segmentId,
-            final K newMaxKey) {
-        withWriteLock(() -> delegate.updateSegmentMaxKey(segmentId, newMaxKey));
+    void updateSegmentMaxKey(final SegmentId segmentId, final K newMaxKey) {
+        writeLock.lock();
+        try {
+            delegate.updateSegmentMaxKey(segmentId, newMaxKey);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
-    public boolean applyRouteSplit(final RouteSplitPlan<K> plan) {
-        return withWriteLock(() -> delegate.applyRouteSplit(plan));
+    @Override
+    public boolean tryApplySplitPlan(final RouteSplitPlan<K> plan) {
+        writeLock.lock();
+        try {
+            return delegate.tryApplySplitPlan(plan);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     /**
@@ -154,21 +144,13 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
      *
      * @param segmentId segment id to remove
      */
-    public void removeSegment(final SegmentId segmentId) {
-        withWriteLock(() -> delegate.removeSegment(segmentId));
-    }
-
-    /**
-     * Returns a stream of key-to-segment mappings.
-     *
-     * @return stream of entries
-     */
-    public Stream<Entry<K, SegmentId>> getSegmentsAsStream() {
-        readLock.lock();
+    @Override
+    public void removeSegmentRoute(final SegmentId segmentId) {
+        writeLock.lock();
         try {
-            return delegate.getSegmentsAsStream();
+            delegate.removeSegmentRoute(segmentId);
         } finally {
-            readLock.unlock();
+            writeLock.unlock();
         }
     }
 
@@ -177,6 +159,7 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
      *
      * @return ordered list of segment ids
      */
+    @Override
     public List<SegmentId> getSegmentIds() {
         readLock.lock();
         try {
@@ -192,6 +175,7 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
      * @param segmentWindow window to apply
      * @return ordered list of segment ids
      */
+    @Override
     public List<SegmentId> getSegmentIds(final SegmentWindow segmentWindow) {
         readLock.lock();
         try {
@@ -204,12 +188,23 @@ public final class KeyToSegmentMapSynchronizedAdapter<K>
     /**
      * Flushes the mapping to disk if it has changed.
      */
-    public void optionalyFlush() {
-        withWriteLock(delegate::optionallyFlush);
+    @Override
+    public void flushIfDirty() {
+        writeLock.lock();
+        try {
+            delegate.flushIfDirty();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     @Override
     protected void doClose() {
-        withWriteLock(delegate::close);
+        writeLock.lock();
+        try {
+            delegate.close();
+        } finally {
+            writeLock.unlock();
+        }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/Snapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/Snapshot.java
@@ -1,0 +1,45 @@
+package org.hestiastore.index.segmentindex.mapping;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.segment.SegmentId;
+import org.hestiastore.index.segmentindex.SegmentWindow;
+
+/**
+ * Immutable point-in-time view of a {@link KeyToSegmentMapImpl} routing
+ * topology.
+ *
+ * @param <K> key type
+ */
+public final class Snapshot<K> {
+
+    private final TreeMap<K, SegmentId> map;
+    private final long version;
+
+    Snapshot(final TreeMap<K, SegmentId> map, final long version) {
+        this.map = Vldtn.requireNonNull(map, "map");
+        this.version = version;
+    }
+
+    public SegmentId findSegmentIdForKey(final K key) {
+        Vldtn.requireNonNull(key, "key");
+        final Map.Entry<K, SegmentId> ceilingEntry = map.ceilingEntry(key);
+        return ceilingEntry == null ? null : ceilingEntry.getValue();
+    }
+
+    public List<SegmentId> getSegmentIds(final SegmentWindow segmentWindow) {
+        Vldtn.requireNonNull(segmentWindow, "segmentWindow");
+        return map.entrySet().stream()//
+                .skip(segmentWindow.getIntOffset())//
+                .limit(segmentWindow.getIntLimit())//
+                .map(entry -> entry.getValue())//
+                .toList();
+    }
+
+    public long version() {
+        return version;
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/split/RouteSplitCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/split/RouteSplitCoordinator.java
@@ -18,7 +18,7 @@ import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.IndexConfigurationContract;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -41,7 +41,7 @@ public final class RouteSplitCoordinator<K, V> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final IndexConfiguration<K, V> conf;
     private final Comparator<K> keyComparator;
-    private final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap;
+    private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final SegmentIndexSplitPolicy<K, V> splitPolicy;
     private final IndexRetryPolicy retryPolicy;
@@ -53,7 +53,7 @@ public final class RouteSplitCoordinator<K, V> {
 
     public RouteSplitCoordinator(final IndexConfiguration<K, V> conf,
             final Comparator<K> keyComparator,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry) {
         this(conf, keyComparator, keyToSegmentMap, segmentRegistry,
                 new SegmentIndexSplitPolicyThreshold<>());
@@ -61,7 +61,7 @@ public final class RouteSplitCoordinator<K, V> {
 
     public RouteSplitCoordinator(final IndexConfiguration<K, V> conf,
             final Comparator<K> keyComparator,
-            final KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap,
+            final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final SegmentIndexSplitPolicy<K, V> splitPolicy) {
         this.conf = Vldtn.requireNonNull(conf, "conf");
@@ -149,7 +149,7 @@ public final class RouteSplitCoordinator<K, V> {
                     splitPlan.getUpperSegmentId().orElse(null));
             return false;
         }
-        keyToSegmentMap.optionalyFlush();
+        keyToSegmentMap.flushIfDirty();
         deleteRetiredParentSegment(splitPlan.getReplacedSegmentId());
         if (logger.isDebugEnabled()) {
             logger.debug(
@@ -235,7 +235,7 @@ public final class RouteSplitCoordinator<K, V> {
     private boolean publishRouteSplit(final RouteSplitPlan<K> splitPlan) {
         Vldtn.requireNonNull(splitPlan, "splitPlan");
         try {
-            if (!keyToSegmentMap.applyRouteSplit(splitPlan)) {
+            if (!keyToSegmentMap.tryApplySplitPlan(splitPlan)) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(
                             "Route split publish returned false: replacedSegmentId='{}' lowerSegmentId='{}' upperSegmentId='{}'",

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexSimpleTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexSimpleTest.java
@@ -29,7 +29,7 @@ import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentMaintenancePolicy;
 import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segment.SegmentResultStatus;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +70,7 @@ class IntegrationSegmentIndexSimpleTest {
         index1.close();
 
         final Directory asyncDirectory = directory;
-        final KeyToSegmentMap<Integer> keyToSegmentMap = new KeyToSegmentMap<>(
+        final KeyToSegmentMapImpl<Integer> keyToSegmentMap = new KeyToSegmentMapImpl<>(
                 asyncDirectory, tdi);
         final List<SegmentId> segmentIds = keyToSegmentMap.getSegmentIds();
         assertEquals(expectedFileCount(segmentIds.size()),

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitCoordinatorTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentState;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentindex.split.RouteSplitCoordinator;
@@ -30,9 +31,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class BackgroundSplitCoordinatorTest {
 
     @Mock
-    private KeyToSegmentMap<String> keyToSegmentMap;
+    private KeyToSegmentMapImpl<String> keyToSegmentMap;
 
-    private KeyToSegmentMapSynchronizedAdapter<String> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMap<String> synchronizedKeyToSegmentMap;
 
     @Mock
     private Segment<String, String> segment;

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitPolicyLoopTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/BackgroundSplitPolicyLoopTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
@@ -32,7 +33,7 @@ class BackgroundSplitPolicyLoopTest {
     private RuntimeTuningState runtimeTuningState;
 
     @Mock
-    private KeyToSegmentMap<String> keyToSegmentMap;
+    private KeyToSegmentMapImpl<String> keyToSegmentMap;
 
     @Mock
     private SegmentRegistry<String, String> segmentRegistry;
@@ -43,7 +44,7 @@ class BackgroundSplitPolicyLoopTest {
     @Mock
     private ScheduledExecutorService splitPolicyScheduler;
 
-    private KeyToSegmentMapSynchronizedAdapter<String> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMap<String> synchronizedKeyToSegmentMap;
 
     @BeforeEach
     void setUp() {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/DirectSegmentReadCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/DirectSegmentReadCoordinatorTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.function.Supplier;
 
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DirectSegmentReadCoordinatorTest {
 
     @Mock
-    private KeyToSegmentMapSynchronizedAdapter<Integer> keyToSegmentMap;
+    private KeyToSegmentMap<Integer> keyToSegmentMap;
 
     @Mock
     private SegmentRegistry<Integer, String> segmentRegistry;

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/DirectSegmentWriteCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/DirectSegmentWriteCoordinatorTest.java
@@ -12,6 +12,7 @@ import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentId;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.junit.jupiter.api.AfterEach;
@@ -31,14 +32,15 @@ class DirectSegmentWriteCoordinatorTest {
     private BackgroundSplitCoordinator<Integer, String> backgroundSplitCoordinator;
 
     private Directory directory;
-    private KeyToSegmentMapSynchronizedAdapter<Integer> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMap<Integer> synchronizedKeyToSegmentMap;
     private DirectSegmentWriteCoordinator<Integer, String> coordinator;
 
     @BeforeEach
     void setUp() {
         directory = new MemDirectory();
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
-                new KeyToSegmentMap<>(directory, new TypeDescriptorInteger()));
+                new KeyToSegmentMapImpl<>(directory,
+                        new TypeDescriptorInteger()));
         stubAdmissionRunner();
         coordinator = new DirectSegmentWriteCoordinator<>(
                 synchronizedKeyToSegmentMap, stableSegmentGateway,
@@ -62,13 +64,13 @@ class DirectSegmentWriteCoordinatorTest {
 
         assertEquals(IndexResultStatus.OK, result.getStatus());
         assertEquals(SegmentId.of(0),
-                synchronizedKeyToSegmentMap.findSegmentId(11));
+                synchronizedKeyToSegmentMap.findSegmentIdForKey(11));
         verify(stableSegmentGateway).put(SegmentId.of(0), 11, "v11");
     }
 
     @Test
     void put_returnsBusyWhenStableSegmentRejectsWrite() {
-        synchronizedKeyToSegmentMap.insertKeyToSegment(10);
+        synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded(10);
         when(stableSegmentGateway.put(SegmentId.of(0), 10, "v10"))
                 .thenReturn(IndexResult.busy());
 
@@ -79,7 +81,7 @@ class DirectSegmentWriteCoordinatorTest {
 
     @Test
     void put_returnsBusyWhenRouteIsSplitBlocked() {
-        synchronizedKeyToSegmentMap.insertKeyToSegment(10);
+        synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded(10);
         when(backgroundSplitCoordinator.isSplitBlocked(SegmentId.of(0)))
                 .thenReturn(true);
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexConsistencyCheckerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexConsistencyCheckerTest.java
@@ -6,9 +6,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
-import java.util.stream.Stream;
+import java.util.List;
 
-import org.hestiastore.index.Entry;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
@@ -16,9 +15,10 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
-import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
+import org.hestiastore.index.segmentindex.IndexRetryPolicy;
+import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResultStatus;
@@ -39,24 +39,22 @@ class IndexConsistencyCheckerTest {
     @Mock
     private KeyToSegmentMap<Integer> keyToSegmentMap;
     @Mock
+    private Snapshot<Integer> snapshot;
+    @Mock
     private EntryIterator<Integer, String> iterator;
-
-    private KeyToSegmentMapSynchronizedAdapter<Integer> synchronizedKeyToSegmentMap;
 
     private IndexConsistencyChecker<Integer, String> checker;
 
     @BeforeEach
     void setUp() {
-        synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
-                keyToSegmentMap);
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
-                segmentRegistry, new TypeDescriptorInteger());
+        when(keyToSegmentMap.snapshot()).thenReturn(snapshot);
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap, segmentRegistry,
+                new TypeDescriptorInteger());
     }
 
     @AfterEach
     void tearDown() {
         checker = null;
-        synchronizedKeyToSegmentMap = null;
     }
 
     @Test
@@ -65,31 +63,32 @@ class IndexConsistencyCheckerTest {
         when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
                 .thenReturn(SegmentResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(false);
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(10, SegmentId.of(1))));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SegmentId.of(1)));
         when(segmentRegistry.getSegment(SegmentId.of(1)))
                 .thenReturn(SegmentRegistryResult.ok(segment));
 
         checker.checkAndRepairConsistency();
 
-        verify(keyToSegmentMap).removeSegment(SegmentId.of(1));
-        verify(keyToSegmentMap).optionallyFlush();
+        verify(keyToSegmentMap).removeSegmentRoute(SegmentId.of(1));
+        verify(keyToSegmentMap).flushIfDirty();
         verify(segmentRegistry).deleteSegment(SegmentId.of(1));
     }
 
     @Test
     void busySegmentLoad_retriesUntilSegmentIsAvailable() {
         when(segment.checkAndRepairConsistency()).thenReturn(10);
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(10, SegmentId.of(1))));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SegmentId.of(1)));
+        when(snapshot.findSegmentIdForKey(10)).thenReturn(SegmentId.of(1));
         when(segmentRegistry.getSegment(SegmentId.of(1)))
                 .thenReturn(SegmentRegistryResult
                         .fromStatus(SegmentRegistryResultStatus.BUSY))
                 .thenReturn(SegmentRegistryResult.ok(segment));
 
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
-                segmentRegistry, new TypeDescriptorInteger(),
-                segmentId -> true, new IndexRetryPolicy(1, 20));
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap, segmentRegistry,
+                new TypeDescriptorInteger(), segmentId -> true,
+                new IndexRetryPolicy(1, 20));
 
         checker.checkAndRepairConsistency();
 
@@ -103,14 +102,14 @@ class IndexConsistencyCheckerTest {
                 .thenReturn(SegmentResult.busy())
                 .thenReturn(SegmentResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(false);
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(10, SegmentId.of(1))));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SegmentId.of(1)));
         when(segmentRegistry.getSegment(SegmentId.of(1)))
                 .thenReturn(SegmentRegistryResult.ok(segment));
 
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
-                segmentRegistry, new TypeDescriptorInteger(),
-                segmentId -> true, new IndexRetryPolicy(1, 20));
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap, segmentRegistry,
+                new TypeDescriptorInteger(), segmentId -> true,
+                new IndexRetryPolicy(1, 20));
 
         checker.checkAndRepairConsistency();
 
@@ -120,15 +119,15 @@ class IndexConsistencyCheckerTest {
 
     @Test
     void busySegmentLoad_timesOutWithRetryPolicyMessage() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(10, SegmentId.of(1))));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SegmentId.of(1)));
         when(segmentRegistry.getSegment(SegmentId.of(1)))
                 .thenReturn(SegmentRegistryResult
                         .fromStatus(SegmentRegistryResultStatus.BUSY));
 
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
-                segmentRegistry, new TypeDescriptorInteger(),
-                segmentId -> true, new IndexRetryPolicy(1, 1));
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap, segmentRegistry,
+                new TypeDescriptorInteger(), segmentId -> true,
+                new IndexRetryPolicy(1, 1));
 
         final IndexException ex = assertThrows(IndexException.class,
                 () -> checker.checkAndRepairConsistency());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexMaintenanceCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexMaintenanceCoordinatorTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class IndexMaintenanceCoordinatorTest {
 
     @Mock
-    private KeyToSegmentMapSynchronizedAdapter<Integer> keyToSegmentMap;
+    private KeyToSegmentMap<Integer> keyToSegmentMap;
 
     @Mock
     private BackgroundSplitCoordinator<Integer, String> backgroundSplitCoordinator;
@@ -38,7 +38,7 @@ class IndexMaintenanceCoordinatorTest {
     private IndexWalCoordinator<Integer, String> walCoordinator;
 
     @Mock
-    private KeyToSegmentMap.Snapshot<Integer> snapshot;
+    private Snapshot<Integer> snapshot;
 
     private IndexMaintenanceCoordinator<Integer, String> coordinator;
 
@@ -75,14 +75,14 @@ class IndexMaintenanceCoordinatorTest {
     void flushAndWait_retriesStableFlushWhenTopologyChanges() {
         when(keyToSegmentMap.snapshot()).thenReturn(snapshot);
         when(snapshot.version()).thenReturn(11L);
-        when(keyToSegmentMap.isVersion(anyLong())).thenReturn(false);
+        when(keyToSegmentMap.isAtVersion(anyLong())).thenReturn(false);
 
         coordinator.flushAndWait();
 
         verify(backgroundSplitPolicyLoop, times(2)).awaitExhausted();
         verify(stableSegmentCoordinator, times(2)).flushMappedSegmentsAndWait();
         verify(backgroundSplitPolicyLoop).scheduleScanIfIdle();
-        verify(keyToSegmentMap).optionalyFlush();
+        verify(keyToSegmentMap).flushIfDirty();
         verify(walCoordinator).checkpoint();
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/IndexRecoveryCleanupCoordinatorTest.java
@@ -12,6 +12,7 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentDirectoryLayout;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
@@ -31,14 +32,14 @@ class IndexRecoveryCleanupCoordinatorTest {
     private SegmentRegistry<Integer, String> segmentRegistry;
 
     private Directory directory;
-    private KeyToSegmentMap<Integer> keyToSegmentMap;
-    private KeyToSegmentMapSynchronizedAdapter<Integer> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMapImpl<Integer> keyToSegmentMap;
+    private KeyToSegmentMap<Integer> synchronizedKeyToSegmentMap;
     private IndexRecoveryCleanupCoordinator<Integer, String> coordinator;
 
     @BeforeEach
     void setUp() {
         directory = new MemDirectory();
-        keyToSegmentMap = new KeyToSegmentMap<>(directory,
+        keyToSegmentMap = new KeyToSegmentMapImpl<>(directory,
                 new TypeDescriptorInteger());
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
@@ -59,7 +60,7 @@ class IndexRecoveryCleanupCoordinatorTest {
 
     @Test
     void cleanupOrphanedSegmentDirectories_deletesOnlyUnmappedNonBootstrapDirectories() {
-        keyToSegmentMap.insertKeyToSegment(1);
+        synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded(1);
         directory.mkdir("segment-00000");
         directory.mkdir("segment-00003");
         when(segmentRegistry.deleteSegment(SegmentId.of(3)))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexAsyncMaintenanceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexAsyncMaintenanceTest.java
@@ -31,7 +31,7 @@ import org.hestiastore.index.segment.SegmentRuntimeSnapshot;
 import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistryCache;
 import org.hestiastore.index.segmentregistry.SegmentRegistryImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -72,7 +72,7 @@ class SegmentIndexAsyncMaintenanceTest {
             index.flushAndWait();
 
             final SegmentId segmentId = readKeyToSegmentMap(index)
-                    .findSegmentId(1);
+                    .findSegmentIdForKey(1);
             final SegmentRegistryImpl<Integer, String> registry = readSegmentRegistry(
                     index);
             final Segment<Integer, String> originalSegment = registry
@@ -105,7 +105,7 @@ class SegmentIndexAsyncMaintenanceTest {
             index.flushAndWait();
 
             final SegmentId segmentId = readKeyToSegmentMap(index)
-                    .findSegmentId(1);
+                    .findSegmentIdForKey(1);
             final SegmentRegistryImpl<Integer, String> registry = readSegmentRegistry(
                     index);
             final Segment<Integer, String> originalSegment = registry
@@ -151,7 +151,7 @@ class SegmentIndexAsyncMaintenanceTest {
             index.flushAndWait();
 
             final SegmentId segmentId = readKeyToSegmentMap(index)
-                    .findSegmentId(1);
+                    .findSegmentIdForKey(1);
             final SegmentRegistryImpl<Integer, String> registry = readSegmentRegistry(
                     index);
             final Segment<Integer, String> originalSegment = registry
@@ -303,7 +303,7 @@ class SegmentIndexAsyncMaintenanceTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static <K, V> KeyToSegmentMapSynchronizedAdapter<K> readKeyToSegmentMap(
+    private static <K, V> KeyToSegmentMap<K> readKeyToSegmentMap(
             final SegmentIndexImpl<K, V> index) {
         return index.keyToSegmentMap();
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexConsistencyCheckerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexConsistencyCheckerTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
@@ -20,7 +20,8 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.Snapshot;
+import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.hestiastore.index.segmentregistry.SegmentRegistryResult;
 import org.junit.jupiter.api.AfterEach;
@@ -39,8 +40,8 @@ class SegmentIndexConsistencyCheckerTest {
 
     @Mock
     private KeyToSegmentMap<Integer> keyToSegmentMap;
-
-    private KeyToSegmentMapSynchronizedAdapter<Integer> synchronizedKeyToSegmentMap;
+    @Mock
+    private Snapshot<Integer> snapshot;
 
     @Mock
     private SegmentRegistry<Integer, String> segmentRegistry;
@@ -48,13 +49,12 @@ class SegmentIndexConsistencyCheckerTest {
     @Mock
     private Segment<Integer, String> segment;
 
-    private Entry<Integer, SegmentId> segmentPair;
-
     private IndexConsistencyChecker<Integer, String> checker;
 
     @Test
     void test_noSegments() {
-        when(keyToSegmentMap.getSegmentsAsStream()).thenReturn(Stream.empty());
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of());
 
         checker.checkAndRepairConsistency();
 
@@ -63,8 +63,8 @@ class SegmentIndexConsistencyCheckerTest {
 
     @Test
     void test_missingSegment() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(segmentPair));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SEGMENT_ID));
         when(segmentRegistry.getSegment(SEGMENT_ID))
                 .thenReturn(SegmentRegistryResult.error());
 
@@ -79,23 +79,9 @@ class SegmentIndexConsistencyCheckerTest {
     }
 
     @Test
-    void test_oneSegment_segmentKey_is_null() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(null, SEGMENT_ID)));
-
-        final Exception e = assertThrows(IndexException.class,
-                () -> checker.checkAndRepairConsistency());
-
-        assertEquals(
-                "Index is broken. " + "File 'index.map' containing information "
-                        + "about segments is corrupted. Segment key is null.",
-                e.getMessage());
-    }
-
-    @Test
     void test_oneSegment_segmentId_is_null() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(Entry.of(SEGMENT_MAX_KEY, null)));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(Collections.singletonList(null));
 
         final Exception e = assertThrows(IndexException.class,
                 () -> checker.checkAndRepairConsistency());
@@ -108,8 +94,8 @@ class SegmentIndexConsistencyCheckerTest {
 
     @Test
     void test_oneSegment_segmentMaxKey_is_null_removes_segment() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(segmentPair));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SEGMENT_ID));
         when(segmentRegistry.getSegment(SEGMENT_ID))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.checkAndRepairConsistency()).thenReturn(null);
@@ -120,35 +106,39 @@ class SegmentIndexConsistencyCheckerTest {
         checker.checkAndRepairConsistency();
 
         verify(segmentRegistry).deleteSegment(SEGMENT_ID);
-        verify(keyToSegmentMap).removeSegment(SEGMENT_ID);
-        verify(keyToSegmentMap).optionallyFlush();
+        verify(keyToSegmentMap).removeSegmentRoute(SEGMENT_ID);
+        verify(keyToSegmentMap).flushIfDirty();
     }
 
     @Test
     void test_oneSegment_segmentMaxKeyIsHigher() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(segmentPair));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SEGMENT_ID));
         when(segmentRegistry.getSegment(SEGMENT_ID))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.checkAndRepairConsistency())
                 .thenReturn(SEGMENT_MAX_KEY + 1);
+        when(snapshot.findSegmentIdForKey(SEGMENT_MAX_KEY + 1))
+                .thenReturn(null);
 
         final Exception e = assertThrows(IndexException.class,
                 () -> checker.checkAndRepairConsistency());
 
         assertEquals("Index is broken. File 'index.map' containing information "
                 + "about segments is corrupted. Segment 'segment-00013' "
-                + "has a max key of '73', which is less "
-                + "than the max key '74' from the index data.", e.getMessage());
+                + "contains max key '74', which routes to segment 'null' "
+                + "in the index map.", e.getMessage());
     }
 
     @Test
     void test_oneSegment() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(segmentPair));
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SEGMENT_ID));
         when(segmentRegistry.getSegment(SEGMENT_ID))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.checkAndRepairConsistency()).thenReturn(SEGMENT_MAX_KEY);
+        when(snapshot.findSegmentIdForKey(SEGMENT_MAX_KEY))
+                .thenReturn(SEGMENT_ID);
 
         checker.checkAndRepairConsistency();
 
@@ -157,9 +147,9 @@ class SegmentIndexConsistencyCheckerTest {
 
     @Test
     void test_segmentFilteredOut_isSkippedWithoutLoading() {
-        when(keyToSegmentMap.getSegmentsAsStream())
-                .thenReturn(Stream.of(segmentPair));
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
+        when(snapshot.getSegmentIds(SegmentWindow.unbounded()))
+                .thenReturn(List.of(SEGMENT_ID));
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap,
                 segmentRegistry, TYPE_DESCRIPTOR_INTEGER, segmentId -> false);
 
         checker.checkAndRepairConsistency();
@@ -171,17 +161,13 @@ class SegmentIndexConsistencyCheckerTest {
 
     @BeforeEach
     void setUp() {
-        synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
-                keyToSegmentMap);
-        checker = new IndexConsistencyChecker<>(synchronizedKeyToSegmentMap,
-                segmentRegistry, TYPE_DESCRIPTOR_INTEGER);
-        segmentPair = Entry.of(SEGMENT_MAX_KEY, SEGMENT_ID);
+        when(keyToSegmentMap.snapshot()).thenReturn(snapshot);
+        checker = new IndexConsistencyChecker<>(keyToSegmentMap, segmentRegistry,
+                TYPE_DESCRIPTOR_INTEGER);
     }
 
     @AfterEach
     void tearDown() {
         checker = null;
-        segmentPair = null;
-        synchronizedKeyToSegmentMap = null;
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexImplPutTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexImplPutTest.java
@@ -23,7 +23,7 @@ import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.Wal;
 import org.hestiastore.index.segmentindex.WalDurabilityMode;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistryImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,16 +74,16 @@ class SegmentIndexImplPutTest {
         index.put(5, "e");
         index.flushAndWait();
 
-        final KeyToSegmentMapSynchronizedAdapter<Integer> cache = readKeyToSegmentMap(
+        final KeyToSegmentMap<Integer> cache = readKeyToSegmentMap(
                 index);
         final SegmentRegistryImpl<Integer, String> registry = readSegmentRegistry(
                 index);
-        final SegmentId segmentId = cache.findSegmentId(1);
+        final SegmentId segmentId = cache.findSegmentIdForKey(1);
         final Segment<Integer, String> segment = registry.getSegment(segmentId)
                 .getValue();
         awaitSegmentReady(segment);
         awaitSegmentCount(cache, 2);
-        assertEquals(SegmentId.of(1), cache.findSegmentId(1));
+        assertEquals(SegmentId.of(1), cache.findSegmentIdForKey(1));
     }
 
     @Test
@@ -249,7 +249,7 @@ class SegmentIndexImplPutTest {
     }
 
     private static void awaitSegmentCount(
-            final KeyToSegmentMapSynchronizedAdapter<Integer> cache,
+            final KeyToSegmentMap<Integer> cache,
             final int expectedCount) {
         final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (System.nanoTime() < deadline) {
@@ -280,7 +280,7 @@ class SegmentIndexImplPutTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static <K, V> KeyToSegmentMapSynchronizedAdapter<K> readKeyToSegmentMap(
+    private static <K, V> KeyToSegmentMap<K> readKeyToSegmentMap(
             final SegmentIndexImpl<K, V> index) {
         return index.keyToSegmentMap();
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexImplRetryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexImplRetryTest.java
@@ -19,7 +19,7 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistryCache;
 import org.hestiastore.index.segmentregistry.SegmentRegistryImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -57,9 +57,9 @@ class SegmentIndexImplRetryTest {
         index.put(1, "one");
         index.flushAndWait();
 
-        final KeyToSegmentMapSynchronizedAdapter<Integer> cache = readKeyToSegmentMap(
+        final KeyToSegmentMap<Integer> cache = readKeyToSegmentMap(
                 index);
-        final SegmentId segmentId = cache.findSegmentId(1);
+        final SegmentId segmentId = cache.findSegmentIdForKey(1);
         final SegmentRegistryImpl<Integer, String> registry = readSegmentRegistry(
                 index);
         final Segment<Integer, String> original = registry.getSegment(segmentId)
@@ -149,7 +149,7 @@ class SegmentIndexImplRetryTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static <K, V> KeyToSegmentMapSynchronizedAdapter<K> readKeyToSegmentMap(
+    private static <K, V> KeyToSegmentMap<K> readKeyToSegmentMap(
             final SegmentIndexImpl<K, V> index) {
         return index.keyToSegmentMap();
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexRuntimeBuilderTest.java
@@ -19,7 +19,7 @@ import org.hestiastore.index.segmentindex.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.Wal;
 import org.hestiastore.index.segmentindex.WalDurabilityMode;
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +72,7 @@ class SegmentIndexRuntimeBuilderTest {
 
     @Test
     void buildClosesCreatedResourcesWhenLaterAssemblyFails() {
-        final AtomicReference<KeyToSegmentMapSynchronizedAdapter<Integer>> keyToSegmentMapRef = new AtomicReference<>();
+        final AtomicReference<KeyToSegmentMap<Integer>> keyToSegmentMapRef = new AtomicReference<>();
         final AtomicReference<WalRuntime<Integer, String>> walRuntimeRef = new AtomicReference<>();
         final RuntimeException failure = new IllegalStateException("boom");
         final SegmentIndexRuntimeBuilder<Integer, String> builder = newBuilder(
@@ -80,7 +80,7 @@ class SegmentIndexRuntimeBuilderTest {
                 }, new SegmentIndexRuntimeBuilder.BuildObserver<>() {
                     @Override
                     public void onKeyToSegmentMapCreated(
-                            final KeyToSegmentMapSynchronizedAdapter<Integer> keyToSegmentMap) {
+                            final KeyToSegmentMap<Integer> keyToSegmentMap) {
                         keyToSegmentMapRef.set(keyToSegmentMap);
                     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexTestAccess.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/SegmentIndexTestAccess.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segmentindex.core;
 
-import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.hestiastore.index.segmentregistry.SegmentRegistryImpl;
 
@@ -12,7 +12,7 @@ public final class SegmentIndexTestAccess {
     private SegmentIndexTestAccess() {
     }
 
-    public static <K> KeyToSegmentMapSynchronizedAdapter<K> keyToSegmentMap(
+    public static <K> KeyToSegmentMap<K> keyToSegmentMap(
             final SegmentIndexImpl<K, ?> index) {
         return index.keyToSegmentMap();
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentCoordinatorTest.java
@@ -20,6 +20,7 @@ import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
 import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
@@ -48,15 +49,15 @@ class StableSegmentCoordinatorTest {
     private Segment<String, String> segment;
 
     private Directory directory;
-    private KeyToSegmentMap<String> keyToSegmentMap;
-    private KeyToSegmentMapSynchronizedAdapter<String> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMapImpl<String> keyToSegmentMap;
+    private KeyToSegmentMap<String> synchronizedKeyToSegmentMap;
     private StableSegmentCoordinator<String, String> coordinator;
     private Stats stats;
 
     @BeforeEach
     void setUp() {
         directory = new MemDirectory();
-        keyToSegmentMap = new KeyToSegmentMap<>(directory,
+        keyToSegmentMap = new KeyToSegmentMapImpl<>(directory,
                 new TypeDescriptorShortString());
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
@@ -78,7 +79,7 @@ class StableSegmentCoordinatorTest {
 
     @Test
     void putEntryForDrain_writesToLoadedSegment() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.put("key", "value")).thenReturn(SegmentResult.ok());
@@ -90,7 +91,7 @@ class StableSegmentCoordinatorTest {
 
     @Test
     void invalidateIterators_invalidatesLoadedMappedSegments() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
 
@@ -101,7 +102,7 @@ class StableSegmentCoordinatorTest {
 
     @Test
     void openIteratorWithRetry_returnsIteratorFromCore() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         final EntryIterator<String, String> iterator = EntryIterator
                 .make(List.<Entry<String, String>>of().iterator());
         when(stableSegmentGateway.openIterator(segmentId,
@@ -117,7 +118,7 @@ class StableSegmentCoordinatorTest {
 
     @Test
     void flushSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         coordinator = new StableSegmentCoordinator<>(
                 LoggerFactory.getLogger(StableSegmentCoordinatorTest.class),
                 synchronizedKeyToSegmentMap, segmentRegistry,
@@ -136,7 +137,7 @@ class StableSegmentCoordinatorTest {
 
     @Test
     void compactSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         coordinator = new StableSegmentCoordinator<>(
                 LoggerFactory.getLogger(StableSegmentCoordinatorTest.class),
                 synchronizedKeyToSegmentMap, segmentRegistry,
@@ -161,5 +162,10 @@ class StableSegmentCoordinatorTest {
             final int safeIndex = Math.min(current, nanos.length - 1);
             return nanos[safeIndex];
         };
+    }
+
+    private SegmentId createBootstrapSegment(final String key) {
+        synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded(key);
+        return synchronizedKeyToSegmentMap.findSegmentIdForKey(key);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentGatewayTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/StableSegmentGatewayTest.java
@@ -17,6 +17,7 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segment.SegmentResult;
+import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapImpl;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMapSynchronizedAdapter;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
@@ -38,14 +39,14 @@ class StableSegmentGatewayTest {
     private Segment<String, String> segment;
 
     private Directory asyncDirectory;
-    private KeyToSegmentMap<String> keyToSegmentMap;
-    private KeyToSegmentMapSynchronizedAdapter<String> synchronizedKeyToSegmentMap;
+    private KeyToSegmentMapImpl<String> keyToSegmentMap;
+    private KeyToSegmentMap<String> synchronizedKeyToSegmentMap;
     private StableSegmentGateway<String, String> stableSegmentGateway;
 
     @BeforeEach
     void setUp() {
         asyncDirectory = new MemDirectory();
-        keyToSegmentMap = new KeyToSegmentMap<>(asyncDirectory,
+        keyToSegmentMap = new KeyToSegmentMapImpl<>(asyncDirectory,
                 new TypeDescriptorShortString());
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
@@ -77,7 +78,7 @@ class StableSegmentGatewayTest {
 
     @Test
     void get_returnsBusyWhenSegmentIsBusy() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.get("key")).thenReturn(SegmentResult.busy());
@@ -89,11 +90,11 @@ class StableSegmentGatewayTest {
 
     @Test
     void get_returnsBusyWhenMappingChangesDuringRead() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.get("key")).thenAnswer(invocation -> {
-            synchronizedKeyToSegmentMap.updateSegmentMaxKey(segmentId, "key-2");
+            synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded("key-2");
             return SegmentResult.ok("value");
         });
 
@@ -104,7 +105,7 @@ class StableSegmentGatewayTest {
 
     @Test
     void put_returnsOkWhenSegmentAcceptsWrite() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.put("key", "value")).thenReturn(SegmentResult.ok());
@@ -117,7 +118,7 @@ class StableSegmentGatewayTest {
 
     @Test
     void put_returnsBusyWhenSegmentRejectsWrite() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         when(segmentRegistry.getSegment(segmentId))
                 .thenReturn(SegmentRegistryResult.ok(segment));
         when(segment.put("key", "value")).thenReturn(SegmentResult.busy());
@@ -130,7 +131,7 @@ class StableSegmentGatewayTest {
 
     @Test
     void openIterator_returnsValueWhenOk() {
-        final SegmentId segmentId = keyToSegmentMap.insertKeyToSegment("key");
+        final SegmentId segmentId = createBootstrapSegment("key");
         final EntryIterator<String, String> iterator = EntryIterator
                 .make(List.<Entry<String, String>>of().iterator());
         when(segmentRegistry.getSegment(segmentId))
@@ -143,5 +144,10 @@ class StableSegmentGatewayTest {
 
         assertEquals(IndexResultStatus.OK, result.getStatus());
         assertSame(iterator, result.getValue());
+    }
+
+    private SegmentId createBootstrapSegment(final String key) {
+        synchronizedKeyToSegmentMap.extendMaxKeyIfNeeded(key);
+        return synchronizedKeyToSegmentMap.findSegmentIdForKey(key);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapLifecycleTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapLifecycleTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 
 class KeyToSegmentMapLifecycleTest {
 
-    private KeyToSegmentMap<Integer> keyToSegmentMap;
+    private KeyToSegmentMapImpl<Integer> keyToSegmentMap;
 
     @BeforeEach
     void setUp() {
         final MemDirectory directory = new MemDirectory();
-        keyToSegmentMap = new KeyToSegmentMap<>(directory,
+        keyToSegmentMap = new KeyToSegmentMapImpl<>(directory,
                 new TypeDescriptorInteger());
     }
 
@@ -29,11 +29,11 @@ class KeyToSegmentMapLifecycleTest {
     }
 
     @Test
-    void findSegmentIdThrowsAfterClose() {
+    void findSegmentIdForKeyThrowsAfterClose() {
         keyToSegmentMap.close();
         final Exception e = assertThrows(IllegalStateException.class,
-                () -> keyToSegmentMap.findSegmentId(1));
-        assertEquals("KeyToSegmentMap already closed", e.getMessage());
+                () -> keyToSegmentMap.findSegmentIdForKey(1));
+        assertEquals("KeyToSegmentMapImpl already closed", e.getMessage());
     }
 
     @Test
@@ -45,9 +45,9 @@ class KeyToSegmentMapLifecycleTest {
     }
 
     @Test
-    void optionalyFlushThrowsAfterClose() {
+    void flushIfDirtyThrowsAfterClose() {
         keyToSegmentMap.close();
         assertThrows(IllegalStateException.class,
-                () -> keyToSegmentMap.optionallyFlush());
+                () -> keyToSegmentMap.flushIfDirty());
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSanityCheckTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSanityCheckTest.java
@@ -42,10 +42,10 @@ class KeyToSegmentMapSanityCheckTest {
 
     }
 
-    private static KeyToSegmentMap<String> createKeyToSegmentMap(
+    private static KeyToSegmentMapImpl<String> createKeyToSegmentMap(
             final Directory directory,
             final TypeDescriptorShortString keyTypeDescriptor) {
-        return new KeyToSegmentMap<>(directory, keyTypeDescriptor);
+        return new KeyToSegmentMapImpl<>(directory, keyTypeDescriptor);
     }
 
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSplitConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSplitConcurrencyTest.java
@@ -31,7 +31,8 @@ class KeyToSegmentMapSplitConcurrencyTest {
 
     @BeforeEach
     void setUp() {
-        final KeyToSegmentMap<Integer> rawKeyMap = newCacheWithEntries(List.of(
+        final KeyToSegmentMapImpl<Integer> rawKeyMap = newCacheWithEntries(
+                List.of(
                 Entry.of(10, SegmentId.of(1)),
                 Entry.of(30, SegmentId.of(2))));
         adapter = new KeyToSegmentMapSynchronizedAdapter<>(rawKeyMap);
@@ -65,7 +66,7 @@ class KeyToSegmentMapSplitConcurrencyTest {
             ready.countDown();
             await(start);
             for (int i = 0; i < 1_000; i++) {
-                if (adapter.findSegmentId(5) == null) {
+                if (adapter.findSegmentIdForKey(5) == null) {
                     missing.set(true);
                     break;
                 }
@@ -91,8 +92,8 @@ class KeyToSegmentMapSplitConcurrencyTest {
         assertTrue(await(startedOps, 5),
                 "Workers did not perform initial ops in time");
 
-        assertTrue(adapter.applyRouteSplit(plan));
-        adapter.optionalyFlush();
+        assertTrue(adapter.tryApplySplitPlan(plan));
+        adapter.flushIfDirty();
 
         awaitFuture(reader, "Reader did not finish in time");
         awaitFuture(writer, "Writer did not finish in time");
@@ -125,7 +126,7 @@ class KeyToSegmentMapSplitConcurrencyTest {
         }
     }
 
-    private KeyToSegmentMap<Integer> newCacheWithEntries(
+    private KeyToSegmentMapImpl<Integer> newCacheWithEntries(
             final List<Entry<Integer, SegmentId>> entries) {
         final MemDirectory dir = new MemDirectory();
         final SortedDataFile<Integer, SegmentId> sdf = SortedDataFile
@@ -139,7 +140,7 @@ class KeyToSegmentMapSplitConcurrencyTest {
                 .execute(writer -> entries.stream().sorted(
                         (e1, e2) -> Integer.compare(e1.getKey(), e2.getKey()))
                         .forEach(writer::write));
-        return new KeyToSegmentMap<>(dir,
+        return new KeyToSegmentMapImpl<>(dir,
                 new TypeDescriptorInteger());
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapTest.java
@@ -23,7 +23,8 @@ class KeyToSegmentMapTest {
 
     @Test
     void insertSegmentRejectsDuplicateId() {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of());
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(
+                List.of());
         final SegmentId existingId = SegmentId.of(0);
         cache.insertSegment(5, existingId);
         assertThrows(IllegalArgumentException.class,
@@ -31,30 +32,30 @@ class KeyToSegmentMapTest {
     }
 
     @Test
-    void applySplitPlan_replaces_old_segment_with_lower_and_upper() {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of(
+    void tryApplySplitPlan_replacesOldSegmentWithLowerAndUpper() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
                 Entry.of(10, SegmentId.of(1)),
                 Entry.of(30, SegmentId.of(2))));
         final RouteSplitPlan<Integer> plan = new RouteSplitPlan<>(SegmentId.of(1),
                 SegmentId.of(3), SegmentId.of(4), 1, 5,
                 RouteSplitPlan.SplitMode.SPLIT);
 
-        assertTrue(cache.applyRouteSplit(plan));
+        assertTrue(cache.tryApplySplitPlan(plan));
 
         assertEquals(List.of(SegmentId.of(3), SegmentId.of(4), SegmentId.of(2)),
                 cache.getSegmentIds());
     }
 
     @Test
-    void applySplitPlan_replaces_old_segment_when_compacted() {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of(
+    void tryApplySplitPlan_replacesOldSegmentWhenCompacted() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
                 Entry.of(10, SegmentId.of(1)),
                 Entry.of(30, SegmentId.of(2))));
         final RouteSplitPlan<Integer> plan = new RouteSplitPlan<>(SegmentId.of(1),
                 SegmentId.of(3), null, 1, 10,
                 RouteSplitPlan.SplitMode.COMPACTED);
 
-        assertTrue(cache.applyRouteSplit(plan));
+        assertTrue(cache.tryApplySplitPlan(plan));
 
         assertEquals(List.of(SegmentId.of(3), SegmentId.of(2)),
                 cache.getSegmentIds());
@@ -62,7 +63,8 @@ class KeyToSegmentMapTest {
 
     @Test
     void synchronizedAdapterDelegatesToCache() {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of());
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(
+                List.of());
         final KeyToSegmentMapSynchronizedAdapter<Integer> adapter = new KeyToSegmentMapSynchronizedAdapter<>(
                 cache);
 
@@ -76,7 +78,8 @@ class KeyToSegmentMapTest {
 
     @Test
     void synchronizedAdapterHandlesConcurrentInsertions() throws Exception {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of());
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(
+                List.of());
         final KeyToSegmentMapSynchronizedAdapter<Integer> adapter = new KeyToSegmentMapSynchronizedAdapter<>(
                 cache);
         final int threads = 4;
@@ -120,24 +123,24 @@ class KeyToSegmentMapTest {
 
     @Test
     void snapshotRetainsSegmentOrderAfterLaterSplitMutation() {
-        final KeyToSegmentMap<Integer> cache = newCacheWithEntries(List.of(
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
                 Entry.of(10, SegmentId.of(1)),
                 Entry.of(20, SegmentId.of(2)),
                 Entry.of(30, SegmentId.of(3))));
-        final KeyToSegmentMap.Snapshot<Integer> snapshot = cache.snapshot();
+        final Snapshot<Integer> snapshot = cache.snapshot();
 
         final RouteSplitPlan<Integer> plan = new RouteSplitPlan<>(SegmentId.of(2),
                 SegmentId.of(4), SegmentId.of(5), 11, 15,
                 RouteSplitPlan.SplitMode.SPLIT);
-        assertTrue(cache.applyRouteSplit(plan));
+        assertTrue(cache.tryApplySplitPlan(plan));
 
         assertEquals(List.of(SegmentId.of(1), SegmentId.of(2), SegmentId.of(3)),
                 snapshot.getSegmentIds(SegmentWindow.unbounded()));
-        assertTrue(cache.isVersion(cache.snapshot().version()));
-        assertFalse(cache.isVersion(snapshot.version()));
+        assertTrue(cache.isAtVersion(cache.snapshot().version()));
+        assertFalse(cache.isAtVersion(snapshot.version()));
     }
 
-    private KeyToSegmentMap<Integer> newCacheWithEntries(
+    private KeyToSegmentMapImpl<Integer> newCacheWithEntries(
             final List<Entry<Integer, SegmentId>> entries) {
         final MemDirectory dir = new MemDirectory();
         final var sdf = org.hestiastore.index.sorteddatafile.SortedDataFile
@@ -153,7 +156,7 @@ class KeyToSegmentMapTest {
                 .execute(writer -> entries.stream().sorted(
                         (e1, e2) -> Integer.compare(e1.getKey(), e2.getKey()))
                         .forEach(writer::write));
-        return new KeyToSegmentMap<>(
+        return new KeyToSegmentMapImpl<>(
                 dir,
                 new TypeDescriptorInteger());
     }


### PR DESCRIPTION
## Summary
- extract `Snapshot` and rename `KeyToSegmentMap` implementation/interface types
- reduce the public mapping API and rename methods to match actual behavior
- update production callers, tests, and docs to the new mapping terminology

## Testing
- `mvn clean verify`