### PR TITLE
Refine synchronous segment close

### DIFF
--- a/docs/architecture/segment/segment-concurrency.md
+++ b/docs/architecture/segment/segment-concurrency.md
@@ -110,7 +110,7 @@ Segment can be accessd from multiple threads in paraell. Segment
 | `openIterator(INTERRUPT_FAST)` | `READY` | No | Throws on version change | Yes (snapshot) | Yes | Default mode. |
 | `openIterator(STOP_FAST)` | `READY` | No | Stops on version change | Yes (snapshot) | Yes | Snapshot captured at open time. |
 | `openIterator(EXCLUSIVE_ACCESS)` | `READY` | Yes (on lock acquisition) | Invalidates existing iterators; blocks others | Yes | Yes | Maintenance only; must be short. |
-| `close` | `READY` | No | Invalidates existing iterators; blocks others | N/A | N/A | Sets `FREEZE`, optionally flushes the write cache, schedules close on maintenance thread, then transitions to `CLOSED`. |
+| `close` | `READY` | No | Invalidates existing iterators; blocks others | N/A | N/A | Sets `FREEZE`, optionally flushes the write cache, completes close on the caller thread, then transitions to `CLOSED`. |
 
 ### Flush/Compact Lifecycle
 
@@ -209,8 +209,8 @@ Segment can be accessd from multiple threads in paraell. Segment
 - `SegmentCore.invalidateIterators()` bumps the version for explicit invalidation or exclusive access.
 
 ### Close Workflow
-- `SegmentImpl.close()` enters `FREEZE`, drains in-flight ops, freezes the write cache, and schedules `runClose(...)` on the maintenance executor.
-- `runClose(...)` flushes frozen data (if any), closes the core, transitions to `CLOSED`, and releases the segment lock.
+- `SegmentImpl.close()` enters `FREEZE`, drains in-flight ops, freezes the write cache, and completes close synchronously on the caller thread.
+- `closeInternal(...)` flushes frozen data (if any), closes the core, transitions to `CLOSED`, and releases the segment lock.
 
 ### Components
 - **Segment**: user-facing API (`put`, `get`, `openIterator`, `flush`,

--- a/docs/architecture/segmentindex/segment-index-concurrency.md
+++ b/docs/architecture/segmentindex/segment-index-concurrency.md
@@ -46,10 +46,12 @@
   default segment iterator isolation (FAIL_FAST). An overload allows
   FULL_ISOLATION for per-segment exclusivity; the stream must be closed to
   release the segment lock.
-- Segment close (async): once close starts, the segment drains in-flight work
-  and rejects/blocks new operations until CLOSED. The registry should not
-  reopen a closing segment; attempts should retry until the close completes.
-  The per-segment `.lock` file enforces single-open at the directory level.
+- Segment close (sync): once close starts, the segment drains in-flight work
+  and rejects/blocks new operations until CLOSED. The caller returns only
+  after locks/resources are released or the segment enters `ERROR`. The
+  registry should not reopen a closing segment; attempts should retry until
+  the close completes. The per-segment `.lock` file enforces single-open at
+  the directory level.
 
 ## Maintenance & Splits
 - SegmentIndex evaluates split thresholds after successful writes and schedules

--- a/engine/src/integration-test/java/org/hestiastore/index/it/IntegerationNumberOfKeysIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/IntegerationNumberOfKeysIT.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.it;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public class IntegerationNumberOfKeysIT {
         segment.compact();
 
         assertEquals(NUMBER_OF_TESTING_ENTRIES, segment.getNumberOfKeys());
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class IntegerationNumberOfKeysIT {
         Segment<String, Long> segment = getCommonBuilder();
         writeData(segment);
         segment.compact();
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
         segment = getCommonBuilder();
 
         assertEquals(NUMBER_OF_TESTING_ENTRIES, segment.getNumberOfKeys());
@@ -62,7 +62,7 @@ public class IntegerationNumberOfKeysIT {
         Segment<String, Long> segment = getCommonBuilder();
         writeData(segment);
         assertEquals(NUMBER_OF_TESTING_ENTRIES, segment.getNumberOfKeys());
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
     }
 
     private Segment<String, Long> getCommonBuilder() {

--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentLockIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentLockIT.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.it;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -40,12 +40,12 @@ class SegmentLockIT {
                             List.of(new ChunkFilterDoNothing()))//
                     .build().getStatus());
         } finally {
-            closeAndAwait(first);
+            closeAndAssertClosed(first);
         }
 
         final Segment<Integer, String> reopened = newSegment(directory,
                 segmentId);
-        closeAndAwait(reopened);
+        closeAndAssertClosed(reopened);
     }
 
     private Segment<Integer, String> newSegment(final Directory directory,

--- a/engine/src/main/java/org/hestiastore/index/segment/Segment.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/Segment.java
@@ -279,17 +279,16 @@ public interface Segment<K, V> {
     SegmentState getState();
 
     /**
-     * Starts closing the segment, releasing locks and resources in the
-     * background. Close is asynchronous and returns once the close workflow is
-     * accepted.
+     * Closes the segment and releases its locks and resources before
+     * returning.
      *
      * <p>
      * Close starts only from {@link SegmentState#READY} and transitions the
      * segment into {@link SegmentState#FREEZE} while in-flight operations are
-     * drained. When the background close completes, the segment moves to
-     * {@link SegmentState#CLOSED}. After close, all segment operations return
-     * {@link SegmentResultStatus#CLOSED} (or throw) and no further maintenance
-     * is performed.
+     * drained. When the method returns {@link SegmentResultStatus#OK}, the
+     * segment is already in {@link SegmentState#CLOSED}. After close, all
+     * segment operations return {@link SegmentResultStatus#CLOSED} (or throw)
+     * and no further maintenance is performed.
      * </p>
      *
      * Calls in other states return BUSY/CLOSED/ERROR as appropriate.

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
@@ -376,7 +376,7 @@ class SegmentImpl<K, V> implements Segment<K, V> {
     }
 
     /**
-     * Starts closing the segment in the maintenance thread.
+     * Closes the segment synchronously on the caller thread.
      */
     @Override
     public SegmentResult<Void> close() {
@@ -384,25 +384,25 @@ class SegmentImpl<K, V> implements Segment<K, V> {
             return resultForState(gate.getState());
         }
         core.freezeWriteCacheForFlush();
-        try {
-            maintenanceExecutor.execute(this::runClose);
-        } catch (final RuntimeException e) {
-            failUnlessClosed();
+        if (!closeInternal()) {
             return SegmentResult.error();
         }
         return SegmentResult.ok();
     }
 
-    private void runClose() {
+    private boolean closeInternal() {
         try {
             core.flushFrozenWriteCacheToDeltaFile();
             core.applyFrozenWriteCacheAfterFlush();
             core.close();
             if (!gate.finishCloseToClosed()) {
                 gate.fail();
+                return false;
             }
+            return true;
         } catch (final RuntimeException e) {
             gate.fail();
+            return false;
         } finally {
             if (directoryLocking != null) {
                 directoryLocking.unlock();

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentLifecycleMaintenance.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentLifecycleMaintenance.java
@@ -90,7 +90,6 @@ final class SegmentLifecycleMaintenance<K, V> {
             final SegmentResult<Void> result = segment.close();
             final SegmentResultStatus status = result.getStatus();
             if (status == SegmentResultStatus.OK) {
-                awaitSegmentClosed(segment, startNanos);
                 return;
             }
             if (status == SegmentResultStatus.CLOSED) {
@@ -104,23 +103,6 @@ final class SegmentLifecycleMaintenance<K, V> {
             throw new IndexException(
                     String.format(SEGMENT_CLOSE_FAILED_FORMAT,
                             segment.getId(), status));
-        }
-    }
-
-    private void awaitSegmentClosed(final Segment<K, V> segment,
-            final long startNanos) {
-        while (true) {
-            final SegmentState state = segment.getState();
-            if (state == SegmentState.CLOSED) {
-                return;
-            }
-            if (state == SegmentState.ERROR) {
-                throw new IndexException(
-                        String.format(SEGMENT_CLOSE_FAILED_FORMAT,
-                                segment.getId(), state));
-            }
-            closeRetryPolicy.backoffOrThrow(startNanos, "close",
-                    segment.getId());
         }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentWriteConsistencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/IntegrationSegmentWriteConsistencyTest.java
@@ -2,7 +2,7 @@ package org.hestiastore.index.segment;
 
 import static org.hestiastore.index.AbstractDataTest.verifyNumberOfFiles;
 import static org.hestiastore.index.segment.AbstractSegmentTest.verifySegmentData;
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -48,7 +48,7 @@ class IntegrationSegmentWriteConsistencyTest {
     @AfterEach
     void tearDown() {
         if (segment != null) {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
         segment = null;
         directory = null;
@@ -79,12 +79,12 @@ class IntegrationSegmentWriteConsistencyTest {
         assertTrue(true);
         data.forEach(entry -> segment.put(entry.getKey(), entry.getValue()));
         segment.flush();
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
 
         final Segment<Integer, String> reopened = makeSegment(directory,
                 SEGMENT_ID_1);
         verifySegmentData(reopened, data);
-        closeAndAwait(reopened);
+        closeAndAssertClosed(reopened);
         verifyNumberOfFiles(directory, 5);
     }
 
@@ -94,7 +94,7 @@ class IntegrationSegmentWriteConsistencyTest {
         data.forEach(entry -> segment.put(entry.getKey(), entry.getValue()));
         segment.flush();
         verifySegmentData(segment, data);
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
 
         final Segment<Integer, String> segment2 = makeSegment(directory,
                 SEGMENT_ID_1);
@@ -102,7 +102,7 @@ class IntegrationSegmentWriteConsistencyTest {
                 entry -> segment2.put(entry.getKey(), entry.getValue()));
         segment2.flush();
         verifySegmentData(segment2, updatedData);
-        closeAndAwait(segment2);
+        closeAndAssertClosed(segment2);
         verifyNumberOfFiles(directory, 6);
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentBuilderTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 
 /**
  * Class test invalid parameters of segment.
@@ -285,7 +285,7 @@ class SegmentBuilderTest {
                 .build().getValue();
 
         assertNotNull(segment);
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
     }
 
     @Test
@@ -317,7 +317,7 @@ class SegmentBuilderTest {
         assertEquals(SegmentResultStatus.OK, second.getStatus());
         assertEquals("a", first.getValue());
         assertEquals("b", second.getValue());
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
     }
 
     @Test
@@ -340,7 +340,7 @@ class SegmentBuilderTest {
         final Object executor = field.get(impl);
 
         assertEquals(DirectExecutor.class, executor.getClass());
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
     }
 
     @Test
@@ -380,7 +380,7 @@ class SegmentBuilderTest {
                     .get(core);
             assertEquals(2L, files.getActiveVersion());
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         final SegmentPropertiesManager rootProperties = new SegmentPropertiesManager(

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentCompactionPublishTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentCompactionPublishTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,7 +65,7 @@ class SegmentCompactionPublishTest {
             assertDoesNotThrow(() -> compacter.publishCompaction(plan));
             guardedDirectory.allowIo();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentFlushOnlyReadRegressionTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentFlushOnlyReadRegressionTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -72,7 +72,7 @@ class SegmentFlushOnlyReadRegressionTest {
             assertEquals(SegmentResultStatus.OK, result.getStatus());
             assertNull(result.getValue());
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +49,7 @@ class SegmentImplConcurrencyContractTest {
                     segment.put(2, "b").getStatus());
             assertEquals(SegmentResultStatus.OK, segment.get(1).getStatus());
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -77,7 +77,7 @@ class SegmentImplConcurrencyContractTest {
             exclusive.getValue().close();
             failFast.close();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -100,7 +100,7 @@ class SegmentImplConcurrencyContractTest {
             assertFalse(failFast.hasNext());
             failFast.close();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -129,7 +129,7 @@ class SegmentImplConcurrencyContractTest {
             assertEquals("a", segment.get(1).getValue());
             assertEquals("b", segment.get(2).getValue());
         } finally {
-            closeAndDrainExecutor(segment, executor);
+            closeAfterMaintenanceIfNeeded(segment, executor);
         }
     }
 
@@ -142,7 +142,7 @@ class SegmentImplConcurrencyContractTest {
             assertEquals(SegmentResultStatus.BUSY,
                     segment.put(2, "b").getStatus());
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -171,7 +171,7 @@ class SegmentImplConcurrencyContractTest {
             assertEquals("a", segment.get(1).getValue());
             assertEquals("b", segment.get(2).getValue());
         } finally {
-            closeAndDrainExecutor(segment, executor);
+            closeAfterMaintenanceIfNeeded(segment, executor);
         }
     }
 
@@ -232,7 +232,7 @@ class SegmentImplConcurrencyContractTest {
                 assertEquals("v" + i, result.getValue());
             }
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -261,7 +261,8 @@ class SegmentImplConcurrencyContractTest {
         return builder.build().getValue();
     }
 
-    private static void closeAndDrainExecutor(final Segment<?, ?> segment,
+    private static void closeAfterMaintenanceIfNeeded(
+            final Segment<?, ?> segment,
             final CapturingExecutor executor) {
         if (segment == null) {
             return;
@@ -271,9 +272,6 @@ class SegmentImplConcurrencyContractTest {
                 && executor.hasTask()) {
             executor.runTask();
             segment.close();
-        }
-        if (executor.hasTask()) {
-            executor.runTask();
         }
         if (segment.getState() != SegmentState.CLOSED) {
             throw new AssertionError("Segment did not close.");

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -177,7 +177,7 @@ class SegmentImplTest {
     @AfterEach
     void tearDown() {
         if (subject != null && subject.getState() != SegmentState.ERROR) {
-            closeAndAwait(subject);
+            closeAndAssertClosed(subject);
         }
     }
 
@@ -276,7 +276,7 @@ class SegmentImplTest {
             assertEquals(SegmentResultStatus.OK, result.getStatus());
             verify(segment).compact();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -293,7 +293,7 @@ class SegmentImplTest {
             verify(segment).flush();
             verify(segment, never()).compact();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -310,7 +310,7 @@ class SegmentImplTest {
             verify(segment).compact();
             verify(segment, never()).flush();
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
     }
 
@@ -401,7 +401,6 @@ class SegmentImplTest {
             assertEquals(SegmentState.READY, segment.getState());
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -429,7 +428,6 @@ class SegmentImplTest {
             assertEquals("B", segment.get(2).getValue());
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -459,7 +457,6 @@ class SegmentImplTest {
             verify(segment, times(1)).compact();
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -479,7 +476,6 @@ class SegmentImplTest {
             executor.runTask();
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -489,8 +485,6 @@ class SegmentImplTest {
         final SegmentImpl<Integer, String> segment = newSegment(executor,
                 versionController);
         segment.close();
-        assertTrue(executor.hasTask());
-        executor.runTask();
 
         final SegmentResult<Void> result = segment.flush();
 
@@ -521,7 +515,6 @@ class SegmentImplTest {
             assertEquals(SegmentState.READY, segment.getState());
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -544,7 +537,6 @@ class SegmentImplTest {
             executor.runTask();
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -566,7 +558,6 @@ class SegmentImplTest {
             assertEquals(SegmentState.READY, segment.getState());
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -588,7 +579,6 @@ class SegmentImplTest {
             executor.runTask();
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -611,7 +601,6 @@ class SegmentImplTest {
             assertEquals(SegmentState.ERROR, segment.getState());
         } finally {
             segment.close();
-            executor.runTask();
         }
     }
 
@@ -667,6 +656,27 @@ class SegmentImplTest {
     }
 
     @Test
+    void close_returns_error_when_core_close_fails() {
+        final SegmentCore<Integer, String> failingCore = spy(
+                createCore(versionController));
+        doThrow(new RuntimeException("close failed")).when(failingCore)
+                .close();
+        final SegmentCompacter<Integer, String> compacter = new SegmentCompacter<>(
+                versionController);
+        final SegmentMaintenancePolicyThreshold<Integer, String> maintenancePolicy = new SegmentMaintenancePolicyThreshold<>(
+                conf.getMaxNumberOfKeysInSegmentCache(),
+                conf.getMaxNumberOfKeysInSegmentWriteCache(),
+                conf.getMaxNumberOfDeltaCacheFiles());
+        final SegmentImpl<Integer, String> segment = new SegmentImpl<>(
+                failingCore, compacter, Runnable::run, maintenancePolicy);
+
+        final SegmentResult<Void> result = segment.close();
+
+        assertEquals(SegmentResultStatus.ERROR, result.getStatus());
+        assertEquals(SegmentState.ERROR, segment.getState());
+    }
+
+    @Test
     void maintenance_keeps_closed_state_after_completion() {
         final CapturingExecutor executor = new CapturingExecutor();
         final SegmentCompacter<Integer, String> compacter = new SegmentCompacter<>(
@@ -689,8 +699,6 @@ class SegmentImplTest {
 
         final SegmentResult<Void> secondClose = segment.close();
         assertEquals(SegmentResultStatus.OK, secondClose.getStatus());
-        assertTrue(executor.hasTask());
-        executor.runTask();
 
         assertEquals(SegmentState.CLOSED, segment.getState());
     }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentLayoutCompatibilityTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentLayoutCompatibilityTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,7 +54,7 @@ class SegmentLayoutCompatibilityTest extends AbstractSegmentTest {
                         "Expected flat segment files in base directory.");
             }
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         final Segment<Integer, String> reopened = applyConf(
@@ -66,7 +66,7 @@ class SegmentLayoutCompatibilityTest extends AbstractSegmentTest {
         try {
             verifySegmentSearch(reopened, entries);
         } finally {
-            closeAndAwait(reopened);
+            closeAndAssertClosed(reopened);
         }
     }
 
@@ -93,7 +93,7 @@ class SegmentLayoutCompatibilityTest extends AbstractSegmentTest {
             assertEquals(SegmentResultStatus.OK, result.getStatus());
             awaitReady(segment);
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         final Directory rootDirectory = asyncDirectory
@@ -120,7 +120,7 @@ class SegmentLayoutCompatibilityTest extends AbstractSegmentTest {
         try {
             assertEquals(SegmentResultStatus.OK, segment.flush().getStatus());
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         final Directory rootDirectory = asyncDirectory
@@ -153,7 +153,7 @@ class SegmentLayoutCompatibilityTest extends AbstractSegmentTest {
         try {
             assertNotNull(segment);
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         final SegmentPropertiesManager reloaded = new SegmentPropertiesManager(

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentLockTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentLockTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +55,7 @@ class SegmentLockTest {
         try {
             assertTrue(directory.isFileExists(lockFileName));
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
 
         assertFalse(directory.isFileExists(lockFileName));
@@ -75,7 +75,7 @@ class SegmentLockTest {
         try {
             assertTrue(directory.isFileExists(lockFileName));
         } finally {
-            closeAndAwait(result.getValue());
+            closeAndAssertClosed(result.getValue());
         }
         assertTrue(directory.isFileExists(lockFileName));
     }
@@ -93,7 +93,7 @@ class SegmentLockTest {
         try {
             assertFalse(directory.isFileExists(lockFileName));
         } finally {
-            closeAndAwait(segment);
+            closeAndAssertClosed(segment);
         }
         assertFalse(directory.isFileExists(lockFileName));
     }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentTestHelper.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentTestHelper.java
@@ -11,7 +11,7 @@ public final class SegmentTestHelper {
     private SegmentTestHelper() {
     }
 
-    public static void closeAndAwait(final Segment<?, ?> segment) {
+    public static void closeAndAssertClosed(final Segment<?, ?> segment) {
         if (segment == null) {
             return;
         }
@@ -30,6 +30,10 @@ public final class SegmentTestHelper {
             if (result.getStatus() == SegmentResultStatus.ERROR) {
                 throw new AssertionError(String.format(
                         "Segment '%s' failed to close.", segment.getId()));
+            }
+            if (result.getStatus() == SegmentResultStatus.OK
+                    && segment.getState() == SegmentState.CLOSED) {
+                return;
             }
             LockSupport.parkNanos(
                     TimeUnit.MILLISECONDS.toNanos(CLOSE_POLL_MILLIS));

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentThreadSafetyStressTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentThreadSafetyStressTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segment;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.List;
@@ -79,7 +79,7 @@ class SegmentThreadSafetyStressTest {
 
                 assertNotEquals(SegmentState.ERROR, segment.getState());
             } finally {
-                closeAndAwait(segment);
+                closeAndAssertClosed(segment);
             }
         }
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexSimpleTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexSimpleTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segmentindex;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -368,7 +368,7 @@ class IntegrationSegmentIndexSimpleTest {
                 }
             }
         } finally {
-            closeAndAwait(seg);
+            closeAndAssertClosed(seg);
         }
         return out;
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentFactoryTest.java
@@ -62,7 +62,7 @@ class SegmentFactoryTest {
             assertNotNull(segment);
             assertEquals(segmentId, segment.getId());
         } finally {
-            SegmentTestHelper.closeAndAwait(segment);
+            SegmentTestHelper.closeAndAssertClosed(segment);
             stableSegmentMaintenancePool.shutdownNow();
         }
     }
@@ -91,7 +91,7 @@ class SegmentFactoryTest {
             assertEquals(SegmentBuildStatus.OK, buildResult.getStatus());
             assertTrue(segmentDirectory.isFileExists(lockFileName));
         } finally {
-            SegmentTestHelper.closeAndAwait(segment);
+            SegmentTestHelper.closeAndAssertClosed(segment);
             stableSegmentMaintenancePool.shutdownNow();
         }
         assertFalse(segmentDirectory.isFileExists(lockFileName));
@@ -124,7 +124,7 @@ class SegmentFactoryTest {
                 assertEquals(List.of(Entry.of(1, "a"), Entry.of(2, "b")),
                         readEntries(segment));
             } finally {
-                SegmentTestHelper.closeAndAwait(segment);
+                SegmentTestHelper.closeAndAssertClosed(segment);
             }
         } finally {
             stableSegmentMaintenancePool.shutdownNow();

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
@@ -1,6 +1,6 @@
 package org.hestiastore.index.segmentregistry;
 
-import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAwait;
+import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -87,7 +87,7 @@ class SegmentRegistryImplTest {
                 .getValue();
 
         assertSame(first, second);
-        closeAndAwait(first);
+        closeAndAssertClosed(first);
         final Segment<Integer, String> third = registry.tryLoadSegment(segmentId)
                 .getValue();
 
@@ -243,7 +243,7 @@ class SegmentRegistryImplTest {
                 .tryLoadSegment(segmentId);
         assertSame(SegmentRegistryResultStatus.BUSY, result.getStatus());
 
-        closeAndAwait(segment);
+        closeAndAssertClosed(segment);
         removeCacheEntry(segmentId);
     }
 


### PR DESCRIPTION
## Summary
- finalize the synchronous Segment.close() contract in code and tests
- rename close helpers to match the new blocking behavior
- update concurrency documentation for sync close semantics

## Testing
- mvn -pl engine -Dtest=SegmentImplTest,SegmentImplConcurrencyContractTest,SegmentLifecycleMaintenanceTest test
- mvn clean verify