### PR TITLE
Re-enable stabilized segment tests

### DIFF
--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
@@ -28,7 +28,6 @@ import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.IndexConfiguration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -41,8 +40,7 @@ import org.junit.jupiter.api.Timeout;
  * disjoint keyspaces (order-independent) and "last write wins" for a single
  * key.
  */
-@Timeout(value = 90, unit = TimeUnit.SECONDS,
-        threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+@Timeout(value = 90, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
 class SegmentIndexConcurrentIT {
 
     private static final int TEST_CPU_THREADS = Math.max(1,
@@ -176,7 +174,6 @@ class SegmentIndexConcurrentIT {
     }
 
     @Test
-    @Disabled("Known nondeterministic failure kept out of the architecture cleanup flow.")
     void concurrent_put_delete_with_background_flush_compact_produces_consistent_state()
             throws Exception {
         final Directory directory = new MemDirectory();
@@ -401,8 +398,7 @@ class SegmentIndexConcurrentIT {
     }
 
     @Test
-    @Timeout(value = 180, unit = TimeUnit.SECONDS,
-            threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    @Timeout(value = 180, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void hotRangeRandomPutsWithAutonomousSplitDoNotStall() throws Exception {
         final Directory directory = new MemDirectory();
         final IndexConfiguration<Integer, Integer> conf = newAutonomousSplitConfiguration(
@@ -514,7 +510,7 @@ class SegmentIndexConcurrentIT {
             for (final Map.Entry<Integer, Integer> entry : expectedCold
                     .entrySet()) {
                 assertEquals(entry.getValue(), index.get(entry.getKey()),
-                    "Unexpected value for cold key " + entry.getKey());
+                        "Unexpected value for cold key " + entry.getKey());
             }
         } finally {
             executor.shutdownNow();
@@ -527,8 +523,7 @@ class SegmentIndexConcurrentIT {
     }
 
     @Test
-    @Timeout(value = 180, unit = TimeUnit.SECONDS,
-            threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    @Timeout(value = 180, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void hotRangeAutonomousSplitSurvivesCloseReopenRotations() throws Exception {
         final Directory directory = new MemDirectory();
         final IndexConfiguration<Integer, Integer> conf = newAutonomousSplitConfiguration(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexIteratorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexIteratorTest.java
@@ -25,7 +25,6 @@ import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -199,7 +198,6 @@ class IntegrationSegmentIndexIteratorTest {
     }
 
     @Test
-    @Disabled("Known regular failure; intentionally disabled until root cause is understood.")
     void fullIsolationStreamDelaysSplitRemapUntilSnapshotCloses() {
         try (SegmentIndex<Integer, String> index = makeAutonomousSplitIndex()) {
             for (int i = 0; i < 48; i++) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 
 import org.hestiastore.index.segmentindex.core.metrics.IndexExecutorMetricsAccess;
 import org.hestiastore.index.segmentindex.core.metrics.IndexExecutorRuntimeAccess;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ExecutorRegistryTest {
@@ -239,8 +238,7 @@ class ExecutorRegistryTest {
     void stableSegmentMaintenanceExecutorUsesConfiguredThreadCount()
             throws InterruptedException {
         final int stableSegmentMaintenanceThreads = 4;
-        final ExecutorRegistry registry =
-                newRegistry(stableSegmentMaintenanceThreads, 1, 1);
+        final ExecutorRegistry registry = newRegistry(stableSegmentMaintenanceThreads, 1, 1);
         final CountDownLatch started = new CountDownLatch(
                 stableSegmentMaintenanceThreads);
         final CountDownLatch release = new CountDownLatch(1);
@@ -295,15 +293,13 @@ class ExecutorRegistryTest {
                 registry.getIndexMaintenanceExecutor().execute(() -> {
                 });
             }
-            final ExecutorService indexMaintenanceExecutor =
-                    registry.getIndexMaintenanceExecutor();
+            final ExecutorService indexMaintenanceExecutor = registry.getIndexMaintenanceExecutor();
 
             assertThrows(RejectedExecutionException.class,
                     () -> indexMaintenanceExecutor.execute(() -> {
                     }));
 
-            final IndexExecutorMetricsAccess snapshot =
-                    registry.runtimeSnapshot().getIndexMaintenance();
+            final IndexExecutorMetricsAccess snapshot = registry.runtimeSnapshot().getIndexMaintenance();
             assertEquals(1, snapshot.getActiveThreadCount());
             assertEquals(64, snapshot.getQueueSize());
             assertEquals(64, snapshot.getQueueCapacity());
@@ -316,7 +312,6 @@ class ExecutorRegistryTest {
     }
 
     @Test
-    @Disabled("Known regular failure; intentionally disabled until root cause is understood.")
     void runtimeSnapshotTracksCompletedTasksAndCallerRuns()
             throws InterruptedException, ExecutionException {
         final ExecutorRegistry registry = newRegistry(1, 1, 1);
@@ -346,8 +341,7 @@ class ExecutorRegistryTest {
 
             assertEquals(submittingThreadName, callerRunThread.get());
 
-            final IndexExecutorRuntimeAccess runtimeSnapshot =
-                    registry.runtimeSnapshot();
+            final IndexExecutorRuntimeAccess runtimeSnapshot = registry.runtimeSnapshot();
             assertEquals(1L, runtimeSnapshot.getSplitMaintenance()
                     .getCompletedTaskCount());
             assertEquals(1L, runtimeSnapshot.getStableSegmentMaintenance()


### PR DESCRIPTION
Summary:
- Re-enable the stabilized concurrent segment index integration scenario.
- Re-enable iterator isolation and executor runtime snapshot tests.
- Remove now-unused Disabled imports.

Tests:
- mvn clean verify