### PR TITLE
Rename segment topology implementation

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/DefaultRouteDrain.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/DefaultRouteDrain.java
@@ -7,11 +7,11 @@ import org.hestiastore.index.segment.SegmentId;
 
 final class DefaultRouteDrain implements SegmentTopology.RouteDrain {
 
-    private final DefaultSegmentTopology<?> topology;
+    private final SegmentTopologyImpl<?> topology;
     private final SegmentId segmentId;
     private final AtomicBoolean completed = new AtomicBoolean();
 
-    DefaultRouteDrain(final DefaultSegmentTopology<?> topology,
+    DefaultRouteDrain(final SegmentTopologyImpl<?> topology,
             final SegmentId segmentId) {
         this.topology = Vldtn.requireNonNull(topology, "topology");
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/DefaultRouteLease.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/DefaultRouteLease.java
@@ -7,11 +7,11 @@ import org.hestiastore.index.segment.SegmentId;
 
 final class DefaultRouteLease implements SegmentTopology.RouteLease {
 
-    private final DefaultSegmentTopology<?> topology;
+    private final SegmentTopologyImpl<?> topology;
     private final SegmentId segmentId;
     private final AtomicBoolean closed = new AtomicBoolean();
 
-    DefaultRouteLease(final DefaultSegmentTopology<?> topology,
+    DefaultRouteLease(final SegmentTopologyImpl<?> topology,
             final SegmentId segmentId) {
         this.topology = Vldtn.requireNonNull(topology, "topology");
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilder.java
@@ -32,7 +32,7 @@ public final class SegmentTopologyBuilder<K> {
      * @return segment topology
      */
     public SegmentTopology<K> build() {
-        return new DefaultSegmentTopology<>(
+        return new SegmentTopologyImpl<>(
                 Vldtn.requireNonNull(snapshot, "snapshot"));
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyImpl.java
@@ -13,13 +13,13 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.mapping.Snapshot;
 
-final class DefaultSegmentTopology<K> implements SegmentTopology<K> {
+final class SegmentTopologyImpl<K> implements SegmentTopology<K> {
 
     private final Object monitor = new Object();
     private final Map<SegmentId, RouteEntry> routes = new HashMap<>();
     private long version;
 
-    DefaultSegmentTopology(final Snapshot<K> snapshot) {
+    SegmentTopologyImpl(final Snapshot<K> snapshot) {
         reconcile(snapshot);
     }
 


### PR DESCRIPTION
## Summary
- Rename the package-private SegmentTopology implementation from DefaultSegmentTopology to SegmentTopologyImpl.
- Update route lease, route drain, and builder references to the renamed implementation.

## Tests
- mvn -pl engine -Dtest=SegmentTopologyTest,SegmentTopologyBuilderTest test