### PR TITLE
Remove startup consistency hook

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
@@ -321,15 +321,8 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
         sessionOwner.prepareFailedStartupCleanup(failure);
     }
 
-    /**
-     * Startup-only extension point invoked immediately before the first
-     * consistency repair that runs after stale lock recovery.
-     */
-    void onStartupConsistencyCheck() {
-    }
-
     final void completeStartup() {
-        sessionOwner.completeStartup(this::onStartupConsistencyCheck);
+        sessionOwner.completeStartup();
     }
 
     void ensureOperational() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionOwner.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionOwner.java
@@ -61,11 +61,11 @@ final class SegmentIndexSessionOwner<K, V> {
         closeCoordinator.close();
     }
 
-    void completeStartup(final Runnable consistencyCheckHook) {
+    void completeStartup() {
         if (!startupCompleted.compareAndSet(false, true)) {
             return;
         }
-        startupCoordinator.completeStartup(consistencyCheckHook);
+        startupCoordinator.completeStartup();
     }
 
     void prepareFailedStartupCleanup(final Throwable failure) {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinator.java
@@ -38,16 +38,15 @@ final class SegmentIndexStartupCoordinator<K, V> {
                 consistencyCoordinator, "consistencyCoordinator");
     }
 
-    void completeStartup(final Runnable startupConsistencyCheck) {
-        final Runnable consistencyCheck = Vldtn.requireNonNull(
-                startupConsistencyCheck, "startupConsistencyCheck");
+    void completeStartup() {
         logger.debug("Opening index '{}'.", indexName);
         runtime.recoverFromWal();
         runtime.cleanupOrphanedSegmentDirectories();
         stateMachine.markReady();
         if (staleLockRecovered) {
             logger.info(STALE_LOCK_RECOVERY_MESSAGE);
-            consistencyCoordinator.runStartupConsistencyCheck(consistencyCheck);
+            consistencyCoordinator.runStartupConsistencyCheck(
+                    consistencyCoordinator::checkAndRepairConsistency);
         }
         runtime.requestFullSplitScan();
         logger.debug("Index '{}' opened.", indexName);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionOwnerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionOwnerTest.java
@@ -53,11 +53,9 @@ class SegmentIndexSessionOwnerTest {
 
     @Test
     void completeStartupRunsOnlyOnce() {
-        final Runnable hook = mock(Runnable.class);
+        owner.completeStartup();
 
-        owner.completeStartup(hook);
-
-        verify(startupCoordinator).completeStartup(hook);
+        verify(startupCoordinator).completeStartup();
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinatorTest.java
@@ -1,13 +1,10 @@
 package org.hestiastore.index.segmentindex.core.session;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
@@ -34,10 +31,6 @@ class SegmentIndexStartupCoordinatorTest {
     @Mock
     private IndexConsistencyCoordinator<Integer, String> consistencyCoordinator;
 
-    @Mock
-    private SegmentIndexImpl<Integer, String> owner;
-
-    private final AtomicInteger startupConsistencyChecks = new AtomicInteger();
     private SegmentIndexStartupCoordinator<Integer, String> startupCoordinator;
 
     @BeforeEach
@@ -49,8 +42,7 @@ class SegmentIndexStartupCoordinatorTest {
 
     @Test
     void completeStartup_recoversAndMarksReadyWithoutConsistencyCheck() {
-        startupCoordinator.completeStartup(
-                startupConsistencyChecks::incrementAndGet);
+        startupCoordinator.completeStartup();
 
         final InOrder inOrder = inOrder(runtime, stateMachine);
         inOrder.verify(runtime).recoverFromWal();
@@ -58,7 +50,6 @@ class SegmentIndexStartupCoordinatorTest {
         inOrder.verify(stateMachine).markReady();
         inOrder.verify(runtime).requestFullSplitScan();
         verify(consistencyCoordinator, never()).runStartupConsistencyCheck(any());
-        assertEquals(0, startupConsistencyChecks.get());
     }
 
     @Test
@@ -72,8 +63,7 @@ class SegmentIndexStartupCoordinatorTest {
             return null;
         }).when(consistencyCoordinator).runStartupConsistencyCheck(any());
 
-        startupCoordinator.completeStartup(
-                startupConsistencyChecks::incrementAndGet);
+        startupCoordinator.completeStartup();
 
         final InOrder inOrder = inOrder(runtime, stateMachine,
                 consistencyCoordinator);
@@ -82,7 +72,8 @@ class SegmentIndexStartupCoordinatorTest {
         inOrder.verify(stateMachine).markReady();
         inOrder.verify(consistencyCoordinator)
                 .runStartupConsistencyCheck(any());
+        inOrder.verify(consistencyCoordinator).checkAndRepairConsistency();
         inOrder.verify(runtime).requestFullSplitScan();
-        assertEquals(1, startupConsistencyChecks.get());
+        verify(consistencyCoordinator).checkAndRepairConsistency();
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
@@ -7,6 +7,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
@@ -70,28 +71,26 @@ class SegmentIndexStartupRecoveryTest {
     private static final class TrackingIndex
             extends SegmentIndexImpl<Integer, String> {
 
-        private int startupConsistencyChecks;
+        private final AtomicInteger startupConsistencyChecks;
 
         private TrackingIndex(final Directory directoryFacade) {
-            this(directoryFacade, buildConf());
+            this(directoryFacade, buildConf(), new AtomicInteger());
         }
 
         private TrackingIndex(final Directory directoryFacade,
-                final IndexConfiguration<Integer, String> conf) {
+                final IndexConfiguration<Integer, String> conf,
+                final AtomicInteger startupConsistencyChecks) {
             super(new TypeDescriptorInteger(), mockPointOperationFacade(),
                     mockReadFacade(), mock(MaintenanceService.class),
                     mockTrackedRunner(), mock(SegmentIndexMaintenance.class),
-                    newSessionOwner(directoryFacade, conf));
+                    newSessionOwner(directoryFacade, conf,
+                            startupConsistencyChecks));
+            this.startupConsistencyChecks = startupConsistencyChecks;
             completeStartup();
         }
 
-        @Override
-        protected void onStartupConsistencyCheck() {
-            startupConsistencyChecks++;
-        }
-
         private int getStartupConsistencyChecks() {
-            return startupConsistencyChecks;
+            return startupConsistencyChecks.get();
         }
 
         private static IndexConfiguration<Integer, String> buildConf() {
@@ -119,7 +118,8 @@ class SegmentIndexStartupRecoveryTest {
 
         private static SegmentIndexSessionOwner<Integer, String> newSessionOwner(
                 final Directory directoryFacade,
-                final IndexConfiguration<Integer, String> conf) {
+                final IndexConfiguration<Integer, String> conf,
+                final AtomicInteger startupConsistencyChecks) {
             final IndexDirectoryLock directoryLock =
                     new IndexDirectoryLock(directoryFacade);
             final SegmentIndexStateMachine stateMachine =
@@ -128,6 +128,7 @@ class SegmentIndexStartupRecoveryTest {
             final IndexConsistencyCoordinator<Integer, String> consistencyCoordinator =
                     new IndexConsistencyCoordinator<>(() -> {
                     }, segmentFilter -> {
+                        startupConsistencyChecks.incrementAndGet();
                     }, () -> {
                     }, () -> {
                     }, segmentId -> false);


### PR DESCRIPTION
## Summary
- Remove the no-op `SegmentIndexImpl.onStartupConsistencyCheck()` hook.
- Simplify startup completion so callers no longer pass a callback through `SegmentIndexImpl` and `SegmentIndexSessionOwner`.
- Run the real `IndexConsistencyCoordinator.checkAndRepairConsistency()` during stale-lock startup recovery.

## Tests
- `mvn -pl engine -Dtest='SegmentIndexStartupCoordinatorTest,SegmentIndexSessionOwnerTest,SegmentIndexStartupRecoveryTest,SegmentIndexImplTest' test`
- `mvn -pl engine test`
- `git diff --check`
