### PR TITLE
Remove segmentindex logger plumbing

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceBuilder.java
@@ -9,7 +9,6 @@ import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.hestiastore.index.segmentindex.core.stablesegment.StableSegmentOperationAccess;
 import org.hestiastore.index.segmentindex.core.split.SplitService;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
-import org.slf4j.Logger;
 
 /**
  * Builder for {@link MaintenanceService} instances.
@@ -19,7 +18,6 @@ import org.slf4j.Logger;
  */
 public final class MaintenanceServiceBuilder<K, V> {
 
-    private Logger logger;
     private KeyToSegmentMap<K> keyToSegmentMap;
     private StableSegmentOperationAccess<K, V> stableSegmentGateway;
     private SplitService splitService;
@@ -30,17 +28,6 @@ public final class MaintenanceServiceBuilder<K, V> {
     private LongSupplier nanoTimeSupplier = System::nanoTime;
 
     MaintenanceServiceBuilder() {
-    }
-
-    /**
-     * Sets the logger used by stable segment maintenance operations.
-     *
-     * @param logger logger
-     * @return this builder
-     */
-    public MaintenanceServiceBuilder<K, V> logger(final Logger logger) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
-        return this;
     }
 
     /**
@@ -147,7 +134,6 @@ public final class MaintenanceServiceBuilder<K, V> {
      */
     public MaintenanceService build() {
         return new MaintenanceServiceImpl<>(
-                Vldtn.requireNonNull(logger, "logger"),
                 Vldtn.requireNonNull(keyToSegmentMap, "keyToSegmentMap"),
                 Vldtn.requireNonNull(stableSegmentGateway,
                         "stableSegmentGateway"),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImpl.java
@@ -16,6 +16,7 @@ import org.hestiastore.index.segmentindex.core.split.SplitService;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.BlockingSegment;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Owns foreground flush and compaction orchestration across mapped stable
@@ -27,7 +28,9 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
     private static final String COMPACT_OPERATION_LABEL = "Compact";
     private static final String FLUSH_OPERATION_ID = "flush";
     private static final String FLUSH_OPERATION_LABEL = "Flush";
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MaintenanceServiceImpl.class);
+
     private final KeyToSegmentMap<K> keyToSegmentMap;
     private final StableSegmentOperationAccess<K, V> stableSegmentGateway;
     private final SplitService splitService;
@@ -37,19 +40,19 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
     private final Runnable checkpointAction;
     private final LongSupplier nanoTimeSupplier;
 
-    MaintenanceServiceImpl(final Logger logger,
+    MaintenanceServiceImpl(
             final KeyToSegmentMap<K> keyToSegmentMap,
             final StableSegmentOperationAccess<K, V> stableSegmentGateway,
             final SplitService splitService,
             final IndexRetryPolicy retryPolicy, final Stats stats,
             final ExecutorService maintenanceExecutor,
             final Runnable checkpointAction) {
-        this(logger, keyToSegmentMap, stableSegmentGateway, splitService,
+        this(keyToSegmentMap, stableSegmentGateway, splitService,
                 retryPolicy, stats, maintenanceExecutor, checkpointAction,
                 System::nanoTime);
     }
 
-    MaintenanceServiceImpl(final Logger logger,
+    MaintenanceServiceImpl(
             final KeyToSegmentMap<K> keyToSegmentMap,
             final StableSegmentOperationAccess<K, V> stableSegmentGateway,
             final SplitService splitService,
@@ -57,7 +60,6 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
             final ExecutorService maintenanceExecutor,
             final Runnable checkpointAction,
             final LongSupplier nanoTimeSupplier) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
         this.stableSegmentGateway = Vldtn.requireNonNull(stableSegmentGateway,
@@ -140,7 +142,7 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
             final java.util.function.LongConsumer acceptedToReadyLatencyRecorder,
             final java.util.function.Function<SegmentId,
                     StableSegmentOperationResult<BlockingSegment<K, V>>> operationRunner) {
-        logger.debug("{} attempt started: segment='{}' wait='{}'",
+        LOGGER.debug("{} attempt started: segment='{}' wait='{}'",
                 operationLabel, segmentId, waitForCompletion);
         final long startNanos = retryPolicy.startNanos();
         while (true) {
@@ -180,7 +182,7 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
             final String operationLabel,
             final java.util.function.LongConsumer acceptedToReadyLatencyRecorder,
             final BlockingSegment<K, V> segment) {
-        logger.debug("{} attempt accepted: segment='{}' wait='{}'",
+        LOGGER.debug("{} attempt accepted: segment='{}' wait='{}'",
                 operationLabel, segmentId, waitForCompletion);
         logOperation("{} accepted: segment='{}' wait='{}' state='{}'",
                 operationLabel, segmentId, waitForCompletion,
@@ -295,13 +297,13 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
         try {
             action.run();
         } catch (final RuntimeException e) {
-            logger.error("Index operation '{}' failed.", operation, e);
+            LOGGER.error("Index operation '{}' failed.", operation, e);
         }
     }
 
     private void logOperation(final String message, final Object... args) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(message, args);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(message, args);
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
@@ -5,13 +5,16 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Owns the ordered close sequence for index runtime collaborators.
  */
 final class IndexCloseCoordinator<K, V> {
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(IndexCloseCoordinator.class);
+
     private final String indexName;
     private final SegmentIndexStateMachine stateMachine;
     private final IndexOperationTrackingAccess operationTracker;
@@ -19,13 +22,12 @@ final class IndexCloseCoordinator<K, V> {
     private final SegmentIndexRuntime<K, V> runtime;
     private final IndexDirectoryLock directoryLock;
 
-    IndexCloseCoordinator(final Logger logger, final String indexName,
+    IndexCloseCoordinator(final String indexName,
             final SegmentIndexStateMachine stateMachine,
             final IndexOperationTrackingAccess operationTracker,
             final Stats stats,
             final SegmentIndexRuntime<K, V> runtime,
             final IndexDirectoryLock directoryLock) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.indexName = Vldtn.requireNonNull(indexName, "indexName");
         this.stateMachine = Vldtn.requireNonNull(stateMachine,
                 "stateMachine");
@@ -46,14 +48,14 @@ final class IndexCloseCoordinator<K, V> {
     }
 
     private void close(final Runnable beginClose) {
-        logger.debug("Closing index '{}'.", indexName);
+        LOGGER.debug("Closing index '{}'.", indexName);
         try {
             beginClose.run();
             awaitForegroundOperations();
             closeSplitRuntime();
             sealAndFlushRuntimeState();
             logOperationCounts();
-            logger.debug("Index '{}' closed.", indexName);
+            LOGGER.debug("Index '{}' closed.", indexName);
         } finally {
             try {
                 finishClosedState();
@@ -90,10 +92,10 @@ final class IndexCloseCoordinator<K, V> {
     }
 
     private void logOperationCounts() {
-        if (!logger.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             return;
         }
-        logger.debug(String.format(
+        LOGGER.debug(String.format(
                 "Index is closing, where was %s gets, %s puts and %s deletes.",
                 F.fmt(stats.getGetCount()),
                 F.fmt(stats.getPutCount()),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexInternalConcurrent.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexInternalConcurrent.java
@@ -16,7 +16,6 @@ import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
-import org.slf4j.LoggerFactory;
 
 /**
  * Direct, caller-thread implementation of {@link SegmentIndex}.
@@ -46,11 +45,11 @@ public final class IndexInternalConcurrent<K, V> extends AbstractCloseableResour
     /**
      * Creates an index and completes startup before returning it.
      *
-     * @param directoryFacade      directory facade
-     * @param keyTypeDescriptor    key type descriptor
-     * @param valueTypeDescriptor  value type descriptor
-     * @param conf                 configuration for the index
-     * @param executorRegistry     shared executor registry
+     * @param directoryFacade     directory facade
+     * @param keyTypeDescriptor   key type descriptor
+     * @param valueTypeDescriptor value type descriptor
+     * @param conf                configuration for the index
+     * @param executorRegistry    shared executor registry
      * @return ready index
      */
     @SuppressWarnings("java:S107")
@@ -71,11 +70,11 @@ public final class IndexInternalConcurrent<K, V> extends AbstractCloseableResour
      * Creates an index in opening state so the owning bootstrap flow can
      * register cleanup before completing startup.
      *
-     * @param directoryFacade      directory facade
-     * @param keyTypeDescriptor    key type descriptor
-     * @param valueTypeDescriptor  value type descriptor
-     * @param conf                 configuration for the index
-     * @param executorRegistry     shared executor registry
+     * @param directoryFacade     directory facade
+     * @param keyTypeDescriptor   key type descriptor
+     * @param valueTypeDescriptor value type descriptor
+     * @param conf                configuration for the index
+     * @param executorRegistry    shared executor registry
      * @return index waiting for startup completion
      */
     @SuppressWarnings("java:S107")
@@ -96,8 +95,7 @@ public final class IndexInternalConcurrent<K, V> extends AbstractCloseableResour
             final TypeDescriptor<V> valueTypeDescriptor,
             final EffectiveIndexConfiguration<K, V> conf,
             final ExecutorRegistry executorRegistry) {
-        return SegmentIndexImpl.open(LoggerFactory.getLogger(
-                SegmentIndexImpl.class), directoryFacade, keyTypeDescriptor,
+        return SegmentIndexImpl.open(directoryFacade, keyTypeDescriptor,
                 valueTypeDescriptor, conf, executorRegistry);
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
@@ -27,7 +27,6 @@ import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenanceImpl;
 import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.hestiastore.index.sorteddatafile.EntryComparator;
-import org.slf4j.Logger;
 
 /**
  * Base implementation of the segment index that manages routed segment
@@ -66,13 +65,12 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
     }
 
     @SuppressWarnings("java:S107")
-    static <K, V> SegmentIndexImpl<K, V> open(final Logger logger,
+    static <K, V> SegmentIndexImpl<K, V> open(
             final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
             final EffectiveIndexConfiguration<K, V> conf,
             final ExecutorRegistry executorRegistry) {
-        final Logger validatedLogger = Vldtn.requireNonNull(logger, "logger");
         final Directory validatedDirectory = Vldtn.requireNonNull(
                 directoryFacade, "directoryFacade");
         final TypeDescriptor<K> validatedKeyTypeDescriptor = Vldtn
@@ -95,8 +93,8 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
             final SegmentIndexTrackedOperationRunner<K, V> trackedRunner =
                     new SegmentIndexTrackedOperationRunner<>(
                             stateMachine::ensureOperational, operationTracker);
-            runtime = SegmentIndexRuntime.create(validatedLogger,
-                    validatedDirectory, validatedKeyTypeDescriptor,
+            runtime = SegmentIndexRuntime.create(validatedDirectory,
+                    validatedKeyTypeDescriptor,
                     validatedValueTypeDescriptor, validatedConf,
                     validatedExecutorRegistry, stats, stateMachine::getState,
                     stateMachine::markRuntimeFailure);
@@ -105,9 +103,8 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
             final SegmentIndexFacades<K, V> facades = SegmentIndexFacades
                     .create(validatedConf, trackedRunner, runtime);
             final SegmentIndexSessionOwner<K, V> sessionOwner = newSessionOwner(
-                    validatedLogger, validatedConf, stateMachine, runtime,
-                    operationTracker, stats, directoryLock,
-                    consistencyCoordinator);
+                    validatedConf, stateMachine, runtime, operationTracker,
+                    stats, directoryLock, consistencyCoordinator);
             final SegmentIndexMaintenance maintenanceApi = newMaintenanceApi(
                     sessionOwner, trackedRunner, runtime.maintenance(),
                     consistencyCoordinator);
@@ -175,18 +172,17 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
     }
 
     private static <K, V> SegmentIndexSessionOwner<K, V> newSessionOwner(
-            final Logger logger, final EffectiveIndexConfiguration<K, V> conf,
+            final EffectiveIndexConfiguration<K, V> conf,
             final SegmentIndexStateMachine stateMachine,
             final SegmentIndexRuntime<K, V> runtime,
             final IndexOperationTrackingAccess operationTracker,
             final Stats stats, final IndexDirectoryLock directoryLock,
             final IndexConsistencyCoordinator<K, V> consistencyCoordinator) {
         return new SegmentIndexSessionOwner<>(stateMachine, runtime,
-                new IndexCloseCoordinator<>(logger, conf.identity().name(),
+                new IndexCloseCoordinator<>(conf.identity().name(),
                         stateMachine, operationTracker, stats, runtime,
                         directoryLock),
-                new SegmentIndexStartupCoordinator<>(logger,
-                        conf.identity().name(),
+                new SegmentIndexStartupCoordinator<>(conf.identity().name(),
                         directoryLock.wasStaleLockRecovered(), runtime,
                         stateMachine, consistencyCoordinator));
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntime.java
@@ -26,7 +26,6 @@ import org.hestiastore.index.segmentindex.core.storage.IndexWalCoordinator;
 import org.hestiastore.index.segmentindex.core.storage.SegmentIndexRuntimeStorage;
 import org.hestiastore.index.segmentindex.core.topology.SegmentTopologyRuntime;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
-import org.slf4j.Logger;
 
 /**
  * Aggregates long-lived collaborators created for one running index session.
@@ -38,7 +37,6 @@ final class SegmentIndexRuntime<K, V>
         implements SegmentIndexDataAccess<K, V> {
 
     static <K, V> SegmentIndexRuntime<K, V> create(
-            final Logger logger,
             final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
@@ -47,8 +45,8 @@ final class SegmentIndexRuntime<K, V>
             final Supplier<SegmentIndexState> stateSupplier,
             final Consumer<RuntimeException> failureHandler) {
         return new SegmentIndexRuntimeFactory<>(
-                new SegmentIndexRuntimeOpenContext<>(logger,
-                        directoryFacade, keyTypeDescriptor,
+                new SegmentIndexRuntimeOpenContext<>(directoryFacade,
+                        keyTypeDescriptor,
                         valueTypeDescriptor, conf, executorRegistry, stats,
                         new java.util.concurrent.atomic.AtomicLong(),
                         new java.util.concurrent.atomic.AtomicLong(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactory.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactory.java
@@ -171,7 +171,7 @@ final class SegmentIndexRuntimeFactory<K, V> {
                         coreStorage.segmentRegistry(),
                         coreStorage.retryPolicy());
         final IndexRecoveryCleanupCoordinator<K, V> recoveryCleanupCoordinator =
-                IndexRecoveryCleanupCoordinator.create(openContext.logger,
+                IndexRecoveryCleanupCoordinator.create(
                         openContext.directoryFacade,
                         coreStorage.keyToSegmentMap(),
                         coreStorage.segmentRegistry(),
@@ -234,7 +234,6 @@ final class SegmentIndexRuntimeFactory<K, V> {
             final SegmentIndexCoreStorage<K, V> coreStorage,
             final StableSegmentOperationAccess<K, V> stableSegmentGateway) {
         return SegmentStreamingService.<K, V>builder()
-                .logger(openContext.logger)
                 .keyToSegmentMap(coreStorage.keyToSegmentMap())
                 .segmentRegistry(coreStorage.segmentRegistry())
                 .stableSegmentGateway(stableSegmentGateway)
@@ -252,10 +251,9 @@ final class SegmentIndexRuntimeFactory<K, V> {
         final MaintenanceService maintenance = createMaintenance(coreStorage,
                 topologyRuntime, () -> checkpointAction.get().run());
         final IndexWalCoordinator<K, V> walCoordinator = IndexWalCoordinator
-                .create(openContext.logger, openContext.conf, walRuntime,
-                        coreStorage.retryPolicy(), () -> { },
-                        maintenance::flushAndWait, openContext.stateSupplier,
-                        openContext.failureHandler,
+                .create(openContext.conf, walRuntime, coreStorage.retryPolicy(),
+                        () -> { }, maintenance::flushAndWait,
+                        openContext.stateSupplier, openContext.failureHandler,
                         openContext.lastAppliedWalLsn);
         checkpointAction.set(walCoordinator::checkpoint);
         final SegmentRuntimeLimitApplier<K, V> runtimeLimitApplier =
@@ -288,7 +286,6 @@ final class SegmentIndexRuntimeFactory<K, V> {
             final SegmentTopologyRuntime<K, V> topologyRuntime,
             final Runnable checkpointAction) {
         return MaintenanceService.<K, V>builder()
-                .logger(openContext.logger)
                 .keyToSegmentMap(coreStorage.keyToSegmentMap())
                 .stableSegmentGateway(StableSegmentOperationAccess.create(
                         coreStorage.segmentRegistry()))

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeOpenContext.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeOpenContext.java
@@ -11,7 +11,6 @@ import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndex
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.metrics.Stats;
-import org.slf4j.Logger;
 
 /**
  * Validated context for opening the runtime graph.
@@ -19,9 +18,9 @@ import org.slf4j.Logger;
  * @param <K> key type
  * @param <V> value type
  */
+// FIXME it should not be used at all
 final class SegmentIndexRuntimeOpenContext<K, V> {
 
-    final Logger logger;
     final Directory directoryFacade;
     final TypeDescriptor<K> keyTypeDescriptor;
     final TypeDescriptor<V> valueTypeDescriptor;
@@ -35,7 +34,6 @@ final class SegmentIndexRuntimeOpenContext<K, V> {
     final Consumer<RuntimeException> failureHandler;
 
     SegmentIndexRuntimeOpenContext(
-            final Logger logger,
             final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
@@ -47,7 +45,6 @@ final class SegmentIndexRuntimeOpenContext<K, V> {
             final AtomicLong lastAppliedWalLsn,
             final Supplier<SegmentIndexState> stateSupplier,
             final Consumer<RuntimeException> failureHandler) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.directoryFacade = Vldtn.requireNonNull(directoryFacade,
                 "directoryFacade");
         this.keyTypeDescriptor = Vldtn.requireNonNull(keyTypeDescriptor,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinator.java
@@ -4,6 +4,7 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Owns the one-shot startup sequence that recovers runtime state and marks the
@@ -16,19 +17,20 @@ final class SegmentIndexStartupCoordinator<K, V> {
 
     private static final String STALE_LOCK_RECOVERY_MESSAGE = "Recovered stale index lock (.lock). Index is going to be checked for consistency and unlocked.";
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(SegmentIndexStartupCoordinator.class);
+
     private final String indexName;
     private final boolean staleLockRecovered;
     private final SegmentIndexRuntime<K, V> runtime;
     private final SegmentIndexStateMachine stateMachine;
     private final IndexConsistencyCoordinator<K, V> consistencyCoordinator;
 
-    SegmentIndexStartupCoordinator(final Logger logger,
-            final String indexName, final boolean staleLockRecovered,
+    SegmentIndexStartupCoordinator(final String indexName,
+            final boolean staleLockRecovered,
             final SegmentIndexRuntime<K, V> runtime,
             final SegmentIndexStateMachine stateMachine,
             final IndexConsistencyCoordinator<K, V> consistencyCoordinator) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.indexName = Vldtn.requireNonNull(indexName, "indexName");
         this.staleLockRecovered = staleLockRecovered;
         this.runtime = Vldtn.requireNonNull(runtime, "runtime");
@@ -39,16 +41,16 @@ final class SegmentIndexStartupCoordinator<K, V> {
     }
 
     void completeStartup() {
-        logger.debug("Opening index '{}'.", indexName);
+        LOGGER.debug("Opening index '{}'.", indexName);
         runtime.recoverFromWal();
         runtime.cleanupOrphanedSegmentDirectories();
         stateMachine.markReady();
         if (staleLockRecovered) {
-            logger.info(STALE_LOCK_RECOVERY_MESSAGE);
+            LOGGER.info(STALE_LOCK_RECOVERY_MESSAGE);
             consistencyCoordinator.runStartupConsistencyCheck(
                     consistencyCoordinator::checkAndRepairConsistency);
         }
         runtime.requestFullSplitScan();
-        logger.debug("Index '{}' opened.", indexName);
+        LOGGER.debug("Index '{}' opened.", indexName);
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinator.java
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory;
  */
 final class RouteSplitCoordinator<K, V> {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(RouteSplitCoordinator.class);
     private final SegmentRegistry<K, V> segmentRegistry;
     private final SegmentIndexSplitPolicy<K, V> splitPolicy;
     private final RouteSplitPreparationService<K, V> preparationService;
@@ -69,24 +70,24 @@ final class RouteSplitCoordinator<K, V> {
         try {
             currentSegment = segmentRegistry.tryGetSegment(segmentId);
         } catch (final IndexException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "Route split aborted before validation because registry lookup failed: segment='{}'",
                         segmentId, e);
             }
             return false;
         }
         if (currentSegment.isEmpty()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "Route split aborted before validation because segment is not immediately available: segment='{}'",
                         segmentId);
             }
             return false;
         }
         if (currentSegment.get() != segmentHandle) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "Route split aborted because loaded segment changed: segment='{}'",
                         segmentId);
             }
@@ -110,8 +111,8 @@ final class RouteSplitCoordinator<K, V> {
 
     private void logSkippedSplit(final BlockingSegment<K, V> segmentHandle,
             final long estimatedVisibleKeys, final long splitThreshold) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                     "Route split skipped: segment='{}' estimatedKeys='{}' threshold='{}' splitFeasible='{}'",
                     segmentHandle.getId(), estimatedVisibleKeys, splitThreshold,
                     isSplitFeasible(estimatedVisibleKeys));
@@ -120,7 +121,7 @@ final class RouteSplitCoordinator<K, V> {
 
     private void logStartedSplit(final BlockingSegment<K, V> segmentHandle,
             final long splitThreshold) {
-        logger.debug("Route split started: segment='{}' threshold='{}'",
+        LOGGER.debug("Route split started: segment='{}' threshold='{}'",
                 segmentHandle.getId(), splitThreshold);
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationService.java
@@ -11,6 +11,7 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Prepares route splits by choosing a split boundary and materializing child
@@ -22,18 +23,18 @@ import org.slf4j.Logger;
 final class RouteSplitPreparationService<K, V> {
 
     private static final String SEGMENT_ARG = "segment";
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(RouteSplitPreparationService.class);
 
     private final DefaultSegmentMaterializationService<K, V> materializationService;
     private final IndexRetryPolicy retryPolicy;
-    private final Logger logger;
 
     RouteSplitPreparationService(
             final DefaultSegmentMaterializationService<K, V> materializationService,
-            final IndexRetryPolicy retryPolicy, final Logger logger) {
+            final IndexRetryPolicy retryPolicy) {
         this.materializationService = Vldtn.requireNonNull(
                 materializationService, "materializationService");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
-        this.logger = Vldtn.requireNonNull(logger, "logger");
     }
 
     RouteSplitPlan<K> prepare(final Segment<K, V> parentSegment,
@@ -121,8 +122,8 @@ final class RouteSplitPreparationService<K, V> {
 
     private void logMaterializationAbortedBecauseParentClosed(
             final Segment<K, V> parentSegment) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                     "Route split aborted because parent segment closed before child materialization completed: segment='{}'",
                     parentSegment.getId());
         }
@@ -130,8 +131,8 @@ final class RouteSplitPreparationService<K, V> {
 
     private void logMaterializationAbortedBecauseIteratorInvalidated(
             final Segment<K, V> parentSegment) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                     "Route split aborted because parent iterator was invalidated during child materialization: segment='{}'",
                     parentSegment.getId());
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinator.java
@@ -16,9 +16,10 @@ import org.slf4j.LoggerFactory;
  */
 final class RouteSplitPublishCoordinator<K, V> {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(RouteSplitPublishCoordinator.class);
     private static final String SPLIT_PLAN_ARG = "splitPlan";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final DefaultSegmentMaterializationService<K, V> materializationService;
@@ -43,8 +44,8 @@ final class RouteSplitPublishCoordinator<K, V> {
             throw abortPreparedSplit(splitPlan, e);
         }
         if (!published) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "Route split publish returned false: replacedSegmentId='{}' lowerSegmentId='{}' upperSegmentId='{}'",
                         splitPlan.getReplacedSegmentId(),
                         splitPlan.getLowerSegmentId(),
@@ -61,8 +62,8 @@ final class RouteSplitPublishCoordinator<K, V> {
         Vldtn.requireNonNull(splitPlan, SPLIT_PLAN_ARG);
         keyToSegmentMap.flushIfDirty();
         deleteRetiredParentSegment(splitPlan.getReplacedSegmentId());
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                     "Route split applied: replacedSegmentId='{}' lowerSegmentId='{}' upperSegmentId='{}' lowerMaxKey='{}'",
                     splitPlan.getReplacedSegmentId(),
                     splitPlan.getLowerSegmentId(),
@@ -99,11 +100,11 @@ final class RouteSplitPublishCoordinator<K, V> {
             if (segmentRegistry.deleteSegmentIfAvailable(segmentId)) {
                 return;
             }
-            logger.warn(
+            LOGGER.warn(
                     "Retired parent segment '{}' remained on disk because delete was busy after split publish.",
                     segmentId);
         } catch (final IndexException e) {
-            logger.warn(
+            LOGGER.warn(
                     "Retired parent segment '{}' could not be deleted after split publish: {}",
                     segmentId, e.getMessage());
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitExecutionCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitExecutionCoordinator.java
@@ -59,9 +59,7 @@ interface SplitExecutionCoordinator<K, V> {
                 new RouteSplitPreparationService<>(materializationService,
                         new org.hestiastore.index.segmentindex.IndexRetryPolicy(
                                 conf.maintenance().busyBackoffMillis(),
-                                conf.maintenance().busyTimeoutMillis()),
-                        org.slf4j.LoggerFactory.getLogger(
-                                RouteSplitCoordinator.class));
+                                conf.maintenance().busyTimeoutMillis()));
         return new SplitExecutionCoordinatorImpl<>(
                 Vldtn.requireNonNull(keyToSegmentMap, "keyToSegmentMap"),
                 Vldtn.requireNonNull(segmentTopology, "segmentTopology"),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitServiceBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitServiceBuilder.java
@@ -15,7 +15,6 @@ import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.hestiastore.index.segmentindex.core.topology.SegmentTopology;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
-import org.slf4j.LoggerFactory;
 
 /**
  * Builder for the default split runtime service.
@@ -131,8 +130,7 @@ public final class SplitServiceBuilder<K, V> {
                 validatedConf.maintenance().busyTimeoutMillis());
         final RouteSplitPreparationService<K, V> preparationService =
                 new RouteSplitPreparationService<>(materializationService,
-                        retryPolicy,
-                        LoggerFactory.getLogger(RouteSplitCoordinator.class));
+                        retryPolicy);
         final RouteSplitCoordinator<K, V> routeSplitCoordinator =
                 new RouteSplitCoordinator<>(validatedSegmentRegistry,
                         new SegmentIndexSplitPolicyThreshold<>(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexConsistencyChecker.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexConsistencyChecker.java
@@ -26,9 +26,10 @@ import org.slf4j.LoggerFactory;
  * @param <V>
  */
 public final class IndexConsistencyChecker<K, V> {
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(IndexConsistencyChecker.class);
     private static final String ERROR_MSG = "Index is broken. "
             + "File 'index.map' containing information about segments is corrupted. ";
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final SegmentRegistry<K, V> segmentRegistry;
     private final KeyToSegmentMap<K> keyToSegmentMap;
     private final Predicate<SegmentId> segmentFilter;
@@ -64,11 +65,11 @@ public final class IndexConsistencyChecker<K, V> {
                 throw new IndexException(ERROR_MSG + "Segment id is null.");
             }
             if (!segmentFilter.test(segmentId)) {
-                logger.debug("Skipping consistency check for segment '{}'.",
+                LOGGER.debug("Skipping consistency check for segment '{}'.",
                         segmentId);
                 return;
             }
-            logger.debug("checking segment '{}'.", segmentId);
+            LOGGER.debug("checking segment '{}'.", segmentId);
             final BlockingSegment<K, V> segment = awaitLoadedSegment(segmentId);
             final K maxKey = segment.checkAndRepairConsistency();
             if (maxKey == null) {
@@ -82,7 +83,7 @@ public final class IndexConsistencyChecker<K, V> {
                         + "Segment '%s' contains max key '%s', which routes to segment '%s' in the index map.",
                         segmentId, maxKey, routedSegmentId));
             }
-            logger.debug("Checking segment '{}' id done.", segmentId);
+            LOGGER.debug("Checking segment '{}' id done.", segmentId);
         });
     }
 
@@ -91,7 +92,7 @@ public final class IndexConsistencyChecker<K, V> {
         if (!confirmEmptyUnderIsolation(segment)) {
             return;
         }
-        logger.warn("Segment '{}' is empty. Removing it from index map.",
+        LOGGER.warn("Segment '{}' is empty. Removing it from index map.",
                 segmentId);
         keyToSegmentMap.removeSegmentRoute(segmentId);
         keyToSegmentMap.flushIfDirty();

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexRecoveryCleanupCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexRecoveryCleanupCoordinator.java
@@ -6,7 +6,6 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
-import org.slf4j.Logger;
 
 /**
  * Owns recovery-time cleanup of orphaned segment directories and stale lock
@@ -18,7 +17,6 @@ public final class IndexRecoveryCleanupCoordinator<K, V> {
     private final OrphanedSegmentDirectoryRemover<K, V> orphanedSegmentDirectoryRemover;
 
     public static <K, V> IndexRecoveryCleanupCoordinator<K, V> create(
-            final Logger logger,
             final Directory directoryFacade,
             final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
@@ -28,7 +26,6 @@ public final class IndexRecoveryCleanupCoordinator<K, V> {
                 Vldtn.requireNonNull(directoryFacade, "directoryFacade"),
                 Vldtn.requireNonNull(keyToSegmentMap, "keyToSegmentMap")),
                 new OrphanedSegmentDirectoryRemover<>(
-                        Vldtn.requireNonNull(logger, "logger"),
                         Vldtn.requireNonNull(segmentRegistry,
                                 "segmentRegistry"),
                         Vldtn.requireNonNull(retryPolicy, "retryPolicy")));

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexWalCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/IndexWalCoordinator.java
@@ -10,7 +10,6 @@ import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndex
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
-import org.slf4j.Logger;
 
 /**
  * Owns WAL replay, checkpointing, retention pressure handling, and failure
@@ -44,7 +43,7 @@ public final class IndexWalCoordinator<K, V> {
 
     @SuppressWarnings("java:S107")
     public static <K, V> IndexWalCoordinator<K, V> create(
-            final Logger logger, final EffectiveIndexConfiguration<K, V> conf,
+            final EffectiveIndexConfiguration<K, V> conf,
             final WalRuntime<K, V> walRuntime,
             final IndexRetryPolicy retryPolicy,
             final Runnable prepareDurableStateAction,
@@ -58,16 +57,15 @@ public final class IndexWalCoordinator<K, V> {
                         Vldtn.requireNonNull(lastAppliedWalLsn,
                                 "lastAppliedWalLsn"));
         final WalFailureTransitionHandler failureTransitionHandler =
-                new WalFailureTransitionHandler(
-                        Vldtn.requireNonNull(logger, "logger"), walRuntime,
+                new WalFailureTransitionHandler(walRuntime,
                         Vldtn.requireNonNull(stateSupplier, "stateSupplier"),
                         Vldtn.requireNonNull(failureHandler,
                                 "failureHandler"));
         final WalCheckpointExecutor<K, V> checkpointExecutor =
-                new WalCheckpointExecutor<>(logger, walRuntime,
-                        lastAppliedWalLsn, failureTransitionHandler);
+                new WalCheckpointExecutor<>(walRuntime, lastAppliedWalLsn,
+                        failureTransitionHandler);
         final WalRetentionPressureCoordinator<K, V> retentionPressureCoordinator =
-                new WalRetentionPressureCoordinator<>(logger,
+                new WalRetentionPressureCoordinator<>(
                         Vldtn.requireNonNull(conf, "conf"), walRuntime,
                         Vldtn.requireNonNull(retryPolicy, "retryPolicy"),
                         Vldtn.requireNonNull(prepareDurableStateAction,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentDirectoryRemover.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentDirectoryRemover.java
@@ -6,6 +6,7 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Removes orphaned segment directories through the registry with retry-aware
@@ -18,14 +19,15 @@ final class OrphanedSegmentDirectoryRemover<K, V> {
 
     private static final String OPERATION_CLEANUP_ORPHAN_SEGMENT = "cleanupOrphanSegment";
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(OrphanedSegmentDirectoryRemover.class);
+
     private final SegmentRegistry<K, V> segmentRegistry;
     private final IndexRetryPolicy retryPolicy;
 
-    OrphanedSegmentDirectoryRemover(final Logger logger,
+    OrphanedSegmentDirectoryRemover(
             final SegmentRegistry<K, V> segmentRegistry,
             final IndexRetryPolicy retryPolicy) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.segmentRegistry = Vldtn.requireNonNull(segmentRegistry,
                 "segmentRegistry");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
@@ -51,14 +53,14 @@ final class OrphanedSegmentDirectoryRemover<K, V> {
     }
 
     private void logDeletedOrphanedSegment(final SegmentId segmentId) {
-        logger.info(
+        LOGGER.info(
                 "Deleted orphaned segment directory '{}' during recovery/consistency cleanup.",
                 segmentId);
     }
 
     private void logDeleteFailure(final SegmentId segmentId,
             final IndexException failure) {
-        logger.warn(
+        LOGGER.warn(
                 "Orphaned segment directory '{}' could not be deleted during cleanup: {}",
                 segmentId, failure.getMessage());
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalCheckpointExecutor.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalCheckpointExecutor.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Executes WAL checkpoints and emits checkpoint diagnostics.
@@ -14,16 +15,17 @@ import org.slf4j.Logger;
  */
 final class WalCheckpointExecutor<K, V> {
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalCheckpointExecutor.class);
+
     private final WalRuntime<K, V> walRuntime;
     private final AtomicLong lastAppliedWalLsn;
     private final WalFailureTransitionHandler walFailureTransitionHandler;
 
-    WalCheckpointExecutor(final Logger logger,
+    WalCheckpointExecutor(
             final WalRuntime<K, V> walRuntime,
             final AtomicLong lastAppliedWalLsn,
             final WalFailureTransitionHandler walFailureTransitionHandler) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.walRuntime = Vldtn.requireNonNull(walRuntime, "walRuntime");
         this.lastAppliedWalLsn = Vldtn.requireNonNull(lastAppliedWalLsn,
                 "lastAppliedWalLsn");
@@ -45,11 +47,11 @@ final class WalCheckpointExecutor<K, V> {
     }
 
     private void logCheckpointStatsIfEnabled() {
-        if (!logger.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             return;
         }
         final var walStats = walRuntime.statsSnapshot();
-        logger.debug(
+        LOGGER.debug(
                 "WAL checkpoint: durableLsn={}, checkpointLsn={}, retainedBytes={}, segments={}",
                 walStats.durableLsn(), walStats.checkpointLsn(),
                 walStats.retainedBytes(), walStats.segmentCount());

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalFailureTransitionHandler.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalFailureTransitionHandler.java
@@ -7,6 +7,7 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Transitions the owning index into the error state when WAL runtime failures
@@ -14,16 +15,17 @@ import org.slf4j.Logger;
  */
 final class WalFailureTransitionHandler {
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalFailureTransitionHandler.class);
+
     private final WalRuntime<?, ?> walRuntime;
     private final Supplier<SegmentIndexState> stateSupplier;
     private final Consumer<RuntimeException> failureHandler;
 
-    WalFailureTransitionHandler(final Logger logger,
+    WalFailureTransitionHandler(
             final WalRuntime<?, ?> walRuntime,
             final Supplier<SegmentIndexState> stateSupplier,
             final Consumer<RuntimeException> failureHandler) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.walRuntime = Vldtn.requireNonNull(walRuntime, "walRuntime");
         this.stateSupplier = Vldtn.requireNonNull(stateSupplier,
                 "stateSupplier");
@@ -40,7 +42,7 @@ final class WalFailureTransitionHandler {
                 || state == SegmentIndexState.ERROR) {
             return failure;
         }
-        logger.error(
+        LOGGER.error(
                 "event=wal_sync_failure_transition state={} action=transition_to_error reason=wal_sync_failure",
                 state, failure);
         failureHandler.accept(failure);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalRetentionPressureCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/storage/WalRetentionPressureCoordinator.java
@@ -9,6 +9,7 @@ import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndex
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles WAL retention pressure backpressure, warning cadence, and forced
@@ -22,7 +23,9 @@ final class WalRetentionPressureCoordinator<K, V> {
     private static final long WAL_RETENTION_PRESSURE_WARN_INTERVAL_NANOS = TimeUnit.SECONDS
             .toNanos(5L);
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalRetentionPressureCoordinator.class);
+
     private final EffectiveIndexConfiguration<K, V> conf;
     private final WalRuntime<K, V> walRuntime;
     private final IndexRetryPolicy retryPolicy;
@@ -34,14 +37,13 @@ final class WalRetentionPressureCoordinator<K, V> {
     private final AtomicBoolean walRetentionPressureWarnActive = new AtomicBoolean(
             false);
 
-    WalRetentionPressureCoordinator(final Logger logger,
+    WalRetentionPressureCoordinator(
             final EffectiveIndexConfiguration<K, V> conf,
             final WalRuntime<K, V> walRuntime,
             final IndexRetryPolicy retryPolicy,
             final Runnable prepareDurableStateAction,
             final Runnable flushDurableStateAction,
             final Runnable checkpointAction) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.conf = Vldtn.requireNonNull(conf, "conf");
         this.walRuntime = Vldtn.requireNonNull(walRuntime, "walRuntime");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
@@ -90,7 +92,7 @@ final class WalRetentionPressureCoordinator<K, V> {
             if (walRetentionPressureLastWarnNanos
                     .compareAndSet(previousWarnNanos, nowNanos)) {
                 walRetentionPressureWarnActive.set(true);
-                logger.warn(
+                LOGGER.warn(
                         "event=wal_retention_pressure_start retainedBytes={} threshold={} action=force_checkpoint_backpressure",
                         walRuntime.retainedBytes(),
                         conf.wal().getMaxBytesBeforeForcedCheckpoint());
@@ -106,7 +108,7 @@ final class WalRetentionPressureCoordinator<K, V> {
         }
         final long elapsedMillis = TimeUnit.NANOSECONDS
                 .toMillis(Math.max(0L, System.nanoTime() - startNanos));
-        logger.info(
+        LOGGER.info(
                 "event=wal_retention_pressure_cleared retainedBytes={} threshold={} checkpointAttempts={} elapsedMillis={}",
                 walRuntime.retainedBytes(),
                 conf.wal().getMaxBytesBeforeForcedCheckpoint(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceBuilder.java
@@ -5,7 +5,6 @@ import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentindex.core.stablesegment.StableSegmentOperationAccess;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
-import org.slf4j.Logger;
 
 /**
  * Builder for {@link SegmentStreamingService} instances.
@@ -15,24 +14,12 @@ import org.slf4j.Logger;
  */
 public final class SegmentStreamingServiceBuilder<K, V> {
 
-    private Logger logger;
     private KeyToSegmentMap<K> keyToSegmentMap;
     private SegmentRegistry<K, V> segmentRegistry;
     private StableSegmentOperationAccess<K, V> stableSegmentGateway;
     private IndexRetryPolicy retryPolicy;
 
     SegmentStreamingServiceBuilder() {
-    }
-
-    /**
-     * Sets the logger used by streaming operations.
-     *
-     * @param logger logger
-     * @return this builder
-     */
-    public SegmentStreamingServiceBuilder<K, V> logger(final Logger logger) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
-        return this;
     }
 
     /**
@@ -93,7 +80,6 @@ public final class SegmentStreamingServiceBuilder<K, V> {
      */
     public SegmentStreamingService<K, V> build() {
         return new SegmentStreamingServiceImpl<>(
-                Vldtn.requireNonNull(logger, "logger"),
                 Vldtn.requireNonNull(keyToSegmentMap, "keyToSegmentMap"),
                 Vldtn.requireNonNull(segmentRegistry, "segmentRegistry"),
                 Vldtn.requireNonNull(stableSegmentGateway,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceImpl.java
@@ -15,24 +15,26 @@ import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.BlockingSegment;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class SegmentStreamingServiceImpl<K, V>
         implements SegmentStreamingService<K, V> {
 
     private static final String OPEN_ITERATOR_OPERATION = "openIterator";
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(SegmentStreamingServiceImpl.class);
+
     private final KeyToSegmentMap<K> keyToSegmentMap;
     private final SegmentRegistry<K, V> segmentRegistry;
     private final StableSegmentOperationAccess<K, V> stableSegmentGateway;
     private final IndexRetryPolicy retryPolicy;
 
-    SegmentStreamingServiceImpl(final Logger logger,
+    SegmentStreamingServiceImpl(
             final KeyToSegmentMap<K> keyToSegmentMap,
             final SegmentRegistry<K, V> segmentRegistry,
             final StableSegmentOperationAccess<K, V> stableSegmentGateway,
             final IndexRetryPolicy retryPolicy) {
-        this.logger = Vldtn.requireNonNull(logger, "logger");
         this.keyToSegmentMap = Vldtn.requireNonNull(keyToSegmentMap,
                 "keyToSegmentMap");
         this.segmentRegistry = Vldtn.requireNonNull(segmentRegistry,
@@ -90,7 +92,7 @@ final class SegmentStreamingServiceImpl<K, V>
         if (!isSegmentStillMapped(segmentId)) {
             return;
         }
-        logger.debug(
+        LOGGER.debug(
                 "Skipping iterator invalidation for segment '{}' because it is "
                         + "not immediately available.",
                 segmentId);
@@ -101,7 +103,7 @@ final class SegmentStreamingServiceImpl<K, V>
         if (!isSegmentStillMapped(segmentId)) {
             return;
         }
-        logger.debug(
+        LOGGER.debug(
                 "Skipping iterator invalidation for segment '{}' because registry lookup failed.",
                 segmentId, exception);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentsIterator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/streaming/SegmentsIterator.java
@@ -29,12 +29,12 @@ import org.slf4j.LoggerFactory;
 class SegmentsIterator<K, V> extends AbstractCloseableResource
         implements EntryIterator<K, V> {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(SegmentsIterator.class);
     private static final IndexRetryPolicy DEFAULT_RETRY_POLICY = new IndexRetryPolicy(
             IndexConfigurationContract.DEFAULT_INDEX_BUSY_BACKOFF_MILLIS,
             IndexConfigurationContract.DEFAULT_INDEX_BUSY_TIMEOUT_MILLIS);
     private static final String OPEN_ITERATOR_OPERATION = "openIterator";
-
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final SegmentRegistry<K, V> segmentRegistry;
     private final SegmentIteratorIsolation isolation;
@@ -70,7 +70,7 @@ class SegmentsIterator<K, V> extends AbstractCloseableResource
         nextEntry = null;
         while (position < ids.size()) {
             final SegmentId segmentId = ids.get(position);
-            logger.debug("Starting processing segment '{}' which is {} of {}",
+            LOGGER.debug("Starting processing segment '{}' which is {} of {}",
                     segmentId, position, ids.size());
             position++;
             final EntryIterator<K, V> iterator = openSegmentIterator(segmentId);
@@ -93,7 +93,7 @@ class SegmentsIterator<K, V> extends AbstractCloseableResource
     private EntryIterator<K, V> openSegmentIterator(final SegmentId segmentId) {
         final BlockingSegment<K, V> segmentHandle = awaitSegment(segmentId);
         if (segmentHandle == null) {
-            logger.debug(
+            LOGGER.debug(
                     "Skipping segment '{}' because it is not available in '{}' isolation mode.",
                     segmentId, isolation);
             return null;
@@ -101,7 +101,7 @@ class SegmentsIterator<K, V> extends AbstractCloseableResource
         final EntryIterator<K, V> iterator = awaitOpenIterator(segmentHandle,
                 segmentId);
         if (iterator == null) {
-            logger.debug(
+            LOGGER.debug(
                     "Skipping segment '{}' because iterator cannot be opened in '{}' isolation mode.",
                     segmentId, isolation);
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
@@ -29,7 +29,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(KeyToSegmentMapImpl.class);
     private static final TypeDescriptorSegmentId tdSegId = new TypeDescriptorSegmentId();
 
     private static final String FILE_NAME = "index.map";
@@ -84,7 +85,7 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
             if (oldKey == null) {
                 tmp.put(segmentId, key);
             } else {
-                logger.error(String.format(
+                LOGGER.error(String.format(
                         "Segment id '%s' is used for segment with "
                                 + "key '%s' and segment with key '%s'.",
                         segmentId, key, oldKey));
@@ -286,8 +287,8 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
         if (upperMaxKey == null) {
             return false;
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                     "Split debug: map apply replacedSegmentId='{}', oldMaxKey='{}', lowerSegmentId='{}', lowerMaxKey='{}', splitMode='{}', upperSegmentId='{}'.",
                     replacedSegmentId, upperMaxKey, lowerSegmentId,
                     plan.getLowerMaxKey(), plan.getSplitMode(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalMetadataCatalog.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalMetadataCatalog.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.hestiastore.index.IndexException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class WalMetadataCatalog {
 
@@ -25,13 +26,13 @@ final class WalMetadataCatalog {
     private static final int SEGMENT_FILE_DIGITS = 20;
     private static final String SEGMENT_FILE_FORMAT = "%020d" + SEGMENT_SUFFIX;
     private static final int FORMAT_VERSION = 1;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalMetadataCatalog.class);
 
     private final WalStorage storage;
-    private final Logger logger;
 
-    WalMetadataCatalog(final WalStorage storage, final Logger logger) {
+    WalMetadataCatalog(final WalStorage storage) {
         this.storage = storage;
-        this.logger = logger;
     }
 
     void ensureFormatMarker() {
@@ -153,11 +154,11 @@ final class WalMetadataCatalog {
             storage.rename(CHECKPOINT_FILE_TMP, CHECKPOINT_FILE);
             storage.sync(CHECKPOINT_FILE);
             storage.syncMetadata();
-            logger.info(
+            LOGGER.info(
                     "event=wal_checkpoint_metadata_tmp_recovered checkpointLsn={}",
                     parsed);
         } catch (RuntimeException ex) {
-            logger.warn(
+            LOGGER.warn(
                     "event=wal_checkpoint_metadata_tmp_dropped reason=invalid error={}",
                     ex.getMessage());
             storage.delete(CHECKPOINT_FILE_TMP);
@@ -265,17 +266,17 @@ final class WalMetadataCatalog {
                 storage.rename(FORMAT_FILE_TMP, FORMAT_FILE);
                 storage.sync(FORMAT_FILE);
                 storage.syncMetadata();
-                logger.info(
+                LOGGER.info(
                         "event=wal_format_metadata_tmp_recovered version={} checksum={}",
                         meta.version(), meta.checksum());
                 return;
             }
-            logger.warn(
+            LOGGER.warn(
                     "event=wal_format_metadata_tmp_dropped reason=unsupported version={} checksum={} expectedVersion={} expectedChecksum={}",
                     meta.version(), meta.checksum(), FORMAT_VERSION,
                     expectedChecksum);
         } catch (RuntimeException ex) {
-            logger.warn(
+            LOGGER.warn(
                     "event=wal_format_metadata_tmp_dropped reason=invalid error={}",
                     ex.getMessage());
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRecoveryManager.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRecoveryManager.java
@@ -6,10 +6,13 @@ import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.WalCorruptionPolicy;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class WalRecoveryManager<K, V> {
 
     private static final int BUFFER_SIZE = 8 * 1024;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalRecoveryManager.class);
 
     private final IndexWalConfiguration wal;
     private final WalStorage storage;
@@ -17,20 +20,18 @@ final class WalRecoveryManager<K, V> {
     private final WalRecordCodec<K, V> recordCodec;
     private final WalSegmentCatalog segmentCatalog;
     private final WalRuntimeMetrics metrics;
-    private final Logger logger;
 
     WalRecoveryManager(final IndexWalConfiguration wal, final WalStorage storage,
             final WalMetadataCatalog metadataCatalog,
             final WalRecordCodec<K, V> recordCodec,
             final WalSegmentCatalog segmentCatalog,
-            final WalRuntimeMetrics metrics, final Logger logger) {
+            final WalRuntimeMetrics metrics) {
         this.wal = wal;
         this.storage = storage;
         this.metadataCatalog = metadataCatalog;
         this.recordCodec = recordCodec;
         this.segmentCatalog = segmentCatalog;
         this.metrics = metrics;
-        this.logger = logger;
     }
 
     WalRecoveryOutcome recover(
@@ -40,7 +41,7 @@ final class WalRecoveryManager<K, V> {
         segmentCatalog.resetRecoveredSegments();
         final List<WalSegmentDescriptor> discoveredSegments = catalogView
                 .discoveredSegments();
-        logger.info(
+        LOGGER.info(
                 "event=wal_recovery_start checkpointLsn={} segmentCount={} corruptionPolicy={}",
                 checkpointLsn, discoveredSegments.size(),
                 wal.getCorruptionPolicy());
@@ -63,7 +64,7 @@ final class WalRecoveryManager<K, V> {
             }
             if (scan.invalidTail()) {
                 truncatedTail = true;
-                logger.warn(
+                LOGGER.warn(
                         "event=wal_recovery_invalid_tail segment={} validBytes={} observedMaxLsn={} policy={}",
                         current.name(), scan.validBytes(), scan.maxLsn(),
                         wal.getCorruptionPolicy());
@@ -71,7 +72,7 @@ final class WalRecoveryManager<K, V> {
                 final int deletedAfterCorruption = segmentCatalog
                         .deleteSegmentsAfter(discoveredSegments, i + 1);
                 if (deletedAfterCorruption > 0) {
-                    logger.warn(
+                    LOGGER.warn(
                             "event=wal_recovery_drop_newer_segments deletedSegments={} fromSegmentIndex={}",
                             deletedAfterCorruption, i + 1);
                 }
@@ -94,7 +95,7 @@ final class WalRecoveryManager<K, V> {
                 final String name = current.name();
                 storage.delete(name);
                 storage.syncMetadata();
-                logger.info("event=wal_recovery_drop_empty_segment segment={}",
+                LOGGER.info("event=wal_recovery_drop_empty_segment segment={}",
                         name);
             }
         }
@@ -103,14 +104,14 @@ final class WalRecoveryManager<K, V> {
             checkpointLsn = lastSeenLsn;
             metadataCatalog.writeCheckpointLsnAtomic(checkpointLsn);
             maxLsn = lastSeenLsn;
-            logger.warn(
+            LOGGER.warn(
                     "event=wal_recovery_checkpoint_clamp previousCheckpointLsn={} clampedCheckpointLsn={} maxLsn={}",
                     previousCheckpointLsn, checkpointLsn, maxLsn);
         }
         if (lastReplayedLsn > maxLsn) {
             lastReplayedLsn = maxLsn;
         }
-        logger.info(
+        LOGGER.info(
                 "event=wal_recovery_complete maxLsn={} checkpointLsn={} lastReplayedLsn={} truncatedTail={} segmentCount={}",
                 maxLsn, checkpointLsn, lastReplayedLsn, truncatedTail,
                 segmentCatalog.segmentCount());
@@ -175,7 +176,7 @@ final class WalRecoveryManager<K, V> {
     private void handleInvalidTail(final String fileName, final long validBytes) {
         metrics.recordCorruption();
         if (wal.getCorruptionPolicy() == WalCorruptionPolicy.FAIL_FAST) {
-            logger.error(
+            LOGGER.error(
                     "event=wal_recovery_tail_repair action=fail_fast segment={} validBytes={}",
                     fileName, validBytes);
             throw new IndexException(
@@ -185,14 +186,14 @@ final class WalRecoveryManager<K, V> {
         if (validBytes <= 0L) {
             storage.delete(fileName);
             storage.syncMetadata();
-            logger.warn(
+            LOGGER.warn(
                     "event=wal_recovery_tail_repair action=delete_segment segment={} validBytes={}",
                     fileName, validBytes);
             return;
         }
         storage.truncate(fileName, validBytes);
         storage.sync(fileName);
-        logger.warn(
+        LOGGER.warn(
                 "event=wal_recovery_tail_repair action=truncate_segment segment={} validBytes={}",
                 fileName, validBytes);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRuntime.java
@@ -13,8 +13,6 @@ import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.WalDurabilityMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compatibility-facing WAL runtime facade.
@@ -33,9 +31,6 @@ import org.slf4j.LoggerFactory;
  * @param <V> value type
  */
 public final class WalRuntime<K, V> implements AutoCloseable {
-
-    private static final Logger logger = LoggerFactory
-            .getLogger(WalRuntime.class);
 
     /**
      * WAL operation kind.
@@ -204,7 +199,7 @@ public final class WalRuntime<K, V> implements AutoCloseable {
         final WalRuntimeMetrics metrics = new WalRuntimeMetrics();
         final AtomicBoolean closed = new AtomicBoolean();
         final WalMetadataCatalog metadataCatalog = new WalMetadataCatalog(
-                storage, logger);
+                storage);
         final WalRecordCodec<K, V> recordCodec = new WalRecordCodec<>(
                 keyDescriptor == null ? null : keyDescriptor.getTypeEncoder(),
                 keyDescriptor == null ? null : keyDescriptor.getTypeDecoder(),
@@ -213,15 +208,14 @@ public final class WalRuntime<K, V> implements AutoCloseable {
                 valueDescriptor == null ? null
                         : valueDescriptor.getTypeDecoder());
         final WalSegmentCatalog segmentCatalog = new WalSegmentCatalog(wal,
-                storage, metadataCatalog, logger);
+                storage, metadataCatalog);
         final WalSyncPolicy syncPolicy = new WalSyncPolicy(wal, storage,
-                metrics, logger, monitor, segmentCatalog::segments,
-                closed::get);
+                metrics, monitor, segmentCatalog::segments, closed::get);
         final WalWriter<K, V> writer = new WalWriter<>(wal, storage,
                 recordCodec, segmentCatalog, metrics, syncPolicy);
         final WalRecoveryManager<K, V> recoveryManager =
                 new WalRecoveryManager<>(wal, storage, metadataCatalog,
-                        recordCodec, segmentCatalog, metrics, logger);
+                        recordCodec, segmentCatalog, metrics);
         return new WalRuntime<>(wal, monitor, metrics, closed, metadataCatalog,
                 segmentCatalog, syncPolicy, writer, recoveryManager,
                 newGroupSyncExecutor(wal, syncPolicy));

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalSegmentCatalog.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalSegmentCatalog.java
@@ -6,16 +6,18 @@ import java.util.concurrent.TimeUnit;
 
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class WalSegmentCatalog {
 
     private static final long CHECKPOINT_CLEANUP_LOG_INTERVAL_NANOS = TimeUnit.SECONDS
             .toNanos(5L);
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalSegmentCatalog.class);
 
     private final IndexWalConfiguration wal;
     private final WalStorage storage;
     private final WalMetadataCatalog metadataCatalog;
-    private final Logger logger;
     private final List<WalSegmentDescriptor> segments = new ArrayList<>();
 
     private long retainedBytes = 0L;
@@ -25,11 +27,10 @@ final class WalSegmentCatalog {
     private long checkpointCleanupSuppressedDeletedBytes = 0L;
 
     WalSegmentCatalog(final IndexWalConfiguration wal, final WalStorage storage,
-            final WalMetadataCatalog metadataCatalog, final Logger logger) {
+            final WalMetadataCatalog metadataCatalog) {
         this.wal = wal;
         this.storage = storage;
         this.metadataCatalog = metadataCatalog;
-        this.logger = logger;
     }
 
     void resetRecoveredSegments() {
@@ -154,7 +155,7 @@ final class WalSegmentCatalog {
         checkpointCleanupSuppressedDeletedSegments = 0L;
         checkpointCleanupSuppressedDeletedBytes = 0L;
         checkpointCleanupLastLogNanos = nowNanos;
-        logger.info(
+        LOGGER.info(
                 "event=wal_checkpoint_cleanup checkpointLsn={} deletedSegments={} deletedBytes={} retainedSegments={} retainedBytes={} suppressedEvents={} suppressedDeletedSegments={} suppressedDeletedBytes={}",
                 checkpointLsn, deletedCount, deletedBytes, segments.size(),
                 retainedBytes, suppressedEvents, suppressedDeletedSegments,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalSyncPolicy.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalSyncPolicy.java
@@ -12,13 +12,16 @@ import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.WalDurabilityMode;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class WalSyncPolicy {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WalSyncPolicy.class);
 
     private final IndexWalConfiguration wal;
     private final WalStorage storage;
     private final WalRuntimeMetrics metrics;
-    private final Logger logger;
     private final Object monitor;
     private final Supplier<List<WalSegmentDescriptor>> segmentsSupplier;
     private final BooleanSupplier closedSupplier;
@@ -30,14 +33,12 @@ final class WalSyncPolicy {
     private RuntimeException syncFailure;
 
     WalSyncPolicy(final IndexWalConfiguration wal, final WalStorage storage,
-            final WalRuntimeMetrics metrics, final Logger logger,
-            final Object monitor,
+            final WalRuntimeMetrics metrics, final Object monitor,
             final Supplier<List<WalSegmentDescriptor>> segmentsSupplier,
             final BooleanSupplier closedSupplier) {
         this.wal = wal;
         this.storage = storage;
         this.metrics = metrics;
-        this.logger = logger;
         this.monitor = monitor;
         this.segmentsSupplier = segmentsSupplier;
         this.closedSupplier = closedSupplier;
@@ -176,7 +177,7 @@ final class WalSyncPolicy {
             syncFailure = ex;
         }
         metrics.recordSyncFailure();
-        logger.error(
+        LOGGER.error(
                 "event=wal_sync_failure durableLsn={} pendingHighLsn={} pendingSyncBytes={} segmentCount={} syncFailureCount={}",
                 durableLsn.get(), pendingSyncHighLsn, pendingSyncBytes,
                 segmentsSupplier.get().size(), metrics.syncFailureCount(), ex);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImplTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class MaintenanceServiceImplTest {
@@ -73,7 +72,6 @@ class MaintenanceServiceImplTest {
         stats = new Stats();
         maintenanceExecutor = Executors.newSingleThreadExecutor();
         service = new MaintenanceServiceImpl<>(
-                LoggerFactory.getLogger(MaintenanceServiceImplTest.class),
                 synchronizedKeyToSegmentMap, stableSegmentGateway,
                 splitService, retryPolicy(), stats, maintenanceExecutor,
                 checkpointAction);
@@ -117,8 +115,6 @@ class MaintenanceServiceImplTest {
         when(stableSegments.flush(segmentId)).thenReturn(StableSegmentOperationResult.busy());
         final MaintenanceServiceImpl<Integer, String> maintenance =
                 new MaintenanceServiceImpl<>(
-                        LoggerFactory.getLogger(
-                                MaintenanceServiceImplTest.class),
                         mappedSegments, stableSegments, splitServiceValue,
                         retryPolicy(), new Stats(), maintenanceExecutor,
                         checkpoint);
@@ -133,7 +129,6 @@ class MaintenanceServiceImplTest {
     void flushSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
         final SegmentId segmentId = createBootstrapSegment("key");
         service = new MaintenanceServiceImpl<>(
-                LoggerFactory.getLogger(MaintenanceServiceImplTest.class),
                 synchronizedKeyToSegmentMap, stableSegmentGateway, splitService,
                 retryPolicy(), stats, maintenanceExecutor, checkpointAction,
                 sequenceNanoTimeSupplier(10_000L, 35_000L));
@@ -153,7 +148,6 @@ class MaintenanceServiceImplTest {
     void compactSegment_recordsAcceptedToReadyLatencyAndBusyRetryCount() {
         final SegmentId segmentId = createBootstrapSegment("key");
         service = new MaintenanceServiceImpl<>(
-                LoggerFactory.getLogger(MaintenanceServiceImplTest.class),
                 synchronizedKeyToSegmentMap, stableSegmentGateway, splitService,
                 retryPolicy(), stats, maintenanceExecutor, checkpointAction,
                 sequenceNanoTimeSupplier(20_000L, 68_000L));

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceTest.java
@@ -23,7 +23,6 @@ import org.hestiastore.index.segmentindex.core.stablesegment.StableSegmentOperat
 import org.hestiastore.index.segmentindex.core.split.SplitService;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class MaintenanceServiceTest {
 
@@ -62,8 +61,6 @@ class MaintenanceServiceTest {
                     StableSegmentOperationResult.busy());
             final MaintenanceService maintenance = MaintenanceService
                     .<Integer, String>builder()
-                    .logger(LoggerFactory.getLogger(
-                            MaintenanceServiceTest.class))
                     .keyToSegmentMap(keyToSegmentMap)
                     .stableSegmentGateway(stableSegmentGateway)
                     .splitService(splitService)
@@ -88,14 +85,15 @@ class MaintenanceServiceTest {
     }
 
     @Test
-    void builderRejectsMissingLogger() {
+    void builderRejectsMissingKeyToSegmentMap() {
         final MaintenanceServiceBuilder<Integer, String> builder =
                 MaintenanceService.<Integer, String>builder();
 
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, builder::build);
 
-        assertEquals("Property 'logger' must not be null.", ex.getMessage());
+        assertEquals("Property 'keyToSegmentMap' must not be null.",
+                ex.getMessage());
     }
 
     @Test
@@ -109,7 +107,6 @@ class MaintenanceServiceTest {
                 SplitService.class);
         final MaintenanceServiceBuilder<Integer, String> builder = MaintenanceService
                 .<Integer, String>builder()
-                .logger(LoggerFactory.getLogger(MaintenanceServiceTest.class))
                 .keyToSegmentMap(keyToSegmentMap)
                 .stableSegmentGateway(stableSegmentGateway)
                 .splitService(splitService)
@@ -137,8 +134,6 @@ class MaintenanceServiceTest {
         try {
             final MaintenanceServiceBuilder<Integer, String> builder =
                     MaintenanceService.<Integer, String>builder()
-                            .logger(LoggerFactory.getLogger(
-                                    MaintenanceServiceTest.class))
                             .keyToSegmentMap(keyToSegmentMap)
                             .stableSegmentGateway(stableSegmentGateway)
                             .splitService(splitService)

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
@@ -18,13 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class IndexCloseCoordinatorTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private Runnable awaitOperations;
@@ -62,15 +58,13 @@ class IndexCloseCoordinatorTest {
             finishCloseTransition.run();
             return null;
         }).when(stateMachine).completeClose();
-        closeCoordinator = new IndexCloseCoordinator<>(logger, "test-index",
+        closeCoordinator = new IndexCloseCoordinator<>("test-index",
                 stateMachine, operationTracker, new Stats(), runtime,
                 new IndexDirectoryLock(directory));
     }
 
     @Test
     void close_runsShutdownStepsInOrder() {
-        when(logger.isDebugEnabled()).thenReturn(true);
-
         closeCoordinator.close();
 
         final InOrder inOrder = inOrder(awaitOperations, runtime,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactoryTest.java
@@ -31,12 +31,9 @@ import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class SegmentIndexRuntimeFactoryTest {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final TypeDescriptorInteger tdi = new TypeDescriptorInteger();
     private final TypeDescriptorShortString tds = new TypeDescriptorShortString();
 
@@ -56,8 +53,7 @@ class SegmentIndexRuntimeFactoryTest {
         if (runtime != null) {
             final SegmentIndexStateMachine stateMachine = new SegmentIndexStateMachine();
             stateMachine.markReady();
-            new IndexCloseCoordinator<>(logger,
-                    "runtime-graph-builder-test",
+            new IndexCloseCoordinator<>("runtime-graph-builder-test",
                     stateMachine,
                     Mockito.mock(IndexOperationTrackingAccess.class), new Stats(),
                     runtime, new IndexDirectoryLock(new MemDirectory())).close();
@@ -118,7 +114,7 @@ class SegmentIndexRuntimeFactoryTest {
             final IndexConfiguration<Integer, String> conf,
             final Consumer<RuntimeException> failureHandler,
             final SegmentIndexRuntimeFactory.ResourceCreationObserver<Integer, String> resourceCreationObserver) {
-        final SegmentIndexRuntimeOpenContext<Integer, String> request = new SegmentIndexRuntimeOpenContext<>(logger,
+        final SegmentIndexRuntimeOpenContext<Integer, String> request = new SegmentIndexRuntimeOpenContext<>(
                 new MemDirectory(), tdi, tds, effective(conf),
                 executorRegistry, new Stats(), new AtomicLong(),
                 new AtomicLong(), new AtomicLong(),

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeOpenContextTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeOpenContextTest.java
@@ -16,14 +16,12 @@ import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
 
 @SuppressWarnings("unchecked")
 class SegmentIndexRuntimeOpenContextTest {
 
     @Test
-    void constructorRejectsNullLogger() {
-        final Directory directory = mock(Directory.class);
+    void constructorRejectsNullDirectory() {
         final TypeDescriptor<Integer> keyTypeDescriptor = mock(
                 TypeDescriptor.class);
         final TypeDescriptor<String> valueTypeDescriptor = mock(
@@ -40,17 +38,17 @@ class SegmentIndexRuntimeOpenContextTest {
 
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new SegmentIndexRuntimeOpenContext<>(null, directory,
+                () -> new SegmentIndexRuntimeOpenContext<>(null,
                         keyTypeDescriptor, valueTypeDescriptor, conf,
                         executorRegistry, stats, compactRequestHighWaterMark,
                         flushRequestHighWaterMark, lastAppliedWalLsn,
                         stateSupplier, failureHandler));
-        assertEquals("Property 'logger' must not be null.", ex.getMessage());
+        assertEquals("Property 'directoryFacade' must not be null.",
+                ex.getMessage());
     }
 
     @Test
     void constructorExposesValidatedAssemblyInputs() {
-        final Logger logger = mock(Logger.class);
         final Directory directory = mock(Directory.class);
         final TypeDescriptor<Integer> keyTypeDescriptor = mock(
                 TypeDescriptor.class);
@@ -68,13 +66,12 @@ class SegmentIndexRuntimeOpenContextTest {
         final Consumer<RuntimeException> failureHandler = failureHandler();
 
         final SegmentIndexRuntimeOpenContext<Integer, String> request =
-                new SegmentIndexRuntimeOpenContext<>(logger, directory,
+                new SegmentIndexRuntimeOpenContext<>(directory,
                         keyTypeDescriptor, valueTypeDescriptor, conf,
                         executorRegistry, stats, compactRequestHighWaterMark,
                         flushRequestHighWaterMark, lastAppliedWalLsn,
                         stateSupplier, failureHandler);
 
-        assertSame(logger, request.logger);
         assertSame(stats, request.stats);
         assertSame(compactRequestHighWaterMark,
                 request.compactRequestHighWaterMark);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTest.java
@@ -22,12 +22,9 @@ import org.mockito.Mockito;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class SegmentIndexRuntimeTest {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final TypeDescriptorInteger tdi = new TypeDescriptorInteger();
     private final TypeDescriptorShortString tds = new TypeDescriptorShortString();
 
@@ -41,7 +38,7 @@ class SegmentIndexRuntimeTest {
         final AtomicReference<RuntimeException> failureRef = new AtomicReference<>();
         runtime = new SegmentIndexRuntimeFactory<>(
                 new SegmentIndexRuntimeOpenContext<>(
-                        logger, new MemDirectory(), tdi, tds, effective(conf),
+                        new MemDirectory(), tdi, tds, effective(conf),
                         executorRegistry, new Stats(), new AtomicLong(),
                         new AtomicLong(), new AtomicLong(),
                         () -> SegmentIndexState.READY, failureRef::set))
@@ -53,8 +50,7 @@ class SegmentIndexRuntimeTest {
         if (runtime != null) {
             final SegmentIndexStateMachine stateMachine = new SegmentIndexStateMachine();
             stateMachine.markReady();
-            new IndexCloseCoordinator<>(logger, "runtime-test",
-                    stateMachine,
+            new IndexCloseCoordinator<>("runtime-test", stateMachine,
                     Mockito.mock(IndexOperationTrackingAccess.class), new Stats(),
                     runtime, new IndexDirectoryLock(new MemDirectory())).close();
             SegmentIndexRuntimeTestAccess.keyToSegmentMap(runtime).close();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
@@ -23,7 +23,6 @@ import org.hestiastore.index.segmentindex.metrics.Stats;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
-import org.slf4j.Logger;
 
 /**
  * Test-only bridge exposing package-private runtime internals without keeping
@@ -34,14 +33,14 @@ public final class SegmentIndexRuntimeTestAccess {
     private SegmentIndexRuntimeTestAccess() {
     }
 
-    public static <K, V> Object openRuntime(final Logger logger,
+    public static <K, V> Object openRuntime(
             final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
             final IndexConfiguration<K, V> conf,
             final ExecutorRegistry executorRegistry) {
-        return SegmentIndexRuntime.create(logger, directoryFacade,
-                keyTypeDescriptor, valueTypeDescriptor, effective(conf),
+        return SegmentIndexRuntime.create(directoryFacade, keyTypeDescriptor,
+                valueTypeDescriptor, effective(conf),
                 executorRegistry, new Stats(), () -> SegmentIndexState.READY,
                 failure -> {
                 });
@@ -107,9 +106,7 @@ public final class SegmentIndexRuntimeTestAccess {
         final SegmentIndexStateMachine stateMachine =
                 new SegmentIndexStateMachine();
         stateMachine.markReady();
-        new IndexCloseCoordinator<>(org.slf4j.LoggerFactory
-                .getLogger(SegmentIndexRuntimeTestAccess.class), indexName,
-                stateMachine,
+        new IndexCloseCoordinator<>(indexName, stateMachine,
                 mock(IndexOperationTrackingAccess.class),
                 new Stats(), runtime,
                 new IndexDirectoryLock(new MemDirectory()))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupCoordinatorTest.java
@@ -14,13 +14,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class SegmentIndexStartupCoordinatorTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private SegmentIndexRuntime<Integer, String> runtime;
@@ -35,7 +31,7 @@ class SegmentIndexStartupCoordinatorTest {
 
     @BeforeEach
     void setUp() {
-        startupCoordinator = new SegmentIndexStartupCoordinator<>(logger,
+        startupCoordinator = new SegmentIndexStartupCoordinator<>(
                 "startup-test", false, runtime, stateMachine,
                 consistencyCoordinator);
     }
@@ -54,7 +50,7 @@ class SegmentIndexStartupCoordinatorTest {
 
     @Test
     void completeStartup_runsConsistencyCheckAfterStaleLockRecovery() {
-        startupCoordinator = new SegmentIndexStartupCoordinator<>(logger,
+        startupCoordinator = new SegmentIndexStartupCoordinator<>(
                 "startup-test", true, runtime, stateMachine,
                 consistencyCoordinator);
         doAnswer(invocation -> {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
@@ -134,12 +134,10 @@ class SegmentIndexStartupRecoveryTest {
                     }, segmentId -> false);
             return new SegmentIndexSessionOwner<>(stateMachine, runtime,
                     new IndexCloseCoordinator<>(
-                            LoggerFactory.getLogger(TrackingIndex.class),
                             conf.identity().name(), stateMachine,
                             IndexOperationTrackingAccess.create(), new Stats(),
                             runtime, directoryLock),
                     new SegmentIndexStartupCoordinator<>(
-                            LoggerFactory.getLogger(TrackingIndex.class),
                             conf.identity().name(),
                             directoryLock.wasStaleLockRecovered(), runtime,
                             stateMachine, consistencyCoordinator));

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class RouteSplitCoordinatorTest {
@@ -72,8 +71,7 @@ class RouteSplitCoordinatorTest {
                 new SegmentIndexSplitPolicyThreshold<>(),
                 new RouteSplitPreparationService<>(materializationService,
                         new IndexRetryPolicy(maintenance.busyBackoffMillis(),
-                                maintenance.busyTimeoutMillis()),
-                        LoggerFactory.getLogger(RouteSplitCoordinator.class)));
+                                maintenance.busyTimeoutMillis())));
         splitPlan = new RouteSplitPlan<>(PARENT_SEGMENT_ID, LOWER_SEGMENT_ID,
                 UPPER_SEGMENT_ID, 2, RouteSplitPlan.SplitMode.SPLIT);
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class RouteSplitPreparationServiceTest {
@@ -33,15 +32,12 @@ class RouteSplitPreparationServiceTest {
     @Mock
     private DefaultSegmentMaterializationService<Integer, String> materializationService;
 
-    @Mock
-    private Logger logger;
-
     private RouteSplitPreparationService<Integer, String> preparationService;
 
     @BeforeEach
     void setUp() {
         preparationService = new RouteSplitPreparationService<>(
-                materializationService, new IndexRetryPolicy(1, 1), logger);
+                materializationService, new IndexRetryPolicy(1, 1));
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/IndexRecoveryCleanupCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/IndexRecoveryCleanupCoordinatorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class IndexRecoveryCleanupCoordinatorTest {
@@ -43,8 +42,6 @@ class IndexRecoveryCleanupCoordinatorTest {
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
         coordinator = IndexRecoveryCleanupCoordinator.create(
-                LoggerFactory.getLogger(
-                        IndexRecoveryCleanupCoordinatorTest.class),
                 directory, synchronizedKeyToSegmentMap, segmentRegistry,
                 new IndexRetryPolicy(1, 10));
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/IndexWalCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/IndexWalCoordinatorTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -31,13 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class IndexWalCoordinatorTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private WalRuntime<Integer, String> walRuntime;
@@ -113,7 +108,6 @@ class IndexWalCoordinatorTest {
         assertThrows(IndexException.class, coordinator::checkpoint);
 
         assertNull(handledFailure.get());
-        verifyNoMoreInteractions(logger);
     }
 
     @Test
@@ -130,7 +124,7 @@ class IndexWalCoordinatorTest {
 
     private IndexWalCoordinator<Integer, String> newCoordinator(
             final java.util.function.Supplier<SegmentIndexState> stateSupplier) {
-        return IndexWalCoordinator.create(logger, effective(buildConf()), walRuntime,
+        return IndexWalCoordinator.create(effective(buildConf()), walRuntime,
                 new IndexRetryPolicy(1, 10), drainCalls::incrementAndGet,
                 flushCalls::incrementAndGet, stateSupplier, handledFailure::set,
                 lastAppliedWalLsn);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentDirectoryRemoverTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentDirectoryRemoverTest.java
@@ -1,7 +1,6 @@
 package org.hestiastore.index.segmentindex.core.storage;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,7 +9,6 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.IndexRetryPolicy;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
 
 class OrphanedSegmentDirectoryRemoverTest {
 
@@ -19,12 +17,11 @@ class OrphanedSegmentDirectoryRemoverTest {
         @SuppressWarnings("unchecked")
         final SegmentRegistry<Integer, String> segmentRegistry =
                 mock(SegmentRegistry.class);
-        final Logger logger = mock(Logger.class);
         final SegmentId segmentId = SegmentId.of(3);
         when(segmentRegistry.deleteSegmentIfAvailable(segmentId))
                 .thenReturn(false, true);
         final OrphanedSegmentDirectoryRemover<Integer, String> remover =
-                new OrphanedSegmentDirectoryRemover<>(logger, segmentRegistry,
+                new OrphanedSegmentDirectoryRemover<>(segmentRegistry,
                         new IndexRetryPolicy(2, 1));
 
         remover.remove(segmentId);
@@ -38,19 +35,15 @@ class OrphanedSegmentDirectoryRemoverTest {
         @SuppressWarnings("unchecked")
         final SegmentRegistry<Integer, String> segmentRegistry =
                 mock(SegmentRegistry.class);
-        final Logger logger = mock(Logger.class);
         final SegmentId segmentId = SegmentId.of(3);
         when(segmentRegistry.deleteSegmentIfAvailable(segmentId))
                 .thenThrow(new IndexException("boom"));
         final OrphanedSegmentDirectoryRemover<Integer, String> remover =
-                new OrphanedSegmentDirectoryRemover<>(logger, segmentRegistry,
+                new OrphanedSegmentDirectoryRemover<>(segmentRegistry,
                         new IndexRetryPolicy(2, 1));
 
         remover.remove(segmentId);
 
         verify(segmentRegistry).deleteSegmentIfAvailable(segmentId);
-        verify(logger, never()).info(
-                "Deleted orphaned segment directory '{}' during recovery/consistency cleanup.",
-                segmentId);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalCheckpointExecutorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalCheckpointExecutorTest.java
@@ -11,18 +11,13 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.wal.WalRuntime;
-import org.hestiastore.index.segmentindex.wal.WalStats;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class WalCheckpointExecutorTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private WalRuntime<Integer, String> walRuntime;
@@ -33,9 +28,9 @@ class WalCheckpointExecutorTest {
         final java.util.concurrent.atomic.AtomicReference<RuntimeException> handledFailure =
                 new java.util.concurrent.atomic.AtomicReference<>();
         final WalCheckpointExecutor<Integer, String> executor =
-                new WalCheckpointExecutor<>(logger, walRuntime,
+                new WalCheckpointExecutor<>(walRuntime,
                         new AtomicLong(),
-                        new WalFailureTransitionHandler(logger, walRuntime,
+                        new WalFailureTransitionHandler(walRuntime,
                                 () -> SegmentIndexState.READY,
                                 handledFailure::set));
         when(walRuntime.isEnabled()).thenReturn(true);
@@ -50,23 +45,16 @@ class WalCheckpointExecutorTest {
     }
 
     @Test
-    void checkpointInternal_logsWalStatsWhenDebugEnabled() {
+    void checkpointInternal_appliesLastAppliedLsn() {
         final WalCheckpointExecutor<Integer, String> executor =
-                new WalCheckpointExecutor<>(logger, walRuntime,
+                new WalCheckpointExecutor<>(walRuntime,
                         new AtomicLong(9L),
-                        new WalFailureTransitionHandler(logger, walRuntime,
+                        new WalFailureTransitionHandler(walRuntime,
                                 () -> SegmentIndexState.READY, failure -> {
                                 }));
-        when(logger.isDebugEnabled()).thenReturn(true);
-        when(walRuntime.statsSnapshot())
-                .thenReturn(new WalStats(0L, 0L, 0L, 0L, 0L, 0L, 7L, 8, 5L, 6L,
-                        0L, 0L, 0L, 0L, 0L));
 
         executor.checkpointInternal();
 
         verify(walRuntime).onCheckpoint(9L);
-        verify(logger).debug(
-                "WAL checkpoint: durableLsn={}, checkpointLsn={}, retainedBytes={}, segments={}",
-                5L, 6L, 7L, 8);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalFailureTransitionHandlerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalFailureTransitionHandlerTest.java
@@ -1,8 +1,6 @@
 package org.hestiastore.index.segmentindex.core.storage;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -14,13 +12,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class WalFailureTransitionHandlerTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private WalRuntime<Integer, String> walRuntime;
@@ -30,7 +24,7 @@ class WalFailureTransitionHandlerTest {
         final AtomicReference<RuntimeException> handledFailure =
                 new AtomicReference<>();
         final WalFailureTransitionHandler handler =
-                new WalFailureTransitionHandler(logger, walRuntime,
+                new WalFailureTransitionHandler(walRuntime,
                         () -> SegmentIndexState.READY, handledFailure::set);
         final IndexException failure = new IndexException("sync failure");
         when(walRuntime.isEnabled()).thenReturn(true);
@@ -38,15 +32,12 @@ class WalFailureTransitionHandlerTest {
 
         assertSame(failure, handler.propagate(failure));
         assertSame(failure, handledFailure.get());
-        verify(logger).error(
-                "event=wal_sync_failure_transition state={} action=transition_to_error reason=wal_sync_failure",
-                SegmentIndexState.READY, failure);
     }
 
     @Test
     void propagateIgnoresClosedState() {
         final WalFailureTransitionHandler handler =
-                new WalFailureTransitionHandler(logger, walRuntime,
+                new WalFailureTransitionHandler(walRuntime,
                         () -> SegmentIndexState.CLOSED, failure -> {
                         });
         final IndexException failure = new IndexException("sync failure");
@@ -54,6 +45,5 @@ class WalFailureTransitionHandlerTest {
         when(walRuntime.hasSyncFailure()).thenReturn(true);
 
         assertSame(failure, handler.propagate(failure));
-        verifyNoInteractions(logger);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalRetentionPressureCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/WalRetentionPressureCoordinatorTest.java
@@ -3,7 +3,6 @@ package org.hestiastore.index.segmentindex.core.storage;
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -20,13 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class WalRetentionPressureCoordinatorTest {
-
-    @Mock
-    private Logger logger;
 
     @Mock
     private WalRuntime<Integer, String> walRuntime;
@@ -37,7 +32,7 @@ class WalRetentionPressureCoordinatorTest {
         final AtomicInteger flushCalls = new AtomicInteger();
         final AtomicInteger checkpointCalls = new AtomicInteger();
         final WalRetentionPressureCoordinator<Integer, String> coordinator =
-                new WalRetentionPressureCoordinator<>(logger, effective(buildConf()),
+                new WalRetentionPressureCoordinator<>(effective(buildConf()),
                         walRuntime, new IndexRetryPolicy(1, 10),
                         prepareCalls::incrementAndGet,
                         flushCalls::incrementAndGet,
@@ -51,9 +46,6 @@ class WalRetentionPressureCoordinatorTest {
         assertEquals(1, prepareCalls.get());
         assertEquals(1, flushCalls.get());
         assertEquals(1, checkpointCalls.get());
-        verify(logger).warn(
-                "event=wal_retention_pressure_start retainedBytes={} threshold={} action=force_checkpoint_backpressure",
-                99L, 1024L);
     }
 
     private IndexConfiguration<Integer, String> buildConf() {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceBuilderTest.java
@@ -19,7 +19,6 @@ import org.hestiastore.index.segmentindex.core.stablesegment.StableSegmentOperat
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class SegmentStreamingServiceBuilderTest {
 
@@ -41,8 +40,6 @@ class SegmentStreamingServiceBuilderTest {
 
         final SegmentStreamingService<Integer, String> service =
                 SegmentStreamingService.<Integer, String>builder()
-                        .logger(LoggerFactory.getLogger(
-                                SegmentStreamingServiceBuilderTest.class))
                         .keyToSegmentMap(keyToSegmentMap)
                         .segmentRegistry(segmentRegistry)
                         .stableSegmentGateway(stableSegmentGateway)
@@ -56,13 +53,14 @@ class SegmentStreamingServiceBuilderTest {
     }
 
     @Test
-    void buildRejectsMissingLogger() {
+    void buildRejectsMissingKeyToSegmentMap() {
         final SegmentStreamingServiceBuilder<Integer, String> builder =
                 SegmentStreamingService.<Integer, String>builder();
 
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, builder::build);
 
-        assertEquals("Property 'logger' must not be null.", ex.getMessage());
+        assertEquals("Property 'keyToSegmentMap' must not be null.",
+                ex.getMessage());
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/streaming/SegmentStreamingServiceImplTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class SegmentStreamingServiceImplTest {
@@ -58,7 +57,6 @@ class SegmentStreamingServiceImplTest {
         synchronizedKeyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 keyToSegmentMap);
         service = new SegmentStreamingServiceImpl<>(
-                LoggerFactory.getLogger(SegmentStreamingServiceImplTest.class),
                 synchronizedKeyToSegmentMap, segmentRegistry,
                 stableSegmentGateway, new IndexRetryPolicy(1, 10));
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyRuntimeTest.java
@@ -16,7 +16,6 @@ import org.hestiastore.index.segmentindex.core.session.SegmentIndexRuntimeTestAc
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class SegmentTopologyRuntimeTest {
 
@@ -31,8 +30,7 @@ class SegmentTopologyRuntimeTest {
         final IndexConfiguration<Integer, String> conf = buildConf();
         executorRegistry = ExecutorRegistryFixture.from(conf);
         runtime = SegmentIndexRuntimeTestAccess.openRuntime(
-                LoggerFactory.getLogger(getClass()), new MemDirectory(), tdi,
-                tds, conf, executorRegistry);
+                new MemDirectory(), tdi, tds, conf, executorRegistry);
     }
 
     @AfterEach

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalMetadataCatalogTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalMetadataCatalogTest.java
@@ -8,15 +8,13 @@ import java.nio.charset.StandardCharsets;
 
 import org.hestiastore.index.directory.MemDirectory;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class WalMetadataCatalogTest {
 
     @Test
     void loadRecoveryCatalogPromotesValidCheckpointTempFile() {
         final WalStorageMem storage = new WalStorageMem(new MemDirectory());
-        final WalMetadataCatalog catalog = new WalMetadataCatalog(storage,
-                LoggerFactory.getLogger(WalMetadataCatalogTest.class));
+        final WalMetadataCatalog catalog = new WalMetadataCatalog(storage);
 
         catalog.ensureFormatMarker();
         final byte[] checkpoint = "5".getBytes(StandardCharsets.US_ASCII);
@@ -33,8 +31,7 @@ class WalMetadataCatalogTest {
     @Test
     void ensureFormatMarkerCreatesCanonicalMetadata() {
         final WalStorageMem storage = new WalStorageMem(new MemDirectory());
-        final WalMetadataCatalog catalog = new WalMetadataCatalog(storage,
-                LoggerFactory.getLogger(WalMetadataCatalogTest.class));
+        final WalMetadataCatalog catalog = new WalMetadataCatalog(storage);
 
         catalog.ensureFormatMarker();
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalSegmentCatalogTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalSegmentCatalogTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class WalSegmentCatalogTest {
 
@@ -16,10 +15,9 @@ class WalSegmentCatalogTest {
         final IndexWalConfiguration wal = IndexWalConfiguration.builder().segmentSizeBytes(16L).build();
         final WalStorageMem storage = new WalStorageMem(new MemDirectory());
         final WalMetadataCatalog metadataCatalog = new WalMetadataCatalog(
-                storage, LoggerFactory.getLogger(WalSegmentCatalogTest.class));
+                storage);
         final WalSegmentCatalog catalog = new WalSegmentCatalog(wal, storage,
-                metadataCatalog,
-                LoggerFactory.getLogger(WalSegmentCatalogTest.class));
+                metadataCatalog);
 
         final WalSegmentDescriptor first = catalog.ensureActiveSegmentFor(1L,
                 8);
@@ -41,10 +39,9 @@ class WalSegmentCatalogTest {
                 .maxBytesBeforeForcedCheckpoint(1L).build();
         final WalStorageMem storage = new WalStorageMem(new MemDirectory());
         final WalMetadataCatalog metadataCatalog = new WalMetadataCatalog(
-                storage, LoggerFactory.getLogger(WalSegmentCatalogTest.class));
+                storage);
         final WalSegmentCatalog catalog = new WalSegmentCatalog(wal, storage,
-                metadataCatalog,
-                LoggerFactory.getLogger(WalSegmentCatalogTest.class));
+                metadataCatalog);
 
         final WalSegmentDescriptor active = catalog.ensureActiveSegmentFor(1L,
                 4);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalSyncPolicyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalSyncPolicyTest.java
@@ -8,7 +8,6 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.WalDurabilityMode;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class WalSyncPolicyTest {
 
@@ -18,16 +17,14 @@ class WalSyncPolicyTest {
                 .build();
         final WalStorageMem storage = new WalStorageMem(new MemDirectory());
         final WalMetadataCatalog metadataCatalog = new WalMetadataCatalog(
-                storage, LoggerFactory.getLogger(WalSyncPolicyTest.class));
+                storage);
         final WalSegmentCatalog segmentCatalog = new WalSegmentCatalog(wal,
-                storage, metadataCatalog,
-                LoggerFactory.getLogger(WalSyncPolicyTest.class));
+                storage, metadataCatalog);
         final WalRuntimeMetrics metrics = new WalRuntimeMetrics();
         final Object monitor = new Object();
         final AtomicBoolean closed = new AtomicBoolean(false);
         final WalSyncPolicy syncPolicy = new WalSyncPolicy(wal, storage, metrics,
-                LoggerFactory.getLogger(WalSyncPolicyTest.class), monitor,
-                segmentCatalog::segments, closed::get);
+                monitor, segmentCatalog::segments, closed::get);
 
         synchronized (monitor) {
             final WalSegmentDescriptor segment = segmentCatalog


### PR DESCRIPTION
## Summary
- remove Logger constructor, context, factory, and builder parameter plumbing from segmentindex runtime paths
- move logging ownership to class-local static LOGGER instances in runtime, maintenance, streaming, split, storage, and WAL collaborators
- remove MaintenanceServiceBuilder.logger(...) and SegmentStreamingServiceBuilder.logger(...) and update tests for new signatures

## Testing
- mvn -pl engine test
- mvn clean verify