### PR TITLE
Fix close-safe maintenance shutdown

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/directory/FileLockMetadata.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/FileLockMetadata.java
@@ -141,10 +141,6 @@ final class FileLockMetadata {
         return false;
     }
 
-    boolean hasSameSession(final FileLockMetadata other) {
-        return other != null && sessionId.equals(other.sessionId);
-    }
-
     long getPid() {
         return pid;
     }

--- a/engine/src/main/java/org/hestiastore/index/directory/FsFileLock.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/FsFileLock.java
@@ -10,7 +10,6 @@ public class FsFileLock implements FileLock {
     private final Directory directory;
 
     private final String lockFileName;
-    private FileLockMetadata ownedMetadata;
 
     FsFileLock(final Directory directory, final String lockFileName) {
         this.directory = Vldtn.requireNonNull(directory, "directory");
@@ -47,7 +46,6 @@ public class FsFileLock implements FileLock {
         }
         final FileLockMetadata metadata = FileLockMetadata.currentProcess();
         metadata.write(directory, lockFileName);
-        ownedMetadata = metadata;
     }
 
     @Override
@@ -56,18 +54,7 @@ public class FsFileLock implements FileLock {
             throw new IllegalStateException(String.format(
                     "Can't unlock already unlocked file '%s'.", lockFileName));
         }
-        if (ownedMetadata != null) {
-            final FileLockMetadata currentMetadata = FileLockMetadata
-                    .read(directory, lockFileName).orElse(null);
-            if (currentMetadata != null
-                    && !ownedMetadata.hasSameSession(currentMetadata)) {
-                throw new IllegalStateException(String.format(
-                        "Can't unlock file '%s' owned by another process.",
-                        lockFileName));
-            }
-        }
         directory.deleteFile(lockFileName);
-        ownedMetadata = null;
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/directory/MemFileLock.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/MemFileLock.java
@@ -10,7 +10,6 @@ public class MemFileLock implements FileLock {
     private final MemDirectory directory;
 
     private final String lockFileName;
-    private FileLockMetadata ownedMetadata;
 
     MemFileLock(final MemDirectory directory, final String lockFileName) {
         this.directory = Vldtn.requireNonNull(directory, "directory");
@@ -47,7 +46,6 @@ public class MemFileLock implements FileLock {
         }
         final FileLockMetadata metadata = FileLockMetadata.currentProcess();
         metadata.write(directory, lockFileName);
-        ownedMetadata = metadata;
     }
 
     @Override
@@ -56,18 +54,7 @@ public class MemFileLock implements FileLock {
             throw new IllegalStateException(String.format(
                     "Can't unlock already unlocked file '%s'.", lockFileName));
         }
-        if (ownedMetadata != null) {
-            final FileLockMetadata currentMetadata = FileLockMetadata
-                    .read(directory, lockFileName).orElse(null);
-            if (currentMetadata != null
-                    && !ownedMetadata.hasSameSession(currentMetadata)) {
-                throw new IllegalStateException(String.format(
-                        "Can't unlock file '%s' owned by another process.",
-                        lockFileName));
-            }
-        }
         directory.deleteFile(lockFileName);
-        ownedMetadata = null;
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentConcurrencyGate.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentConcurrencyGate.java
@@ -34,11 +34,23 @@ final class SegmentConcurrencyGate {
      * @return true when close admission succeeded
      */
     boolean tryEnterCloseAndDrain() {
+        closing.set(true);
+        if (stateMachine.getState() != SegmentState.READY) {
+            return false;
+        }
         if (!stateMachine.tryEnterFreeze()) {
             return false;
         }
-        closing.set(true);
         return awaitNoInFlight();
+    }
+
+    /**
+     * Returns whether close has been requested.
+     *
+     * @return true when close admission has started
+     */
+    boolean isClosing() {
+        return closing.get();
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentDirectoryLocking.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentDirectoryLocking.java
@@ -67,9 +67,6 @@ final class SegmentDirectoryLocking {
             lockHandle.unlock();
         } catch (final IllegalStateException e) {
             // Another closer may have released the file just before this call.
-            if (lockHandle.isLocked()) {
-                throw e;
-            }
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
@@ -268,7 +268,7 @@ class SegmentImpl<K, V> implements Segment<K, V> {
     }
 
     private void scheduleMaintenanceIfNeeded() {
-        if (gate.getState() != SegmentState.READY) {
+        if (gate.isClosing() || gate.getState() != SegmentState.READY) {
             return;
         }
         final SegmentMaintenanceDecision decision = maintenancePolicy
@@ -401,14 +401,17 @@ class SegmentImpl<K, V> implements Segment<K, V> {
                 gate.fail();
                 return false;
             }
+            releaseDirectoryLock();
             return true;
         } catch (final RuntimeException e) {
             gate.fail();
             return false;
-        } finally {
-            if (directoryLocking != null) {
-                directoryLocking.unlock();
-            }
+        }
+    }
+
+    private void releaseDirectoryLock() {
+        if (directoryLocking != null) {
+            directoryLocking.unlock();
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepCreateExecutorRegistry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepCreateExecutorRegistry.java
@@ -28,6 +28,8 @@ final class BootstrapStepCreateExecutorRegistry<K, V>
                         configuration.maintenance().segmentThreads())
                 .withRegistryMaintenanceThreads(
                         configuration.maintenance().registryLifecycleThreads())
+                .withShutdownTimeoutMillis(
+                        configuration.maintenance().busyTimeoutMillis())
                 .build();
         state.setExecutorRegistry(executorRegistry);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepWrapResourceClosing.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepWrapResourceClosing.java
@@ -12,7 +12,7 @@ final class BootstrapStepWrapResourceClosing<K, V>
     void apply(final SegmentIndexBootstrapRequest<K, V> request,
             final SegmentIndexBootstrapState<K, V> state) {
         final IndexInternal<K, V> returnedIndex = new SegmentIndexResourceClosingAdapter<>(
-                state.getManagedIndex(), state.getExecutorRegistry());
+                state.getManagedIndex());
         state.setIndex(returnedIndex);
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryBuilder.java
@@ -3,6 +3,7 @@ package org.hestiastore.index.segmentindex.core.executorregistry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.hestiastore.index.Vldtn;
 
@@ -15,6 +16,7 @@ public final class ExecutorRegistryBuilder {
     private static final String ARG_SPLIT_MAINTENANCE_THREADS = "splitMaintenanceThreads";
     private static final String ARG_SEGMENT_MAINTENANCE_THREADS = "numberOfSegmentMaintenanceThreads";
     private static final String ARG_REGISTRY_MAINTENANCE_THREADS = "registryMaintenanceThreads";
+    private static final String ARG_SHUTDOWN_TIMEOUT_MILLIS = "shutdownTimeoutMillis";
     private static final String ARG_INDEX_NAME = "indexName";
     private static final String THREAD_NAME_PREFIX_INDEX_MAINTENANCE = "index-maintenance-";
     private static final String THREAD_NAME_PREFIX_SPLIT_MAINTENANCE = "split-maintenance-";
@@ -26,6 +28,7 @@ public final class ExecutorRegistryBuilder {
     private Integer indexMaintenanceThreads;
     private Integer splitMaintenanceThreads;
     private Integer registryMaintenanceThreads;
+    private Integer shutdownTimeoutMillis = 30_000;
     private boolean contextLoggingEnabled;
     private String indexName;
 
@@ -77,6 +80,18 @@ public final class ExecutorRegistryBuilder {
     public ExecutorRegistryBuilder withRegistryMaintenanceThreads(
             final Integer threads) {
         this.registryMaintenanceThreads = threads;
+        return this;
+    }
+
+    /**
+     * Sets executor shutdown wait timeout in milliseconds.
+     *
+     * @param value shutdown timeout
+     * @return this builder
+     */
+    public ExecutorRegistryBuilder withShutdownTimeoutMillis(
+            final Integer value) {
+        this.shutdownTimeoutMillis = value;
         return this;
     }
 
@@ -143,10 +158,18 @@ public final class ExecutorRegistryBuilder {
                                 () -> contextDecorator.decorate(
                                         createRegistryMaintenanceExecutor(
                                                 threadPoolFactory,
-                                                registryMaintenanceThreadCount)))),
+                                                registryMaintenanceThreadCount))),
+                        shutdownTimeoutMillis()),
                 new ExecutorRuntimeMonitor(indexMaintenanceThreadPool,
                         splitMaintenanceThreadPool,
                         stableSegmentMaintenanceThreadPool));
+    }
+
+    private int shutdownTimeoutMillis() {
+        return Vldtn.requireGreaterThanZero(
+                Vldtn.requireNonNull(shutdownTimeoutMillis,
+                        ARG_SHUTDOWN_TIMEOUT_MILLIS),
+                ARG_SHUTDOWN_TIMEOUT_MILLIS);
     }
 
     private String contextIndexName() {
@@ -199,9 +222,14 @@ public final class ExecutorRegistryBuilder {
 
     private ScheduledExecutorService createSplitPolicyScheduler(
             final ObservedThreadPoolFactory threadPoolFactory) {
-        return Executors.newSingleThreadScheduledExecutor(
-                threadPoolFactory.daemonThreadFactory(
-                        THREAD_NAME_PREFIX_SPLIT_POLICY));
+        final ScheduledThreadPoolExecutor executor =
+                new ScheduledThreadPoolExecutor(1,
+                        threadPoolFactory.daemonThreadFactory(
+                                THREAD_NAME_PREFIX_SPLIT_POLICY));
+        executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        executor.setRemoveOnCancelPolicy(true);
+        return executor;
     }
 
     private ExecutorService createFixedDaemonExecutor(

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopology.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopology.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 
 /**
@@ -16,12 +17,14 @@ final class ExecutorTopology {
     private final LazyExecutorReference<ScheduledExecutorService> splitPolicyScheduler;
     private final ExecutorService stableSegmentMaintenanceExecutor;
     private final LazyExecutorReference<ExecutorService> registryMaintenanceExecutor;
+    private final int shutdownTimeoutMillis;
 
     ExecutorTopology(final ExecutorService indexMaintenanceExecutor,
             final ExecutorService splitMaintenanceExecutor,
             final LazyExecutorReference<ScheduledExecutorService> splitPolicyScheduler,
             final ExecutorService stableSegmentMaintenanceExecutor,
-            final LazyExecutorReference<ExecutorService> registryMaintenanceExecutor) {
+            final LazyExecutorReference<ExecutorService> registryMaintenanceExecutor,
+            final int shutdownTimeoutMillis) {
         this.indexMaintenanceExecutor = Vldtn.requireNonNull(
                 indexMaintenanceExecutor, "indexMaintenanceExecutor");
         this.splitMaintenanceExecutor = Vldtn.requireNonNull(
@@ -33,6 +36,8 @@ final class ExecutorTopology {
                 "stableSegmentMaintenanceExecutor");
         this.registryMaintenanceExecutor = Vldtn.requireNonNull(
                 registryMaintenanceExecutor, "registryMaintenanceExecutor");
+        this.shutdownTimeoutMillis = Vldtn.requireGreaterThanZero(
+                shutdownTimeoutMillis, "shutdownTimeoutMillis");
     }
 
     ExecutorService indexMaintenanceExecutor() {
@@ -57,16 +62,21 @@ final class ExecutorTopology {
 
     RuntimeException shutdownExecutorsInCloseOrder() {
         RuntimeException failure = null;
-        failure = shutdownAndAwait(indexMaintenanceExecutor, failure);
-        failure = shutdownAndAwait(splitMaintenanceExecutor, failure);
-        failure = shutdownAndAwait(splitPolicyScheduler.getIfCreated(), failure);
-        failure = shutdownAndAwait(stableSegmentMaintenanceExecutor, failure);
-        failure = shutdownAndAwait(registryMaintenanceExecutor.getIfCreated(),
-                failure);
+        failure = shutdownAndAwait("indexMaintenance",
+                indexMaintenanceExecutor, failure);
+        failure = shutdownAndAwait("splitMaintenance",
+                splitMaintenanceExecutor, failure);
+        failure = shutdownAndAwait("splitPolicy",
+                splitPolicyScheduler.getIfCreated(), failure);
+        failure = shutdownAndAwait("segmentMaintenance",
+                stableSegmentMaintenanceExecutor, failure);
+        failure = shutdownAndAwait("registryMaintenance",
+                registryMaintenanceExecutor.getIfCreated(), failure);
         return failure;
     }
 
-    private RuntimeException shutdownAndAwait(final ExecutorService executor,
+    private RuntimeException shutdownAndAwait(final String executorName,
+            final ExecutorService executor,
             final RuntimeException failure) {
         if (executor == null) {
             return failure;
@@ -75,23 +85,37 @@ final class ExecutorTopology {
         executor.shutdown();
         boolean interrupted = false;
         try {
-            while (!executor.isTerminated()) {
-                executor.awaitTermination(1, TimeUnit.SECONDS);
+            if (!executor.awaitTermination(shutdownTimeoutMillis,
+                    TimeUnit.MILLISECONDS)) {
+                executor.shutdownNow();
+                nextFailure = appendFailure(nextFailure, new IndexException(
+                        String.format(
+                                "Executor '%s' did not terminate within %d ms.",
+                                executorName, shutdownTimeoutMillis)));
             }
         } catch (final InterruptedException e) {
             interrupted = true;
             executor.shutdownNow();
+            nextFailure = appendFailure(nextFailure, new IndexException(
+                    String.format("Executor '%s' shutdown was interrupted.",
+                            executorName),
+                    e));
         } catch (final RuntimeException e) {
-            if (nextFailure == null) {
-                nextFailure = e;
-            } else {
-                nextFailure.addSuppressed(e);
-            }
+            nextFailure = appendFailure(nextFailure, e);
         } finally {
             if (interrupted) {
                 Thread.currentThread().interrupt();
             }
         }
         return nextFailure;
+    }
+
+    private RuntimeException appendFailure(final RuntimeException failure,
+            final RuntimeException nextFailure) {
+        if (failure == null) {
+            return nextFailure;
+        }
+        failure.addSuppressed(nextFailure);
+        return failure;
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceService.java
@@ -30,4 +30,10 @@ public interface MaintenanceService {
      * Flushes mapped segments and waits until durable maintenance is settled.
      */
     void flushAndWait();
+
+    /**
+     * Seals asynchronous maintenance submission and waits for accepted
+     * asynchronous work to finish.
+     */
+    void sealAsyncMaintenanceAndWait();
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImpl.java
@@ -1,6 +1,8 @@
 package org.hestiastore.index.segmentindex.core.maintenance;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
 import org.hestiastore.index.IndexException;
@@ -38,6 +40,10 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
     private final ExecutorService maintenanceExecutor;
     private final Runnable checkpointAction;
     private final LongSupplier nanoTimeSupplier;
+    private final AtomicBoolean asyncMaintenanceClosed =
+            new AtomicBoolean(false);
+    private final AtomicInteger asyncMaintenanceInFlight =
+            new AtomicInteger();
 
     MaintenanceServiceImpl(
             final KeyToSegmentMap<K> keyToSegmentMap,
@@ -103,6 +109,16 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
         splitService.awaitQuiescence();
         flushMappedSegmentsAndWait();
         finalizeSettledMaintenance(this::flushMappedSegmentsAndWait);
+    }
+
+    @Override
+    public void sealAsyncMaintenanceAndWait() {
+        asyncMaintenanceClosed.set(true);
+        final long startNanos = retryPolicy.startNanos();
+        while (asyncMaintenanceInFlight.get() > 0) {
+            retryPolicy.backoffOrThrow(startNanos, "asyncMaintenanceClose",
+                    asyncMaintenanceInFlight.get());
+        }
     }
 
     void flushSegments(final boolean waitForCompletion) {
@@ -288,12 +304,43 @@ final class MaintenanceServiceImpl<K, V> implements MaintenanceService {
     }
 
     private void executeAsync(final String operation, final Runnable action) {
+        enterAsyncMaintenance(operation);
         try {
-            maintenanceExecutor.execute(() -> runAsync(operation, action));
+            maintenanceExecutor
+                    .execute(() -> runAsyncMaintenance(operation, action));
         } catch (final RuntimeException e) {
+            exitAsyncMaintenance();
             throw new IndexException(String.format(
                     "Unable to schedule index operation '%s'.", operation), e);
         }
+    }
+
+    private void enterAsyncMaintenance(final String operation) {
+        if (asyncMaintenanceClosed.get()) {
+            throw new IndexException(String.format(
+                    "Index operation '%s' cannot be scheduled because maintenance is closing.",
+                    operation));
+        }
+        asyncMaintenanceInFlight.incrementAndGet();
+        if (asyncMaintenanceClosed.get()) {
+            exitAsyncMaintenance();
+            throw new IndexException(String.format(
+                    "Index operation '%s' cannot be scheduled because maintenance is closing.",
+                    operation));
+        }
+    }
+
+    private void runAsyncMaintenance(final String operation,
+            final Runnable action) {
+        try {
+            runAsync(operation, action);
+        } finally {
+            exitAsyncMaintenance();
+        }
+    }
+
+    private void exitAsyncMaintenance() {
+        asyncMaintenanceInFlight.decrementAndGet();
     }
 
     private void runAsync(final String operation, final Runnable action) {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
@@ -3,6 +3,7 @@ package org.hestiastore.index.segmentindex.core.session;
 import org.hestiastore.index.F;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStats;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ final class IndexCloseCoordinator<K, V> {
     private final IndexOperationTrackingAccess operationTracker;
     private final IndexOperationStatsRecorder operationStatsRecorder;
     private final SegmentIndexRuntime<K, V> runtime;
+    private final ExecutorRegistry executorRegistry;
     private final IndexDirectoryLock directoryLock;
 
     IndexCloseCoordinator(final String indexName,
@@ -28,6 +30,7 @@ final class IndexCloseCoordinator<K, V> {
             final IndexOperationTrackingAccess operationTracker,
             final IndexOperationStatsRecorder operationStatsRecorder,
             final SegmentIndexRuntime<K, V> runtime,
+            final ExecutorRegistry executorRegistry,
             final IndexDirectoryLock directoryLock) {
         this.indexName = Vldtn.requireNonNull(indexName, "indexName");
         this.stateMachine = Vldtn.requireNonNull(stateMachine,
@@ -37,6 +40,8 @@ final class IndexCloseCoordinator<K, V> {
         this.operationStatsRecorder = Vldtn.requireNonNull(
                 operationStatsRecorder, "operationStatsRecorder");
         this.runtime = Vldtn.requireNonNull(runtime, "runtime");
+        this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
+                "executorRegistry");
         this.directoryLock = Vldtn.requireNonNull(directoryLock,
                 "directoryLock");
     }
@@ -51,16 +56,17 @@ final class IndexCloseCoordinator<K, V> {
             beginClose.run();
             awaitForegroundOperations();
             closeSplitRuntime();
+            sealAsyncMaintenanceAndWait();
             sealAndFlushRuntimeState();
             logOperationCounts();
+            releaseWalRuntime();
+            closeExecutorRegistry();
+            finishClosedState();
+            releaseDirectoryLock();
             LOGGER.debug("Index '{}' closed.", indexName);
-        } finally {
-            try {
-                finishClosedState();
-                releaseWalRuntime();
-            } finally {
-                releaseDirectoryLock();
-            }
+        } catch (final RuntimeException e) {
+            stateMachine.markRuntimeFailure(e);
+            throw e;
         }
     }
 
@@ -70,6 +76,10 @@ final class IndexCloseCoordinator<K, V> {
 
     private void closeSplitRuntime() {
         runtime.closeSplitRuntime();
+    }
+
+    private void sealAsyncMaintenanceAndWait() {
+        runtime.sealAsyncMaintenanceAndWait();
     }
 
     private void sealAndFlushRuntimeState() {
@@ -84,6 +94,10 @@ final class IndexCloseCoordinator<K, V> {
 
     private void releaseWalRuntime() {
         runtime.closeWalRuntime();
+    }
+
+    private void closeExecutorRegistry() {
+        executorRegistry.close();
     }
 
     private void releaseDirectoryLock() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexDirectoryLock.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexDirectoryLock.java
@@ -52,8 +52,6 @@ final class IndexDirectoryLock {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
-        if (fileLock.isLocked()) {
-            fileLock.unlock();
-        }
+        fileLock.unlock();
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapter.java
@@ -10,7 +10,6 @@ import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
 import org.hestiastore.index.segmentindex.runtimemonitoring.IndexRuntimeMonitoring;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.SegmentWindow;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
 
 /**
@@ -21,13 +20,9 @@ public final class SegmentIndexResourceClosingAdapter<K, V>
         extends AbstractCloseableResource implements IndexInternal<K, V> {
 
     private final IndexInternal<K, V> delegate;
-    private final ExecutorRegistry executorRegistry;
 
-    public SegmentIndexResourceClosingAdapter(final IndexInternal<K, V> index,
-            final ExecutorRegistry executorRegistry) {
+    public SegmentIndexResourceClosingAdapter(final IndexInternal<K, V> index) {
         this.delegate = Vldtn.requireNonNull(index, "index");
-        this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
-                "executorRegistry");
     }
 
     @Override
@@ -101,11 +96,7 @@ public final class SegmentIndexResourceClosingAdapter<K, V>
     /** {@inheritDoc} */
     @Override
     protected void doClose() {
-        final CloseFailureAccumulator closeFailures =
-                new CloseFailureAccumulator();
-        closeFailures.close(delegate);
-        closeFailures.close(executorRegistry);
-        closeFailures.rethrowIfPresent();
+        delegate.close();
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntime.java
@@ -214,6 +214,10 @@ final class SegmentIndexRuntime<K, V>
         services.maintenance().flushAndWait();
     }
 
+    void sealAsyncMaintenanceAndWait() {
+        services.maintenance().sealAsyncMaintenanceAndWait();
+    }
+
     void closeWalRuntime() {
         walRuntime.close();
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionResources.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionResources.java
@@ -29,6 +29,7 @@ public final class SegmentIndexSessionResources<K, V> {
     private IndexOperationStatsRecorder operationStatsRecorder;
     private MaintenanceStatsRecorder maintenanceStatsRecorder;
     private SplitStatsRecorder splitStatsRecorder;
+    private ExecutorRegistry executorRegistry;
     private IndexOperationTrackingAccess operationTracker;
     private SegmentIndexTrackedOperationRunner<K, V> trackedRunner;
     private SegmentIndexRuntime<K, V> runtime;
@@ -52,6 +53,8 @@ public final class SegmentIndexSessionResources<K, V> {
             final TypeDescriptor<V> valueTypeDescriptor,
             final EffectiveIndexConfiguration<K, V> configuration,
             final ExecutorRegistry executorRegistry) {
+        this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
+                "executorRegistry");
         runtime = SegmentIndexRuntime.create(directory, keyTypeDescriptor,
                 valueTypeDescriptor, configuration, executorRegistry,
                 operationStatsRecorder(), maintenanceStatsRecorder(),
@@ -120,7 +123,7 @@ public final class SegmentIndexSessionResources<K, V> {
                 new IndexCloseCoordinator<>(conf.identity().name(),
                         stateMachine(), operationTracker(),
                         operationStatsRecorder(), runtime,
-                        directoryLock()),
+                        executorRegistry(), directoryLock()),
                 new SegmentIndexStartupCoordinator<>(conf.identity().name(),
                         directoryLock().wasStaleLockRecovered(), runtime,
                         stateMachine(), consistencyCoordinator));
@@ -169,6 +172,10 @@ public final class SegmentIndexSessionResources<K, V> {
     private MaintenanceStatsRecorder maintenanceStatsRecorder() {
         return Vldtn.requireNonNull(maintenanceStatsRecorder,
                 "maintenanceStatsRecorder");
+    }
+
+    private ExecutorRegistry executorRegistry() {
+        return Vldtn.requireNonNull(executorRegistry, "executorRegistry");
     }
 
     private SplitStatsRecorder splitStatsRecorder() {

--- a/engine/src/test/java/org/hestiastore/index/directory/MemFileLockTest.java
+++ b/engine/src/test/java/org/hestiastore/index/directory/MemFileLockTest.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.directory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,6 +49,20 @@ class MemFileLockTest {
         lock1.unlock();
         assertFalse(lock1.isLocked());
         assertThrows(IllegalStateException.class, () -> lock1.unlock());
+    }
+
+    @Test
+    void test_unlock_owned_lock_does_not_reread_metadata() {
+        final CountingMemDirectory countingDirectory =
+                new CountingMemDirectory();
+        final FileLock lock = countingDirectory.getLock(LOCK_FILE_NAME);
+        lock.lock();
+        countingDirectory.resetReadCount();
+
+        lock.unlock();
+
+        assertEquals(0, countingDirectory.getReadCount());
+        assertFalse(countingDirectory.isFileExists(LOCK_FILE_NAME));
     }
 
     @Test
@@ -112,6 +127,32 @@ class MemFileLockTest {
     @BeforeEach
     void createNewStack() {
         directory = new MemDirectory();
+    }
+
+    private static final class CountingMemDirectory extends MemDirectory {
+
+        private int readCount;
+
+        @Override
+        public FileReader getFileReader(final String fileName) {
+            readCount++;
+            return super.getFileReader(fileName);
+        }
+
+        @Override
+        public FileReader getFileReader(final String fileName,
+                final int bufferSize) {
+            readCount++;
+            return super.getFileReader(fileName, bufferSize);
+        }
+
+        void resetReadCount() {
+            readCount = 0;
+        }
+
+        int getReadCount() {
+            return readCount;
+        }
     }
 
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentConcurrencyGateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentConcurrencyGateTest.java
@@ -70,6 +70,22 @@ class SegmentConcurrencyGateTest {
     }
 
     @Test
+    void closeRequestedDuringMaintenanceBlocksNewWorkUntilReady() {
+        assertTrue(gate.tryEnterFreezeAndDrain());
+        assertTrue(gate.enterMaintenanceRunning());
+
+        assertFalse(gate.tryEnterCloseAndDrain());
+        assertTrue(gate.isClosing());
+        assertFalse(gate.tryEnterWrite());
+        assertFalse(gate.tryEnterFreezeAndDrain());
+
+        assertTrue(gate.finishMaintenanceToFreeze());
+        assertTrue(gate.finishFreezeToReady());
+        assertTrue(gate.tryEnterCloseAndDrain());
+        assertEquals(SegmentState.FREEZE, gate.getState());
+    }
+
+    @Test
     void finishMaintenanceToFreeze_waits_for_in_flight_operations()
             throws Exception {
         assertTrue(gate.tryEnterFreezeAndDrain());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepWrapResourceClosingTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/bootstrap/BootstrapStepWrapResourceClosingTest.java
@@ -4,6 +4,7 @@ import static org.hestiastore.index.segmentindex.core.bootstrap.BootstrapStepTes
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import org.hestiastore.index.directory.MemDirectory;
@@ -49,7 +50,7 @@ class BootstrapStepWrapResourceClosingTest {
     }
 
     @Test
-    void returnedIndexCloseClosesManagedIndexAndExecutorRegistry() {
+    void returnedIndexCloseClosesManagedIndexOnly() {
         final SegmentIndexBootstrapState<Integer, String> state =
                 new SegmentIndexBootstrapState<>();
         state.setManagedIndex(managedIndex);
@@ -60,6 +61,6 @@ class BootstrapStepWrapResourceClosingTest {
         assertDoesNotThrow(() -> state.getIndex().close());
 
         verify(managedIndex).close();
-        verify(executorRegistry).close();
+        verify(executorRegistry, never()).close();
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryFixture.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryFixture.java
@@ -33,6 +33,8 @@ public final class ExecutorRegistryFixture {
                         configuration.maintenance().segmentThreads())
                 .withRegistryMaintenanceThreads(
                         configuration.maintenance().registryLifecycleThreads())
+                .withShutdownTimeoutMillis(
+                        configuration.maintenance().busyTimeoutMillis())
                 .build();
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopologyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopologyTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.executorregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -33,7 +34,8 @@ class ExecutorTopologyTest {
                 indexMaintenance, splitMaintenance,
                 new LazyExecutorReference<>(() -> splitPolicyScheduler),
                 stableSegmentMaintenance,
-                new LazyExecutorReference<>(() -> registryMaintenance));
+                new LazyExecutorReference<>(() -> registryMaintenance),
+                1_000);
 
         topology.splitPolicyScheduler();
         topology.registryMaintenanceExecutor();
@@ -48,5 +50,66 @@ class ExecutorTopologyTest {
         assertTrue(splitPolicyScheduler.isShutdown());
         assertTrue(stableSegmentMaintenance.isShutdown());
         assertTrue(registryMaintenance.isShutdown());
+    }
+
+    @Test
+    void shutdownExecutorsInCloseOrderTimesOutAndCallsShutdownNow() {
+        final java.util.ArrayList<String> shutdownOrder =
+                new java.util.ArrayList<>();
+        final NeverTerminatingExecutorService indexMaintenance =
+                new NeverTerminatingExecutorService("index", shutdownOrder);
+        final ExecutorTestSupport.RecordingExecutorService splitMaintenance =
+                new ExecutorTestSupport.RecordingExecutorService("split",
+                        shutdownOrder);
+        final ExecutorTestSupport.RecordingExecutorService stableSegmentMaintenance =
+                new ExecutorTestSupport.RecordingExecutorService(
+                        "stable", shutdownOrder);
+        final ExecutorTopology topology = new ExecutorTopology(
+                indexMaintenance, splitMaintenance,
+                new LazyExecutorReference<>(() -> null),
+                stableSegmentMaintenance,
+                new LazyExecutorReference<>(() -> null), 1);
+
+        final RuntimeException failure = topology.shutdownExecutorsInCloseOrder();
+
+        assertNotNull(failure);
+        assertTrue(failure.getMessage().contains("indexMaintenance"));
+        assertTrue(failure.getMessage().contains("1 ms"));
+        assertTrue(indexMaintenance.shutdownNowCalled());
+        assertEquals(List.of("index", "index", "split", "stable"),
+                shutdownOrder);
+    }
+
+    private static final class NeverTerminatingExecutorService
+            extends ExecutorTestSupport.RecordingExecutorService {
+
+        private boolean shutdownNowCalled;
+
+        private NeverTerminatingExecutorService(final String name,
+                final List<String> shutdownOrder) {
+            super(name, shutdownOrder);
+        }
+
+        @Override
+        public java.util.List<Runnable> shutdownNow() {
+            shutdownNowCalled = true;
+            super.shutdownNow();
+            return List.of();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(final long timeout,
+                final java.util.concurrent.TimeUnit unit) {
+            return false;
+        }
+
+        boolean shutdownNowCalled() {
+            return shutdownNowCalled;
+        }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceImplTest.java
@@ -3,6 +3,7 @@ package org.hestiastore.index.segmentindex.core.maintenance;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -10,8 +11,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
@@ -80,6 +83,7 @@ class MaintenanceServiceImplTest {
     void tearDown() {
         if (maintenanceExecutor != null) {
             maintenanceExecutor.shutdownNow();
+            awaitMaintenanceExecutorClosed();
         }
         if (synchronizedKeyToSegmentMap != null
                 && !synchronizedKeyToSegmentMap.wasClosed()) {
@@ -240,6 +244,87 @@ class MaintenanceServiceImplTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void sealAsyncMaintenanceAndWait_drainsAcceptedTaskAndRejectsNewAsyncWork()
+            throws Exception {
+        final KeyToSegmentMap<Integer> mappedSegments = mock(
+                KeyToSegmentMap.class);
+        final MaintenanceServiceImpl<Integer, String> maintenance =
+                new MaintenanceServiceImpl<>(
+                        mappedSegments, mock(StableSegmentOperationAccess.class),
+                        splitService, retryPolicy(),
+                        new MaintenanceStatsRecorder(), maintenanceExecutor,
+                        checkpointAction);
+        final CountDownLatch taskStarted = new CountDownLatch(1);
+        final CountDownLatch releaseTask = new CountDownLatch(1);
+        when(mappedSegments.getSegmentIds()).thenAnswer(invocation -> {
+            taskStarted.countDown();
+            awaitLatch(releaseTask);
+            return List.of();
+        });
+
+        maintenance.flush();
+        assertTrue(taskStarted.await(1, TimeUnit.SECONDS));
+        releaseTask.countDown();
+
+        maintenance.sealAsyncMaintenanceAndWait();
+
+        assertThrows(IndexException.class, maintenance::flush);
+    }
+
+    @Test
+    void flushAndWait_stillRunsAfterAsyncMaintenanceIsSealed() {
+        final SegmentId segmentId = createBootstrapSegment("sealed-wait-key");
+        when(segmentHandle.getRuntime()).thenReturn(runtime);
+        when(runtime.getState()).thenReturn(SegmentState.READY);
+        when(stableSegmentGateway.flush(segmentId))
+                .thenReturn(StableSegmentOperationResult.ok(segmentHandle));
+
+        service.sealAsyncMaintenanceAndWait();
+        service.flushAndWait();
+
+        verify(stableSegmentGateway).flush(segmentId);
+        verify(checkpointAction).run();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sealAsyncMaintenanceAndWait_timesOutWhenAcceptedTaskDoesNotFinish()
+            throws Exception {
+        final KeyToSegmentMap<Integer> mappedSegments = mock(
+                KeyToSegmentMap.class);
+        final MaintenanceServiceImpl<Integer, String> maintenance =
+                new MaintenanceServiceImpl<>(
+                        mappedSegments, mock(StableSegmentOperationAccess.class),
+                        splitService, new IndexRetryPolicy(1, 25),
+                        new MaintenanceStatsRecorder(), maintenanceExecutor,
+                        checkpointAction);
+        final CountDownLatch taskStarted = new CountDownLatch(1);
+        final CountDownLatch releaseTask = new CountDownLatch(1);
+        final CountDownLatch taskFinished = new CountDownLatch(1);
+        when(mappedSegments.getSegmentIds()).thenAnswer(invocation -> {
+            try {
+                taskStarted.countDown();
+                awaitLatch(releaseTask);
+                return List.of();
+            } finally {
+                taskFinished.countDown();
+            }
+        });
+
+        maintenance.flush();
+        assertTrue(taskStarted.await(1, TimeUnit.SECONDS));
+
+        try {
+            assertThrows(IndexException.class,
+                    maintenance::sealAsyncMaintenanceAndWait);
+        } finally {
+            releaseTask.countDown();
+        }
+        assertTrue(taskFinished.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
     void compactAndWait_settlesSplitsCompactsFlushesAndCheckpoints() {
         final SegmentId segmentId = createBootstrapSegment("compact-wait-key");
         when(segmentHandle.getRuntime()).thenReturn(runtime);
@@ -269,6 +354,26 @@ class MaintenanceServiceImplTest {
 
     private static IndexRetryPolicy retryPolicy() {
         return new IndexRetryPolicy(1, 1_000);
+    }
+
+    private void awaitMaintenanceExecutorClosed() {
+        try {
+            assertTrue(maintenanceExecutor.awaitTermination(1,
+                    TimeUnit.SECONDS));
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted while closing maintenance executor.", e);
+        }
+    }
+
+    private static void awaitLatch(final CountDownLatch latch) {
+        try {
+            assertTrue(latch.await(1, TimeUnit.SECONDS));
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IndexException("Interrupted while waiting for latch.", e);
+        }
     }
 
     private SegmentId createBootstrapSegment(final String key) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/maintenance/MaintenanceServiceTest.java
@@ -35,7 +35,7 @@ class MaintenanceServiceTest {
                 .toList();
 
         assertEquals(List.of("compact", "compactAndWait", "flush",
-                "flushAndWait"),
+                "flushAndWait", "sealAsyncMaintenanceAndWait"),
                 declaredMethodNames);
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
@@ -12,6 +12,7 @@ import org.hestiastore.index.IndexException;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.FileLock;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,9 +26,6 @@ class IndexCloseCoordinatorTest {
 
     @Mock
     private Runnable awaitOperations;
-
-    @Mock
-    private Runnable finishCloseTransition;
 
     @Mock
     private SegmentIndexRuntime<Integer, String> runtime;
@@ -44,6 +42,9 @@ class IndexCloseCoordinatorTest {
     @Mock
     private FileLock fileLock;
 
+    @Mock
+    private ExecutorRegistry executorRegistry;
+
     private IndexCloseCoordinator<Integer, String> closeCoordinator;
 
     @BeforeEach
@@ -55,13 +56,9 @@ class IndexCloseCoordinatorTest {
             awaitOperations.run();
             return null;
         }).when(operationTracker).awaitOperations();
-        doAnswer(invocation -> {
-            finishCloseTransition.run();
-            return null;
-        }).when(stateMachine).completeClose();
         closeCoordinator = new IndexCloseCoordinator<>("test-index",
                 stateMachine, operationTracker, new IndexOperationStatsRecorder(),
-                runtime,
+                runtime, executorRegistry,
                 new IndexDirectoryLock(directory));
     }
 
@@ -70,21 +67,22 @@ class IndexCloseCoordinatorTest {
         closeCoordinator.close();
 
         final InOrder inOrder = inOrder(awaitOperations, runtime,
-                stateMachine,
-                finishCloseTransition, fileLock);
+                stateMachine, executorRegistry, fileLock);
         inOrder.verify(stateMachine).beginClose();
         inOrder.verify(awaitOperations).run();
         inOrder.verify(runtime).closeSplitRuntime();
+        inOrder.verify(runtime).sealAsyncMaintenanceAndWait();
         inOrder.verify(runtime).flushAndWait();
         inOrder.verify(runtime).closeSegmentRegistry();
         inOrder.verify(runtime).closeKeyToSegmentMapIfOpen();
-        inOrder.verify(finishCloseTransition).run();
         inOrder.verify(runtime).closeWalRuntime();
+        inOrder.verify(executorRegistry).close();
+        inOrder.verify(stateMachine).completeClose();
         inOrder.verify(fileLock).unlock();
     }
 
     @Test
-    void close_stillFinishesAndClosesWalWhenRegistryCloseFails() {
+    void close_marksErrorAndKeepsLockWhenRegistryCloseFails() {
         doThrow(new IndexException("close failed")).when(runtime)
                 .closeSegmentRegistry();
 
@@ -92,8 +90,25 @@ class IndexCloseCoordinatorTest {
 
         verify(runtime).flushAndWait();
         verify(runtime, never()).closeKeyToSegmentMapIfOpen();
-        verify(finishCloseTransition).run();
+        verify(runtime, never()).closeWalRuntime();
+        verify(executorRegistry, never()).close();
+        verify(stateMachine, never()).completeClose();
+        verify(fileLock, never()).unlock();
+        verify(stateMachine).markRuntimeFailure(
+                org.mockito.ArgumentMatchers.any(IndexException.class));
+    }
+
+    @Test
+    void close_keepsLockWhenExecutorShutdownFails() {
+        doThrow(new IndexException("executor timeout")).when(executorRegistry)
+                .close();
+
+        assertThrows(IndexException.class, () -> closeCoordinator.close());
+
         verify(runtime).closeWalRuntime();
-        verify(fileLock).unlock();
+        verify(stateMachine, never()).completeClose();
+        verify(fileLock, never()).unlock();
+        verify(stateMachine).markRuntimeFailure(
+                org.mockito.ArgumentMatchers.any(IndexException.class));
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
@@ -147,6 +147,49 @@ class SegmentIndexAsyncMaintenanceTest {
     }
 
     @Test
+    void closeWaitsForAcceptedAsyncFlushBeforeFinalShutdown()
+            throws Exception {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch releaseFlush = new CountDownLatch(1);
+        try {
+            index.put(1, "one");
+            index.maintenance().flushAndWait();
+
+            final SegmentId segmentId = readKeyToSegmentMap(index)
+                    .findSegmentIdForKey(1);
+            final SegmentRegistry<Integer, String> registry = readSegmentRegistry(
+                    index);
+            final CountDownLatch flushStarted = new CountDownLatch(1);
+            final AtomicReference<SegmentState> stateRef =
+                    new AtomicReference<>(SegmentState.READY);
+            final Segment<Integer, String> mockedSegment = mockFlushBlockingSegment(
+                    segmentId, flushStarted, releaseFlush, stateRef);
+            replaceSegment(registry, segmentId, mockedSegment);
+
+            index.maintenance().flush();
+            assertTrue(flushStarted.await(1, TimeUnit.SECONDS));
+
+            final Future<?> closeTask = executor.submit(index::close);
+            awaitCondition(
+                    () -> index.runtimeMonitoring()
+                            .snapshot()
+                            .getState() == SegmentIndexState.CLOSING,
+                    5_000L);
+            assertFalse(closeTask.isDone());
+
+            releaseFlush.countDown();
+            closeTask.get(5, TimeUnit.SECONDS);
+        } finally {
+            releaseFlush.countDown();
+            executor.shutdownNow();
+        }
+
+        assertTrue(index.wasClosed());
+        assertEquals(SegmentIndexState.CLOSED,
+                index.runtimeMonitoring().snapshot().getState());
+    }
+
+    @Test
     void closeExposesClosingStateWhileBlockedSegmentCloseCompletes()
             throws Exception {
         final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -247,6 +290,37 @@ class SegmentIndexAsyncMaintenanceTest {
             return OperationResult.ok();
         });
         return blockingSegment;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Segment<Integer, String> mockFlushBlockingSegment(
+            final SegmentId segmentId, final CountDownLatch started,
+            final CountDownLatch release,
+            final AtomicReference<SegmentState> stateRef) throws Exception {
+        final Segment<Integer, String> blockedSegment = mock(Segment.class);
+        lenient().when(blockedSegment.getId()).thenReturn(segmentId);
+        lenient().when(blockedSegment.getState()).thenAnswer(
+                invocation -> stateRef.get());
+        lenient().when(blockedSegment.getRuntimeSnapshot()).thenAnswer(
+                invocation -> new SegmentRuntimeSnapshot(segmentId,
+                        stateRef.get(), 0L, 0L, 0L, 0L, 0, 0, 0L, 0L, 0L, 0L,
+                        0L, 0L));
+        when(blockedSegment.flush()).thenAnswer(invocation -> {
+            stateRef.set(SegmentState.MAINTENANCE_RUNNING);
+            started.countDown();
+            if (!release.await(5, TimeUnit.SECONDS)) {
+                throw new TimeoutException(
+                        "Timed out waiting to release blocked flush.");
+            }
+            stateRef.set(SegmentState.READY);
+            return OperationResult.ok();
+        });
+        lenient().when(blockedSegment.compact()).thenReturn(OperationResult.ok());
+        lenient().when(blockedSegment.close()).thenAnswer(invocation -> {
+            stateRef.set(SegmentState.CLOSED);
+            return OperationResult.ok();
+        });
+        return blockedSegment;
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplConcurrencyTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
@@ -113,20 +114,7 @@ class SegmentIndexImplConcurrencyTest {
 
         setSplitThreshold(32);
 
-        boolean splitObserved = false;
-        for (int i = 0; i < 256; i++) {
-            index.put(49, "trigger-49-" + i);
-            final SegmentIndexMetricsSnapshot snapshot = index.runtimeMonitoring().snapshot().getMetrics();
-            if (snapshot.getSplitScheduleCount() > 0
-                    || snapshot.getSplitInFlightCount() > 0
-                    || snapshot.getSegmentCount() > 1) {
-                splitObserved = true;
-                break;
-            }
-        }
-
-        assertTrue(splitObserved,
-                "Expected split scheduling while writes were in progress.");
+        awaitSplitObservedWhileWriting();
         setSplitThreshold(10_000_000);
         awaitCondition(() -> index.runtimeMonitoring().snapshot().getMetrics().getSegmentCount() > 1,
                 30_000L);
@@ -226,6 +214,23 @@ class SegmentIndexImplConcurrencyTest {
                                 .segmentSplitKeyThreshold(threshold))
                         .build());
         assertTrue(patchResult.applied());
+    }
+
+    private void awaitSplitObservedWhileWriting() {
+        final AtomicInteger writeCount = new AtomicInteger();
+        awaitCondition(() -> {
+            final int current = writeCount.getAndIncrement();
+            index.put(49, "trigger-49-" + current);
+            return hasSplitActivity();
+        }, 10_000L);
+    }
+
+    private boolean hasSplitActivity() {
+        final SegmentIndexMetricsSnapshot snapshot =
+                index.runtimeMonitoring().snapshot().getMetrics();
+        return snapshot.getSplitScheduleCount() > 0
+                || snapshot.getSplitInFlightCount() > 0
+                || snapshot.getSegmentCount() > 1;
     }
 
     private static void awaitCondition(final Supplier<Boolean> condition,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplTest.java
@@ -67,8 +67,7 @@ class SegmentIndexImplTest {
         final MemDirectory directory = new MemDirectory();
         final IndexConfiguration<Integer, String> conf = buildConf();
         final ExecutorRegistry registry = ExecutorRegistryFixture.from(conf);
-        try (registry;
-                IndexInternal<Integer, String> lockedIndex = IndexInternalTestSupport.createStarted(directory,
+        try (IndexInternal<Integer, String> lockedIndex = IndexInternalTestSupport.createStarted(directory,
                         new TypeDescriptorInteger(),
                         new TypeDescriptorShortString(), effective(conf),
                         registry)) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapterTest.java
@@ -12,7 +12,6 @@ import org.hestiastore.index.AbstractCloseableResource;
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.segmentindex.SegmentWindow;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
 import org.hestiastore.index.segmentindex.runtimemonitoring.IndexRuntimeMonitoring;
@@ -21,30 +20,26 @@ import org.junit.jupiter.api.Test;
 class SegmentIndexResourceClosingAdapterTest {
 
     @Test
-    void closeClosesDelegateAndExecutorRegistry() {
+    void closeClosesDelegate() {
         final NoopSegmentIndex delegate = new NoopSegmentIndex();
-        final ExecutorRegistry executorRegistry = mock(ExecutorRegistry.class);
 
         try (SegmentIndexResourceClosingAdapter<String, String> adapter = new SegmentIndexResourceClosingAdapter<>(
-                delegate, executorRegistry)) {
+                delegate)) {
             // close triggered by try-with-resources
         }
 
         assertTrue(delegate.wasClosed(), "Delegate index should be closed");
-        verify(executorRegistry).close();
     }
 
     @Test
     void delegatesInternalOperations() {
         final IndexInternal<String, String> delegate = mockIndex();
-        final ExecutorRegistry executorRegistry = mock(ExecutorRegistry.class);
         final SegmentWindow window = SegmentWindow.unbounded();
         final EntryIterator<String, String> iterator = mockIterator();
         when(delegate.openSegmentIterator(window)).thenReturn(iterator);
 
         try (SegmentIndexResourceClosingAdapter<String, String> adapter = new SegmentIndexResourceClosingAdapter<>(
-                delegate,
-                executorRegistry)) {
+                delegate)) {
             assertSame(iterator, adapter.openSegmentIterator(window));
             adapter.completeStartup();
         }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactoryTest.java
@@ -59,7 +59,8 @@ class SegmentIndexRuntimeFactoryTest {
                     stateMachine,
                     Mockito.mock(IndexOperationTrackingAccess.class),
                     new IndexOperationStatsRecorder(),
-                    runtime, new IndexDirectoryLock(new MemDirectory())).close();
+                    runtime, executorRegistry,
+                    new IndexDirectoryLock(new MemDirectory())).close();
         }
         if (executorRegistry != null && !executorRegistry.wasClosed()) {
             executorRegistry.close();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTest.java
@@ -69,7 +69,8 @@ class SegmentIndexRuntimeTest {
             new IndexCloseCoordinator<>("runtime-test", stateMachine,
                     mock(IndexOperationTrackingAccess.class),
                     new IndexOperationStatsRecorder(),
-                    runtime, new IndexDirectoryLock(new MemDirectory())).close();
+                    runtime, executorRegistry,
+                    new IndexDirectoryLock(new MemDirectory())).close();
         }
         if (executorRegistry != null && !executorRegistry.wasClosed()) {
             executorRegistry.close();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
@@ -105,20 +105,21 @@ public final class SegmentIndexRuntimeTestAccess {
     }
 
     public static <K, V> void closeRuntime(final SegmentIndexRuntime<K, V> runtime,
-            final String indexName) {
+            final String indexName, final ExecutorRegistry executorRegistry) {
         final SegmentIndexStateMachine stateMachine =
                 new SegmentIndexStateMachine();
         stateMachine.markReady();
         new IndexCloseCoordinator<>(indexName, stateMachine,
                 mock(IndexOperationTrackingAccess.class),
                 new IndexOperationStatsRecorder(), runtime,
+                executorRegistry,
                 new IndexDirectoryLock(new MemDirectory()))
                 .close();
     }
 
     public static void closeRuntime(final Object runtime,
-            final String indexName) {
-        closeRuntime(castRuntime(runtime), indexName);
+            final String indexName, final ExecutorRegistry executorRegistry) {
+        closeRuntime(castRuntime(runtime), indexName, executorRegistry);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
@@ -17,6 +17,7 @@ import org.hestiastore.index.directory.FileWriter;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.configuration.user.IndexConfiguration;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
 import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
@@ -133,7 +134,8 @@ class SegmentIndexStartupRecoveryTest {
                             conf.identity().name(), stateMachine,
                             IndexOperationTrackingAccess.create(),
                             new IndexOperationStatsRecorder(),
-                            runtime, directoryLock),
+                            runtime, mock(ExecutorRegistry.class),
+                            directoryLock),
                     new SegmentIndexStartupCoordinator<>(
                             conf.identity().name(),
                             directoryLock.wasStaleLockRecovered(), runtime,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentTopologyRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentTopologyRuntimeTest.java
@@ -37,7 +37,8 @@ class SegmentTopologyRuntimeTest {
         if (runtime != null) {
             failure = closeIgnoringFailure(
                     () -> SegmentIndexRuntimeTestAccess.closeRuntime(runtime,
-                            "segment-topology-runtime-test"),
+                            "segment-topology-runtime-test",
+                            executorRegistry),
                     failure);
         }
         if (executorRegistry != null && !executorRegistry.wasClosed()) {


### PR DESCRIPTION
## Summary
- Seal async index maintenance during close, drain accepted work with the existing maintenance busy timeout, and keep close-owned flushAndWait available for the final flush.
- Make segment close admission reject new work once close is requested while allowing already-running maintenance to finish naturally.
- Release index and segment locks only after successful safe shutdown, mark runtime ERROR on unsafe close failure, and retain locks on failure.
- Bound executor shutdown and avoid owned-unlock lock metadata rereads.

Fixes #256

## Testing
- mvn -pl engine -Dit.test=SegmentIndexConcurrentIT#hotRangeRandomPutsWithAutonomousSplitDoNotStall failsafe:integration-test failsafe:verify
- mvn -pl engine -Dit.test=SegmentIndexConcurrentIT failsafe:integration-test failsafe:verify
- mvn clean verify