### PR TITLE
Fix close-safe maintenance shutdown

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImpl.java
@@ -17,7 +17,6 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
-import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
 import org.hestiastore.index.sorteddatafile.EntryComparator;
 
@@ -37,12 +36,9 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
     private final SegmentIndexMaintenance maintenanceApi;
     private final SegmentIndexSessionOwner<K, V> sessionOwner;
 
-    @SuppressWarnings("java:S107")
     SegmentIndexImpl(final TypeDescriptor<K> keyTypeDescriptor,
             final SegmentIndexPointOperationFacade<K, V> pointOperationFacade,
             final SegmentIndexReadFacade<K, V> readFacade,
-            final MaintenanceService maintenance,
-            final SegmentIndexTrackedOperationRunner<K, V> trackedRunner,
             final SegmentIndexMaintenance maintenanceApi,
             final SegmentIndexSessionOwner<K, V> sessionOwner) {
         this.keyTypeDescriptor = Vldtn.requireNonNull(keyTypeDescriptor,
@@ -50,8 +46,6 @@ class SegmentIndexImpl<K, V> extends AbstractCloseableResource
         this.pointOperationFacade = Vldtn.requireNonNull(pointOperationFacade,
                 "pointOperationFacade");
         this.readFacade = Vldtn.requireNonNull(readFacade, "readFacade");
-        Vldtn.requireNonNull(maintenance, "maintenance");
-        Vldtn.requireNonNull(trackedRunner, "trackedRunner");
         this.maintenanceApi = Vldtn.requireNonNull(maintenanceApi,
                 "maintenanceApi");
         this.sessionOwner = Vldtn.requireNonNull(sessionOwner, "sessionOwner");

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMaintenanceSessionAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMaintenanceSessionAdapter.java
@@ -1,0 +1,60 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
+
+/**
+ * Applies session lifecycle and operation tracking around maintenance calls.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class SegmentIndexMaintenanceSessionAdapter<K, V>
+        implements SegmentIndexMaintenance {
+
+    private final SegmentIndexMaintenance delegate;
+    private final SegmentIndexSessionOwner<K, V> sessionOwner;
+    private final SegmentIndexTrackedOperationRunner<K, V> trackedRunner;
+
+    SegmentIndexMaintenanceSessionAdapter(
+            final SegmentIndexMaintenance delegate,
+            final SegmentIndexSessionOwner<K, V> sessionOwner,
+            final SegmentIndexTrackedOperationRunner<K, V> trackedRunner) {
+        this.delegate = Vldtn.requireNonNull(delegate, "delegate");
+        this.sessionOwner = Vldtn.requireNonNull(sessionOwner,
+                "sessionOwner");
+        this.trackedRunner = Vldtn.requireNonNull(trackedRunner,
+                "trackedRunner");
+    }
+
+    @Override
+    public void compact() {
+        run(delegate::compact);
+    }
+
+    @Override
+    public void compactAndWait() {
+        run(delegate::compactAndWait);
+    }
+
+    @Override
+    public void flush() {
+        run(delegate::flush);
+    }
+
+    @Override
+    public void flushAndWait() {
+        run(delegate::flushAndWait);
+    }
+
+    @Override
+    public void checkAndRepairConsistency() {
+        run(delegate::checkAndRepairConsistency);
+    }
+
+    // TODO dependency on meessy package
+    private void run(final Runnable action) {
+        sessionOwner.runMaintenanceOperation(
+                () -> trackedRunner.runTrackedVoid(action));
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionResources.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionResources.java
@@ -85,8 +85,7 @@ public final class SegmentIndexSessionResources<K, V> {
                 consistencyCoordinator);
         final SegmentIndexImpl<K, V> index = new SegmentIndexImpl<>(
                 keyTypeDescriptor, pointOperationFacade,
-                readFacade, initializedRuntime.maintenance(),
-                trackedRunner(), maintenanceApi, sessionOwner);
+                readFacade, maintenanceApi, sessionOwner);
         return index;
     }
 
@@ -134,26 +133,11 @@ public final class SegmentIndexSessionResources<K, V> {
             final SegmentIndexTrackedOperationRunner<K, V> trackedRunner,
             final MaintenanceService maintenance,
             final IndexConsistencyCoordinator<K, V> consistencyCoordinator) {
-        return new SegmentIndexMaintenanceImpl(
-                () -> runTrackedMaintenanceOperation(sessionOwner,
-                        trackedRunner, maintenance::compact),
-                () -> runTrackedMaintenanceOperation(sessionOwner,
-                        trackedRunner, maintenance::compactAndWait),
-                () -> runTrackedMaintenanceOperation(sessionOwner,
-                        trackedRunner, maintenance::flush),
-                () -> runTrackedMaintenanceOperation(sessionOwner,
-                        trackedRunner, maintenance::flushAndWait),
-                () -> runTrackedMaintenanceOperation(sessionOwner,
-                        trackedRunner,
-                        consistencyCoordinator::checkAndRepairConsistency));
-    }
-
-    private void runTrackedMaintenanceOperation(
-            final SegmentIndexSessionOwner<K, V> sessionOwner,
-            final SegmentIndexTrackedOperationRunner<K, V> trackedRunner,
-            final Runnable action) {
-        sessionOwner.runMaintenanceOperation(
-                () -> trackedRunner.runTrackedVoid(action));
+        final SegmentIndexMaintenance maintenanceApi =
+                new SegmentIndexMaintenanceImpl(maintenance,
+                        consistencyCoordinator);
+        return new SegmentIndexMaintenanceSessionAdapter<>(maintenanceApi,
+                sessionOwner, trackedRunner);
     }
 
     private IndexDirectoryLock directoryLock() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/maintenance/SegmentIndexMaintenanceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/maintenance/SegmentIndexMaintenanceImpl.java
@@ -1,6 +1,8 @@
 package org.hestiastore.index.segmentindex.maintenance;
 
 import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
+import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
 
 /**
  * Default {@link SegmentIndexMaintenance} implementation backed by index
@@ -9,49 +11,40 @@ import org.hestiastore.index.Vldtn;
 public final class SegmentIndexMaintenanceImpl
         implements SegmentIndexMaintenance {
 
-    private final Runnable compactAction;
-    private final Runnable compactAndWaitAction;
-    private final Runnable flushAction;
-    private final Runnable flushAndWaitAction;
-    private final Runnable consistencyRepairAction;
+    private final MaintenanceService maintenanceService;
+    private final IndexConsistencyCoordinator<?, ?> consistencyCoordinator;
 
-    public SegmentIndexMaintenanceImpl(final Runnable compactAction,
-            final Runnable compactAndWaitAction, final Runnable flushAction,
-            final Runnable flushAndWaitAction,
-            final Runnable consistencyRepairAction) {
-        this.compactAction = Vldtn.requireNonNull(compactAction,
-                "compactAction");
-        this.compactAndWaitAction = Vldtn.requireNonNull(compactAndWaitAction,
-                "compactAndWaitAction");
-        this.flushAction = Vldtn.requireNonNull(flushAction, "flushAction");
-        this.flushAndWaitAction = Vldtn.requireNonNull(flushAndWaitAction,
-                "flushAndWaitAction");
-        this.consistencyRepairAction = Vldtn.requireNonNull(
-                consistencyRepairAction, "consistencyRepairAction");
+    public SegmentIndexMaintenanceImpl(
+            final MaintenanceService maintenanceService,
+            final IndexConsistencyCoordinator<?, ?> consistencyCoordinator) {
+        this.maintenanceService = Vldtn.requireNonNull(maintenanceService,
+                "maintenanceService");
+        this.consistencyCoordinator = Vldtn.requireNonNull(
+                consistencyCoordinator, "consistencyCoordinator");
     }
 
     @Override
     public void compact() {
-        compactAction.run();
+        maintenanceService.compact();
     }
 
     @Override
     public void compactAndWait() {
-        compactAndWaitAction.run();
+        maintenanceService.compactAndWait();
     }
 
     @Override
     public void flush() {
-        flushAction.run();
+        maintenanceService.flush();
     }
 
     @Override
     public void flushAndWait() {
-        flushAndWaitAction.run();
+        maintenanceService.flushAndWait();
     }
 
     @Override
     public void checkAndRepairConsistency() {
-        consistencyRepairAction.run();
+        consistencyCoordinator.checkAndRepairConsistency();
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexInternalTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexInternalTest.java
@@ -23,7 +23,6 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.configuration.user.IndexConfiguration;
 import org.hestiastore.index.segmentindex.SegmentWindow;
-import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -213,8 +212,7 @@ class IndexInternalTest {
         private RecordingIndex(final EntryIterator<Integer, String> iterator,
                 final IndexConfiguration<Integer, String> conf) {
             super(new TypeDescriptorInteger(), mockPointOperationFacade(),
-                    mockReadFacade(), mock(MaintenanceService.class),
-                    mockTrackedRunner(), mock(SegmentIndexMaintenance.class),
+                    mockReadFacade(), mock(SegmentIndexMaintenance.class),
                     mockSessionOwner());
             this.iterator = iterator;
         }
@@ -278,12 +276,6 @@ class IndexInternalTest {
     @SuppressWarnings("unchecked")
     private static SegmentIndexReadFacade<Integer, String> mockReadFacade() {
         return mock(SegmentIndexReadFacade.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static SegmentIndexTrackedOperationRunner<Integer, String>
-            mockTrackedRunner() {
-        return mock(SegmentIndexTrackedOperationRunner.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMaintenanceSessionAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMaintenanceSessionAdapterTest.java
@@ -1,0 +1,80 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SegmentIndexMaintenanceSessionAdapterTest {
+
+    @Mock
+    private SegmentIndexMaintenance delegate;
+
+    @Mock
+    private SegmentIndexSessionOwner<Integer, String> sessionOwner;
+
+    @Mock
+    private SegmentIndexTrackedOperationRunner<Integer, String> trackedRunner;
+
+    @Test
+    void maintenanceCommandsRunThroughSessionAndTrackingBoundaries() {
+        enablePassThroughBoundaries();
+        final SegmentIndexMaintenance adapter =
+                new SegmentIndexMaintenanceSessionAdapter<>(delegate,
+                        sessionOwner, trackedRunner);
+
+        assertDoesNotThrow(() -> {
+            adapter.compact();
+            adapter.compactAndWait();
+            adapter.flush();
+            adapter.flushAndWait();
+            adapter.checkAndRepairConsistency();
+        });
+
+        verify(delegate).compact();
+        verify(delegate).compactAndWait();
+        verify(delegate).flush();
+        verify(delegate).flushAndWait();
+        verify(delegate).checkAndRepairConsistency();
+        verify(sessionOwner, times(5)).runMaintenanceOperation(
+                any(Runnable.class));
+        verify(trackedRunner, times(5)).runTrackedVoid(any(Runnable.class));
+        verifyNoMoreInteractions(delegate, sessionOwner, trackedRunner);
+    }
+
+    @Test
+    void constructorRejectsMissingCollaborators() {
+        assertDoesNotThrow(() -> new SegmentIndexMaintenanceSessionAdapter<>(
+                delegate, sessionOwner, trackedRunner));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SegmentIndexMaintenanceSessionAdapter<>(null,
+                        sessionOwner, trackedRunner));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SegmentIndexMaintenanceSessionAdapter<>(delegate,
+                        null, trackedRunner));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SegmentIndexMaintenanceSessionAdapter<>(delegate,
+                        sessionOwner, null));
+    }
+
+    private void enablePassThroughBoundaries() {
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(sessionOwner).runMaintenanceOperation(any(Runnable.class));
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(trackedRunner).runTrackedVoid(any(Runnable.class));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStartupRecoveryTest.java
@@ -18,7 +18,6 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.configuration.user.IndexConfiguration;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
-import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
 import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
 import org.hestiastore.index.segmentindex.maintenance.SegmentIndexMaintenance;
@@ -80,8 +79,7 @@ class SegmentIndexStartupRecoveryTest {
                 final IndexConfiguration<Integer, String> conf,
                 final AtomicInteger startupConsistencyChecks) {
             super(new TypeDescriptorInteger(), mockPointOperationFacade(),
-                    mockReadFacade(), mock(MaintenanceService.class),
-                    mockTrackedRunner(), mock(SegmentIndexMaintenance.class),
+                    mockReadFacade(), mock(SegmentIndexMaintenance.class),
                     newSessionOwner(directoryFacade, conf,
                             startupConsistencyChecks));
             this.startupConsistencyChecks = startupConsistencyChecks;
@@ -150,11 +148,6 @@ class SegmentIndexStartupRecoveryTest {
         @SuppressWarnings("unchecked")
         private static SegmentIndexReadFacade<Integer, String> mockReadFacade() {
             return mock(SegmentIndexReadFacade.class);
-        }
-
-        @SuppressWarnings("unchecked")
-        private static SegmentIndexTrackedOperationRunner<Integer, String> mockTrackedRunner() {
-            return mock(SegmentIndexTrackedOperationRunner.class);
         }
 
         @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/maintenance/SegmentIndexMaintenanceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/maintenance/SegmentIndexMaintenanceImplTest.java
@@ -1,55 +1,60 @@
 package org.hestiastore.index.segmentindex.maintenance;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.hestiastore.index.segmentindex.core.maintenance.MaintenanceService;
+import org.hestiastore.index.segmentindex.core.storage.IndexConsistencyCoordinator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class SegmentIndexMaintenanceImplTest {
 
-    @Test
-    void delegatesMaintenanceCommands() {
-        final List<String> calls = new ArrayList<>();
-        final SegmentIndexMaintenance maintenance =
-                new SegmentIndexMaintenanceImpl(
-                        () -> calls.add("compact"),
-                        () -> calls.add("compactAndWait"),
-                        () -> calls.add("flush"),
-                        () -> calls.add("flushAndWait"),
-                        () -> calls.add("checkAndRepairConsistency"));
+    @Mock
+    private MaintenanceService maintenanceService;
 
-        maintenance.compact();
-        maintenance.compactAndWait();
-        maintenance.flush();
-        maintenance.flushAndWait();
-        maintenance.checkAndRepairConsistency();
+    @Mock
+    private IndexConsistencyCoordinator<Object, Object> consistencyCoordinator;
 
-        assertEquals(List.of("compact", "compactAndWait", "flush",
-                "flushAndWait", "checkAndRepairConsistency"), calls);
+    private SegmentIndexMaintenance maintenance;
+
+    @BeforeEach
+    void setUp() {
+        maintenance = new SegmentIndexMaintenanceImpl(maintenanceService,
+                consistencyCoordinator);
     }
 
     @Test
-    void constructorRejectsMissingActions() {
-        final Runnable action = () -> {
-        };
+    void delegatesMaintenanceCommands() {
+        assertDoesNotThrow(() -> {
+            maintenance.compact();
+            maintenance.compactAndWait();
+            maintenance.flush();
+            maintenance.flushAndWait();
+            maintenance.checkAndRepairConsistency();
+        });
 
+        verify(maintenanceService).compact();
+        verify(maintenanceService).compactAndWait();
+        verify(maintenanceService).flush();
+        verify(maintenanceService).flushAndWait();
+        verify(consistencyCoordinator).checkAndRepairConsistency();
+        verifyNoMoreInteractions(maintenanceService, consistencyCoordinator);
+    }
+
+    @Test
+    void constructorRejectsMissingCollaborators() {
         assertThrows(IllegalArgumentException.class,
-                () -> new SegmentIndexMaintenanceImpl(null, action, action,
-                        action, action));
+                () -> new SegmentIndexMaintenanceImpl(null,
+                        consistencyCoordinator));
         assertThrows(IllegalArgumentException.class,
-                () -> new SegmentIndexMaintenanceImpl(action, null, action,
-                        action, action));
-        assertThrows(IllegalArgumentException.class,
-                () -> new SegmentIndexMaintenanceImpl(action, action, null,
-                        action, action));
-        assertThrows(IllegalArgumentException.class,
-                () -> new SegmentIndexMaintenanceImpl(action, action, action,
-                        null, action));
-        assertThrows(IllegalArgumentException.class,
-                () -> new SegmentIndexMaintenanceImpl(action, action, action,
-                        action, null));
+                () -> new SegmentIndexMaintenanceImpl(maintenanceService,
+                        null));
     }
 }


### PR DESCRIPTION
## Summary
- fix close-safe maintenance shutdown handling and executor topology wiring
- replace runnable-based SegmentIndexMaintenanceImpl wiring with named maintenance collaborators
- add a session maintenance adapter so lifecycle checks, operation tracking, and iterator invalidation remain applied around public maintenance calls

## Tests
- mvn -pl engine test -Dtest=SegmentIndexMaintenanceImplTest,SegmentIndexMaintenanceSessionAdapterTest,SegmentIndexMaintenanceContextLoggingAdapterTest,SegmentIndexImplTest
- mvn clean verify