### PR TITLE
Use open tail routing for sorted inserts

### DIFF
--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrencyStressIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrencyStressIT.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -42,6 +43,8 @@ class SegmentIndexConcurrencyStressIT {
 
     private static final long RETRY_TIMEOUT_MILLIS = 5_000L;
     private static final long RETRY_BACKOFF_MILLIS = 5L;
+    private static final long SPLIT_EVIDENCE_TIMEOUT_MILLIS = 2_000L;
+    private static final long SPLIT_EVIDENCE_POLL_MILLIS = 25L;
     private static final int TEST_CPU_THREADS = Math.max(1,
             Runtime.getRuntime().availableProcessors());
     private static final int MAX_TEST_WORKERS = Math.max(2,
@@ -225,6 +228,7 @@ class SegmentIndexConcurrencyStressIT {
             }
             index.maintenance().flushAndWait();
             observeSplitEvidence(indexRef.get(), splitObserved);
+            awaitSplitEvidence(indexRef.get(), splitObserved);
         } finally {
             lifecycleLock.writeLock().unlock();
         }
@@ -314,6 +318,7 @@ class SegmentIndexConcurrencyStressIT {
                     checkAndRepairConsistencyWithRetry(current,
                             RETRY_TIMEOUT_MILLIS);
                     observeSplitEvidence(current, splitObserved);
+                    awaitSplitEvidence(current, splitObserved);
                 }
             } finally {
                 lifecycleLock.writeLock().unlock();
@@ -409,6 +414,27 @@ class SegmentIndexConcurrencyStressIT {
                 || snapshot.getSplitInFlightCount() > 0
                 || snapshot.getSegmentCount() > 1) {
             splitObserved.set(true);
+        }
+    }
+
+    private static void awaitSplitEvidence(
+            final SegmentIndex<Integer, Integer> index,
+            final AtomicBoolean splitObserved) {
+        final long deadline = System.nanoTime()
+                + TimeUnit.MILLISECONDS
+                        .toNanos(SPLIT_EVIDENCE_TIMEOUT_MILLIS);
+        while (!splitObserved.get() && System.nanoTime() < deadline) {
+            observeSplitEvidence(index, splitObserved);
+            if (splitObserved.get()) {
+                return;
+            }
+            LockSupport.parkNanos(
+                    TimeUnit.MILLISECONDS
+                            .toNanos(SPLIT_EVIDENCE_POLL_MILLIS));
+            if (Thread.currentThread().isInterrupted()) {
+                Thread.currentThread().interrupt();
+                return;
+            }
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImpl.java
@@ -258,7 +258,7 @@ final class SegmentLeaseServiceImpl<K, V>
             final Snapshot<K> snapshot = currentRouteSnapshot();
             final SegmentId routedSegmentId = snapshot.findSegmentIdForKey(key);
             final RouteLease lease = routedSegmentId == null
-                    ? tryAcquireTailRoute(snapshot, key)
+                    ? tryAcquireBootstrapRoute(key)
                     : tryAcquireRouteLease(routedSegmentId, snapshot);
             if (lease != null) {
                 return lease;
@@ -266,25 +266,6 @@ final class SegmentLeaseServiceImpl<K, V>
             retryPolicy.backoffOrThrow(startNanos, OPERATION_WRITE,
                     routedSegmentId);
         }
-    }
-
-    private RouteLease tryAcquireTailRoute(final Snapshot<K> snapshot,
-            final K key) {
-        final List<SegmentId> segmentIds = snapshot
-                .getSegmentIds(SegmentWindow.unbounded());
-        if (segmentIds.isEmpty()) {
-            return tryAcquireBootstrapRoute(key);
-        }
-        final SegmentId tailSegmentId = segmentIds.get(segmentIds.size() - 1);
-        final RouteLease lease = tryAcquireRouteLease(tailSegmentId, snapshot);
-        if (lease == null) {
-            return null;
-        }
-        if (!keyToSegmentMap.extendMaxKeyIfNeeded(key)) {
-            lease.close();
-            return null;
-        }
-        return lease;
     }
 
     private RouteLease tryAcquireBootstrapRoute(final K key) {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/DefaultSegmentMaterializationService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/DefaultSegmentMaterializationService.java
@@ -75,7 +75,8 @@ final class DefaultSegmentMaterializationService<K, V> {
                     parentSegment.getId(),
                     lowerSegmentId,
                     upperSegmentId,
-                    lowerMaxKey);
+                    lowerMaxKey,
+                    upperSegment.upperMaxKey());
         } finally {
             if (materializationCompleted) {
                 closePreparedWriter(lowerWriter);
@@ -133,6 +134,7 @@ final class DefaultSegmentMaterializationService<K, V> {
         WriteTransaction<K, V> upperWriterTx = null;
         EntryWriter<K, V> upperWriter = null;
         K lowerMaxKey = null;
+        K upperMaxKey = null;
         long lowerCount = 0L;
         while (iterator.hasNext()) {
             final Entry<K, V> entry = iterator.next();
@@ -148,13 +150,15 @@ final class DefaultSegmentMaterializationService<K, V> {
                 upperWriter = openPreparedWriter(upperSegmentId,
                         upperWriterTx);
             }
+            upperMaxKey = entry.getKey();
             writeEntry(upperWriter, entry);
         }
         return new MaterializedUpperSegment<>(
                 Vldtn.requireNonNull(upperSegmentId, "upperSegmentId"),
                 Vldtn.requireNonNull(upperWriterTx, "upperWriterTx"),
                 Vldtn.requireNonNull(upperWriter, "upperWriter"),
-                Vldtn.requireNonNull(lowerMaxKey, "lowerMaxKey"));
+                Vldtn.requireNonNull(lowerMaxKey, "lowerMaxKey"),
+                Vldtn.requireNonNull(upperMaxKey, "upperMaxKey"));
     }
 
     private void writeEntry(final EntryWriter<K, V> writer,
@@ -307,14 +311,17 @@ final class DefaultSegmentMaterializationService<K, V> {
         private final WriteTransaction<K, V> writerTx;
         private final EntryWriter<K, V> writer;
         private final K lowerMaxKey;
+        private final K upperMaxKey;
 
         private MaterializedUpperSegment(final SegmentId segmentId,
                 final WriteTransaction<K, V> writerTx,
-                final EntryWriter<K, V> writer, final K lowerMaxKey) {
+                final EntryWriter<K, V> writer, final K lowerMaxKey,
+                final K upperMaxKey) {
             this.segmentId = segmentId;
             this.writerTx = writerTx;
             this.writer = writer;
             this.lowerMaxKey = lowerMaxKey;
+            this.upperMaxKey = upperMaxKey;
         }
 
         private SegmentId segmentId() {
@@ -331,6 +338,10 @@ final class DefaultSegmentMaterializationService<K, V> {
 
         private K lowerMaxKey() {
             return lowerMaxKey;
+        }
+
+        private K upperMaxKey() {
+            return upperMaxKey;
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMap.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMap.java
@@ -7,14 +7,12 @@ import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 
 /**
- * Holds {@code map<key, segmentId>} where each key is the max key in a given
- * segment.
+ * Holds {@code map<key, segmentId>} where each key is a route boundary.
  *
  * Provide information about keys and particular segment files. Each key
- * represents one segment. All keys in that segment are equal or smaller than
- * the given key. The last key represents the highest key in the index. When a
- * new value outside current routing is entered, the max key must be extended so
- * routing still covers the whole key space.
+ * represents one segment. Non-tail route keys are inclusive upper bounds. The
+ * last route is an open-ended tail, so keys above the last stored boundary
+ * still route to the last segment.
  *
  * Note that this is similar to scarce index, but still different.
  *

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapImpl.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentindex.mapping;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -130,13 +131,6 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
             isDirty = true;
             return true;
         }
-        final Map.Entry<K, SegmentId> lastEntry = list.lastEntry();
-        if (keyComparator.compare(key, lastEntry.getKey()) > 0) {
-            list.remove(lastEntry.getKey());
-            list.put(key, lastEntry.getValue());
-            refreshSnapshot();
-            isDirty = true;
-        }
         return true;
     }
 
@@ -153,12 +147,10 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
         final Entry<K, SegmentId> entry = localFindSegmentForKey(key, list);
         if (entry == null) {
             /*
-             * Key is bigger that all key so it will at last segment. But key at
-             * last segment is smaller than adding one. Because of that key have
-             * to be upgraded.
+             * No route exists yet, so bootstrap the first segment.
              */
             isDirty = true;
-            return updateMaxKey(key);
+            return bootstrapFirstSegment(key);
         } else {
             return entry.getValue();
         }
@@ -168,27 +160,20 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
             final TreeMap<K, SegmentId> source) {
         Vldtn.requireNonNull(key, "key");
         final Map.Entry<K, SegmentId> ceilingEntry = source.ceilingEntry(key);
-        if (ceilingEntry == null) {
-            return null;
-        } else {
+        if (ceilingEntry != null) {
             return Entry.of(ceilingEntry.getKey(), ceilingEntry.getValue());
         }
+        final Map.Entry<K, SegmentId> tailEntry = source.lastEntry();
+        if (tailEntry == null) {
+            return null;
+        }
+        return Entry.of(tailEntry.getKey(), tailEntry.getValue());
     }
 
-    private SegmentId updateMaxKey(final K key) {
-        if (list.size() == 0) {
-            list.put(key, FIRST_SEGMENT_ID);
-            refreshSnapshot();
-            return FIRST_SEGMENT_ID;
-        } else {
-            final Entry<K, SegmentId> max = Entry.of(list.lastEntry().getKey(),
-                    list.lastEntry().getValue());
-            list.remove(max.getKey());
-            final Entry<K, SegmentId> newMax = Entry.of(key, max.getValue());
-            list.put(newMax.getKey(), newMax.getValue());
-            refreshSnapshot();
-            return newMax.getValue();
-        }
+    private SegmentId bootstrapFirstSegment(final K key) {
+        list.put(key, FIRST_SEGMENT_ID);
+        refreshSnapshot();
+        return FIRST_SEGMENT_ID;
     }
 
     /**
@@ -200,6 +185,12 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
     void insertSegment(final K key, final SegmentId segmentId) {
         ensureOpen();
         Vldtn.requireNonNull(key, "key");
+        Vldtn.requireNonNull(segmentId, "segmentId");
+        if (list.containsKey(key) && !segmentId.equals(list.get(key))) {
+            throw new IllegalArgumentException(String.format(
+                    "Segment max key '%s' is already bound to segment '%s'",
+                    key, list.get(key)));
+        }
         if (list.containsValue(segmentId)) {
             throw new IllegalArgumentException(
                     String.format("Segment id '%s' already exists", segmentId));
@@ -260,8 +251,8 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
         }
         boolean removed = false;
         K removedKey = null;
-        final java.util.Iterator<Map.Entry<K, SegmentId>> iterator = list
-                .entrySet().iterator();
+        final Iterator<Map.Entry<K, SegmentId>> iterator = list.entrySet()
+                .iterator();
         while (iterator.hasNext()) {
             final Map.Entry<K, SegmentId> entry = iterator.next();
             if (segmentId.equals(entry.getValue())) {
@@ -279,11 +270,13 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
     }
 
     boolean tryReplaceRouteWithSplit(final SegmentRouteSplit<K> split) {
+        ensureOpen();
         Vldtn.requireNonNull(split, "split");
         final SegmentId replacedSegmentId = split.getReplacedSegmentId();
         final SegmentId lowerSegmentId = split.getLowerSegmentId();
-        final K upperMaxKey = removeSegmentAndReturnMaxKey(replacedSegmentId);
-        if (upperMaxKey == null) {
+        final RouteBoundary<K> replacedBoundary = findRouteBoundary(
+                replacedSegmentId);
+        if (replacedBoundary == null) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(
                         "Route split publish rejected because replaced segment route is missing: replacedSegmentId='{}', lowerSegmentId='{}', lowerMaxKey='{}', upperSegmentId='{}'.",
@@ -292,15 +285,107 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
             }
             return false;
         }
+        validateSplitSegmentIds(split);
+        final K upperBoundary = upperBoundaryForSplit(split,
+                replacedBoundary);
+        validateSplitBoundaries(split.getLowerMaxKey(), upperBoundary);
+        validateSplitBoundaryKeys(split, replacedBoundary, upperBoundary);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(
-                    "Split debug: map apply replacedSegmentId='{}', oldMaxKey='{}', lowerSegmentId='{}', lowerMaxKey='{}', upperSegmentId='{}'.",
-                    replacedSegmentId, upperMaxKey, lowerSegmentId,
+                    "Split debug: map apply replacedSegmentId='{}', upperBoundary='{}', lowerSegmentId='{}', lowerMaxKey='{}', upperSegmentId='{}'.",
+                    replacedSegmentId, upperBoundary, lowerSegmentId,
                     split.getLowerMaxKey(), split.getUpperSegmentId());
         }
-        insertSegment(split.getLowerMaxKey(), lowerSegmentId);
-        insertSegment(upperMaxKey, split.getUpperSegmentId());
+        applyRouteSplit(replacedBoundary.key(), split, upperBoundary);
         return true;
+    }
+
+    private RouteBoundary<K> findRouteBoundary(final SegmentId segmentId) {
+        final Map.Entry<K, SegmentId> tailEntry = list.lastEntry();
+        for (final Map.Entry<K, SegmentId> entry : list.entrySet()) {
+            if (segmentId.equals(entry.getValue())) {
+                return new RouteBoundary<>(entry.getKey(),
+                        isTailEntry(entry, tailEntry));
+            }
+        }
+        return null;
+    }
+
+    private boolean isTailEntry(final Map.Entry<K, SegmentId> entry,
+            final Map.Entry<K, SegmentId> tailEntry) {
+        return tailEntry != null
+                && keyComparator.compare(entry.getKey(), tailEntry.getKey())
+                        == 0;
+    }
+
+    private void validateSplitSegmentIds(final SegmentRouteSplit<K> split) {
+        if (split.getLowerSegmentId().equals(split.getUpperSegmentId())) {
+            throw new IllegalArgumentException(String.format(
+                    "Split child segment id '%s' is used for both routes.",
+                    split.getLowerSegmentId()));
+        }
+        validateNewSplitSegmentId(split.getLowerSegmentId(),
+                split.getReplacedSegmentId());
+        validateNewSplitSegmentId(split.getUpperSegmentId(),
+                split.getReplacedSegmentId());
+    }
+
+    private void validateNewSplitSegmentId(final SegmentId segmentId,
+            final SegmentId replacedSegmentId) {
+        if (segmentId.equals(replacedSegmentId)
+                || !list.containsValue(segmentId)) {
+            return;
+        }
+        throw new IllegalArgumentException(
+                String.format("Segment id '%s' already exists", segmentId));
+    }
+
+    private K upperBoundaryForSplit(final SegmentRouteSplit<K> split,
+            final RouteBoundary<K> replacedBoundary) {
+        if (!replacedBoundary.tail()) {
+            return replacedBoundary.key();
+        }
+        return split.getUpperMaxKey().orElseThrow(
+                () -> new IllegalArgumentException(String.format(
+                        "Tail route split for segment '%s' requires upperMaxKey.",
+                        split.getReplacedSegmentId())));
+    }
+
+    private void validateSplitBoundaries(final K lowerBoundary,
+            final K upperBoundary) {
+        if (keyComparator.compare(lowerBoundary, upperBoundary) < 0) {
+            return;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Split lower max key '%s' must be smaller than upper boundary '%s'.",
+                lowerBoundary, upperBoundary));
+    }
+
+    private void validateSplitBoundaryKeys(final SegmentRouteSplit<K> split,
+            final RouteBoundary<K> replacedBoundary, final K upperBoundary) {
+        validateSplitBoundaryKey(split.getLowerMaxKey(),
+                replacedBoundary.key());
+        validateSplitBoundaryKey(upperBoundary, replacedBoundary.key());
+    }
+
+    private void validateSplitBoundaryKey(final K boundary,
+            final K replacedBoundary) {
+        if (!list.containsKey(boundary)
+                || keyComparator.compare(boundary, replacedBoundary) == 0) {
+            return;
+        }
+        throw new IllegalArgumentException(String.format(
+                "Segment max key '%s' is already bound to segment '%s'",
+                boundary, list.get(boundary)));
+    }
+
+    private void applyRouteSplit(final K replacedBoundary,
+            final SegmentRouteSplit<K> split, final K upperBoundary) {
+        list.remove(replacedBoundary);
+        list.put(split.getLowerMaxKey(), split.getLowerSegmentId());
+        list.put(upperBoundary, split.getUpperSegmentId());
+        refreshSnapshot();
+        isDirty = true;
     }
 
     /**
@@ -358,6 +443,25 @@ public final class KeyToSegmentMapImpl<K> extends AbstractCloseableResource {
         if (wasClosed()) {
             throw new IllegalStateException(
                     getClass().getSimpleName() + " already closed");
+        }
+    }
+
+    private static final class RouteBoundary<T> {
+
+        private final T key;
+        private final boolean tail;
+
+        private RouteBoundary(final T key, final boolean tail) {
+            this.key = key;
+            this.tail = tail;
+        }
+
+        private T key() {
+            return key;
+        }
+
+        private boolean tail() {
+            return tail;
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/SegmentRouteSplit.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/SegmentRouteSplit.java
@@ -1,5 +1,7 @@
 package org.hestiastore.index.segmentindex.mapping;
 
+import java.util.Optional;
+
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 
@@ -15,6 +17,7 @@ public final class SegmentRouteSplit<K> {
     private final SegmentId lowerSegmentId;
     private final SegmentId upperSegmentId;
     private final K lowerMaxKey;
+    private final K upperMaxKey;
 
     /**
      * Creates an immutable split describing how a split outcome should be
@@ -24,10 +27,12 @@ public final class SegmentRouteSplit<K> {
      * @param lowerSegmentId    newly created lower segment id
      * @param upperSegmentId    newly created upper segment id
      * @param lowerMaxKey       maximum key covered by the lower segment
+     * @param upperMaxKey       maximum key covered by the upper segment when it
+     *                          is known
      */
     public SegmentRouteSplit(final SegmentId replacedSegmentId,
             final SegmentId lowerSegmentId, final SegmentId upperSegmentId,
-            final K lowerMaxKey) {
+            final K lowerMaxKey, final K upperMaxKey) {
         this.replacedSegmentId = Vldtn.requireNonNull(replacedSegmentId,
                 "replacedSegmentId");
         this.lowerSegmentId = Vldtn.requireNonNull(lowerSegmentId,
@@ -35,6 +40,7 @@ public final class SegmentRouteSplit<K> {
         this.upperSegmentId = Vldtn.requireNonNull(upperSegmentId,
                 "upperSegmentId");
         this.lowerMaxKey = Vldtn.requireNonNull(lowerMaxKey, "lowerMaxKey");
+        this.upperMaxKey = upperMaxKey;
     }
 
     /**
@@ -63,5 +69,12 @@ public final class SegmentRouteSplit<K> {
      */
     public K getLowerMaxKey() {
         return lowerMaxKey;
+    }
+
+    /**
+     * @return maximum key covered by the upper segment when known
+     */
+    public Optional<K> getUpperMaxKey() {
+        return Optional.ofNullable(upperMaxKey);
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/Snapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/mapping/Snapshot.java
@@ -27,7 +27,11 @@ public final class Snapshot<K> {
     public SegmentId findSegmentIdForKey(final K key) {
         Vldtn.requireNonNull(key, "key");
         final Map.Entry<K, SegmentId> ceilingEntry = map.ceilingEntry(key);
-        return ceilingEntry == null ? null : ceilingEntry.getValue();
+        if (ceilingEntry != null) {
+            return ceilingEntry.getValue();
+        }
+        final Map.Entry<K, SegmentId> tailEntry = map.lastEntry();
+        return tailEntry == null ? null : tailEntry.getValue();
     }
 
     public List<SegmentId> getSegmentIds(final SegmentWindow segmentWindow) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImplTest.java
@@ -98,6 +98,27 @@ class SegmentLeaseServiceImplTest {
     }
 
     @Test
+    void acquireForWriteUsesOpenTailWithoutExtendingRouteMap() {
+        keyToSegmentMap.extendMaxKeyIfNeeded(10);
+        segmentTopology.reconcile(keyToSegmentMap.snapshot());
+        final Snapshot<Integer> before = keyToSegmentMap.snapshot();
+        when(segmentRegistry.loadSegment(SegmentId.of(0)))
+                .thenReturn(blockingSegment);
+
+        try (SegmentLease<Integer, String> lease = service
+                .acquireForWrite(20)) {
+            assertSame(blockingSegment, lease.segment());
+            assertEquals(SegmentId.of(0), lease.segmentId());
+        }
+
+        assertTrue(keyToSegmentMap.isAtVersion(before.version()));
+        assertEquals(SegmentId.of(0),
+                keyToSegmentMap.findSegmentIdForKey(20));
+        verify(retryPolicy, never()).backoffOrThrow(0L, "acquireForWrite",
+                SegmentId.of(0));
+    }
+
+    @Test
     void acquireForWriteProvidesSegmentForCallerOperation() {
         when(segmentRegistry.loadSegment(SegmentId.of(0)))
                 .thenReturn(blockingSegment);

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplPutTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexImplPutTest.java
@@ -1,9 +1,6 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
-
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,10 +19,12 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentState;
-import org.hestiastore.index.segmentindex.configuration.user.IndexConfiguration;
+import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
+import org.hestiastore.index.segmentindex.configuration.user.IndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.user.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.configuration.user.WalDurabilityMode;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -87,6 +86,40 @@ class SegmentIndexImplPutTest {
         awaitSegmentReady(segment);
         awaitSegmentCount(cache, 2);
         assertEquals(SegmentId.of(1), cache.findSegmentIdForKey(1));
+        assertEquals("a", index.get(1));
+        assertEquals("b", index.get(2));
+        assertEquals("c", index.get(3));
+        assertEquals("d", index.get(4));
+        assertEquals("e", index.get(5));
+
+        index.put(6, "f");
+
+        assertEquals("f", index.get(6));
+    }
+
+    @Test
+    void ascendingWritesRouteThroughPersistedOpenTailAfterReopen() {
+        final IndexConfiguration<Integer, String> conf = buildConf(100, 2,
+                IndexWalConfiguration.EMPTY);
+        if (index != null && !index.wasClosed()) {
+            index.close();
+        }
+        index = null;
+        directory = new MemDirectory();
+
+        try (SegmentIndex<Integer, String> created = SegmentIndex.create(
+                directory, conf)) {
+            created.put(10, "ten");
+            created.put(20, "twenty");
+            created.maintenance().flushAndWait();
+        }
+
+        try (SegmentIndex<Integer, String> reopened = SegmentIndex.open(
+                directory, conf)) {
+            assertEquals("ten", reopened.get(10));
+            assertEquals("twenty", reopened.get(20));
+            assertNull(reopened.get(30));
+        }
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/DefaultSegmentMaterializationServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/DefaultSegmentMaterializationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
@@ -54,6 +55,7 @@ class DefaultSegmentMaterializationServiceTest {
                             2L,
                             EntryIterator.make(entries().iterator()));
 
+            assertEquals(Optional.of(4), splitPlan.getUpperMaxKey());
             try {
                 final Segment<Integer, String> lowerSegment = registry
                         .loadSegment(splitPlan.getLowerSegmentId())

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
@@ -66,7 +66,7 @@ class RouteSplitCoordinatorTest {
                         new IndexRetryPolicy(maintenance.busyBackoffMillis(),
                                 maintenance.busyTimeoutMillis())));
         splitPlan = new SegmentRouteSplit<>(PARENT_SEGMENT_ID, LOWER_SEGMENT_ID,
-                UPPER_SEGMENT_ID, 2);
+                UPPER_SEGMENT_ID, 2, null);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
@@ -44,7 +44,7 @@ class RouteSplitPreparationServiceTest {
     @Test
     void prepareReturnsMaterializedSplitForEligibleBoundary() {
         final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
-                SegmentId.of(1), SegmentId.of(2), SegmentId.of(3), 2);
+                SegmentId.of(1), SegmentId.of(2), SegmentId.of(3), 2, null);
         when(parentSegment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
                 .thenReturn(iteratorResult(entries()))
                 .thenReturn(iteratorResult(entries()));

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinatorTest.java
@@ -44,7 +44,7 @@ class RouteSplitPublishCoordinatorTest {
         coordinator = new RouteSplitPublishCoordinator<>(keyToSegmentMap,
                 segmentRegistry, materializationService);
         splitPlan = new SegmentRouteSplit<>(PARENT_SEGMENT_ID, LOWER_SEGMENT_ID,
-                UPPER_SEGMENT_ID, 2);
+                UPPER_SEGMENT_ID, 2, null);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyTest.java
@@ -140,7 +140,7 @@ class SegmentTopologyTest {
 
     private void applySplitPlan() {
         final SegmentRouteSplit<Integer> split = new SegmentRouteSplit<>(
-                SegmentId.of(0), SegmentId.of(1), SegmentId.of(2), 50);
+                SegmentId.of(0), SegmentId.of(1), SegmentId.of(2), 50, 100);
         assertTrue(keyToSegmentMap.tryReplaceRouteWithSplit(split));
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSplitConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapSplitConcurrencyTest.java
@@ -36,7 +36,7 @@ class KeyToSegmentMapSplitConcurrencyTest {
                 Entry.of(30, SegmentId.of(2))));
         adapter = new KeyToSegmentMapSynchronizedAdapter<>(rawKeyMap);
         plan = new SegmentRouteSplit<>(SegmentId.of(1), SegmentId.of(3),
-                SegmentId.of(4), 5);
+                SegmentId.of(4), 5, null);
         executor = Executors.newFixedThreadPool(2);
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/KeyToSegmentMapTest.java
@@ -31,17 +31,119 @@ class KeyToSegmentMapTest {
     }
 
     @Test
+    void insertSegmentRejectsDuplicateBoundaryKey() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1))));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.insertSegment(10, SegmentId.of(2)));
+    }
+
+    @Test
+    void findSegmentIdForKeyRoutesPastLastBoundaryToTail() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1)),
+                Entry.of(30, SegmentId.of(2))));
+
+        assertEquals(SegmentId.of(2), cache.findSegmentIdForKey(31));
+        assertEquals(SegmentId.of(2),
+                cache.snapshot().findSegmentIdForKey(31));
+    }
+
+    @Test
+    void extendMaxKeyIfNeededDoesNotMutateNonEmptyTailBoundary() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(
+                List.of());
+        assertTrue(cache.extendMaxKeyIfNeeded(10));
+        final Snapshot<Integer> before = cache.snapshot();
+        final List<SegmentId> segmentIdsBefore = cache.getSegmentIds();
+
+        assertTrue(cache.extendMaxKeyIfNeeded(20));
+
+        assertTrue(cache.isAtVersion(before.version()));
+        assertEquals(segmentIdsBefore, cache.getSegmentIds());
+        assertEquals(SegmentId.of(0), cache.findSegmentIdForKey(20));
+    }
+
+    @Test
     void tryReplaceRouteWithSplit_replacesOldSegmentWithLowerAndUpper() {
         final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
                 Entry.of(10, SegmentId.of(1)),
                 Entry.of(30, SegmentId.of(2))));
         final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
-                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 5);
+                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 5, null);
 
         assertTrue(cache.tryReplaceRouteWithSplit(routeSplit));
 
         assertEquals(List.of(SegmentId.of(3), SegmentId.of(4), SegmentId.of(2)),
                 cache.getSegmentIds());
+    }
+
+    @Test
+    void tryReplaceTailRouteWithSplitUsesUpperMaxKey() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1))));
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 20, 40);
+
+        assertTrue(cache.tryReplaceRouteWithSplit(routeSplit));
+
+        assertEquals(List.of(SegmentId.of(3), SegmentId.of(4)),
+                cache.getSegmentIds());
+        assertEquals(SegmentId.of(3), cache.findSegmentIdForKey(20));
+        assertEquals(SegmentId.of(4), cache.findSegmentIdForKey(21));
+        assertEquals(SegmentId.of(4), cache.findSegmentIdForKey(41));
+    }
+
+    @Test
+    void tryReplaceNonTailRouteWithSplitPreservesOldUpperBoundary() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1)),
+                Entry.of(30, SegmentId.of(2))));
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 5, 8);
+
+        assertTrue(cache.tryReplaceRouteWithSplit(routeSplit));
+
+        assertEquals(SegmentId.of(3), cache.findSegmentIdForKey(5));
+        assertEquals(SegmentId.of(4), cache.findSegmentIdForKey(6));
+        assertEquals(SegmentId.of(4), cache.findSegmentIdForKey(10));
+        assertEquals(SegmentId.of(2), cache.findSegmentIdForKey(11));
+    }
+
+    @Test
+    void tryReplaceTailRouteWithSplitRequiresUpperMaxKey() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1))));
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 5, null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.tryReplaceRouteWithSplit(routeSplit));
+    }
+
+    @Test
+    void tryReplaceRouteWithSplitRejectsInvalidChildBoundaryOrder() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1))));
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(1), SegmentId.of(3), SegmentId.of(4), 40, 30);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.tryReplaceRouteWithSplit(routeSplit));
+    }
+
+    @Test
+    void tryReplaceRouteWithSplitRejectsDuplicateBoundaryKey() {
+        final KeyToSegmentMapImpl<Integer> cache = newCacheWithEntries(List.of(
+                Entry.of(10, SegmentId.of(1)),
+                Entry.of(20, SegmentId.of(2)),
+                Entry.of(30, SegmentId.of(3))));
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(2), SegmentId.of(4), SegmentId.of(5), 10, 25);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cache.tryReplaceRouteWithSplit(routeSplit));
     }
 
     @Test
@@ -51,7 +153,7 @@ class KeyToSegmentMapTest {
                 Entry.of(30, SegmentId.of(2))));
         final Snapshot<Integer> before = cache.snapshot();
         final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
-                SegmentId.of(9), SegmentId.of(3), SegmentId.of(4), 5);
+                SegmentId.of(9), SegmentId.of(3), SegmentId.of(4), 5, null);
 
         assertFalse(cache.tryReplaceRouteWithSplit(routeSplit));
 
@@ -129,7 +231,7 @@ class KeyToSegmentMapTest {
         final Snapshot<Integer> snapshot = cache.snapshot();
 
         final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
-                SegmentId.of(2), SegmentId.of(4), SegmentId.of(5), 15);
+                SegmentId.of(2), SegmentId.of(4), SegmentId.of(5), 15, null);
         assertTrue(cache.tryReplaceRouteWithSplit(routeSplit));
 
         assertEquals(List.of(SegmentId.of(1), SegmentId.of(2), SegmentId.of(3)),

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/SegmentRouteSplitTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/mapping/SegmentRouteSplitTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Optional;
+
 import org.hestiastore.index.segment.SegmentId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +24,7 @@ class SegmentRouteSplitTest {
         lowerSegmentId = SegmentId.of(2);
         upperSegmentId = SegmentId.of(3);
         routeSplit = new SegmentRouteSplit<>(replacedSegmentId, lowerSegmentId,
-                upperSegmentId, 10);
+                upperSegmentId, 10, null);
     }
 
     @AfterEach
@@ -39,6 +41,15 @@ class SegmentRouteSplitTest {
         assertSame(lowerSegmentId, routeSplit.getLowerSegmentId());
         assertSame(upperSegmentId, routeSplit.getUpperSegmentId());
         assertEquals(10, routeSplit.getLowerMaxKey());
+        assertEquals(Optional.empty(), routeSplit.getUpperMaxKey());
+    }
+
+    @Test
+    void getters_return_optional_upper_max_key() {
+        final SegmentRouteSplit<Integer> split = new SegmentRouteSplit<>(
+                replacedSegmentId, lowerSegmentId, upperSegmentId, 10, 20);
+
+        assertEquals(Optional.of(20), split.getUpperMaxKey());
     }
 
     @Test
@@ -46,7 +57,7 @@ class SegmentRouteSplitTest {
         final IllegalArgumentException err = assertThrows(
                 IllegalArgumentException.class,
                 () -> new SegmentRouteSplit<>(replacedSegmentId, lowerSegmentId,
-                        null, 10));
+                        null, 10, null));
         assertEquals("Property 'upperSegmentId' must not be null.",
                 err.getMessage());
     }
@@ -56,7 +67,7 @@ class SegmentRouteSplitTest {
         final IllegalArgumentException err = assertThrows(
                 IllegalArgumentException.class,
                 () -> new SegmentRouteSplit<>(null, lowerSegmentId, upperSegmentId,
-                        10));
+                        10, null));
         assertEquals("Property 'replacedSegmentId' must not be null.",
                 err.getMessage());
     }
@@ -66,7 +77,7 @@ class SegmentRouteSplitTest {
         final IllegalArgumentException err = assertThrows(
                 IllegalArgumentException.class,
                 () -> new SegmentRouteSplit<>(replacedSegmentId, null,
-                        upperSegmentId, 10));
+                        upperSegmentId, 10, null));
         assertEquals("Property 'lowerSegmentId' must not be null.",
                 err.getMessage());
     }
@@ -76,7 +87,7 @@ class SegmentRouteSplitTest {
         final IllegalArgumentException err = assertThrows(
                 IllegalArgumentException.class,
                 () -> new SegmentRouteSplit<>(replacedSegmentId, lowerSegmentId,
-                        upperSegmentId, null));
+                        upperSegmentId, null, null));
         assertEquals("Property 'lowerMaxKey' must not be null.",
                 err.getMessage());
     }


### PR DESCRIPTION
## Summary
- Treat the last route-map entry as an open-ended tail so sorted inserts above the persisted boundary keep routing to the tail segment.
- Make max-key route extension bootstrap-only; split publish now owns route-boundary updates.
- Carry upper split boundaries from materialization and validate split boundary ordering/duplicates.

## Testing
- mvn -pl engine -Dtest=SegmentRouteSplitTest,KeyToSegmentMapTest,KeyToSegmentMapSplitConcurrencyTest,RouteSplitPublishCoordinatorTest,RouteSplitCoordinatorTest,RouteSplitPreparationServiceTest,DefaultSegmentMaterializationServiceTest test
- mvn clean verify
- git diff --check

Related to jajir/checker-store#2