### PR TITLE
Force cleanup of retired split parents

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinator.java
@@ -98,12 +98,7 @@ final class RouteSplitPublishCoordinator<K, V> {
 
     private void deleteRetiredParentSegment(final SegmentId segmentId) {
         try {
-            if (segmentRegistry.deleteSegmentIfAvailable(segmentId)) {
-                return;
-            }
-            LOGGER.warn(
-                    "Retired parent segment '{}' remained on disk because delete was busy after split publish.",
-                    segmentId);
+            segmentRegistry.deleteRetiredSegment(segmentId);
         } catch (final IndexException e) {
             LOGGER.warn(
                     "Retired parent segment '{}' could not be deleted after split publish: {}",

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegmentRegistryAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegmentRegistryAdapter.java
@@ -118,6 +118,27 @@ final class BlockingSegmentRegistryAdapter<K, V> {
         }
     }
 
+    void deleteRetiredSegment(final SegmentId segmentId) {
+        Vldtn.requireNonNull(segmentId, SEGMENT_ID_PROPERTY);
+        final long startNanos = retryPolicy.startNanos();
+        while (true) {
+            final OperationResult<Void> deleted = segmentRegistry
+                    .tryDeleteRetiredSegment(segmentId);
+            if (deleted.getStatus() == OperationStatus.OK
+                    || deleted.getStatus() == OperationStatus.CLOSED) {
+                return;
+            }
+            if (deleted.getStatus() == OperationStatus.BUSY) {
+                retryPolicy.backoffOrThrow(startNanos,
+                        "deleteRetiredSegment", segmentId);
+                continue;
+            }
+            throw new IndexException(String.format(
+                    "Retired segment '%s' failed to delete: %s", segmentId,
+                    deleted.getStatus()));
+        }
+    }
+
     boolean deleteSegmentIfAvailable(final SegmentId segmentId) {
         Vldtn.requireNonNull(segmentId, SEGMENT_ID_PROPERTY);
         final OperationResult<Void> deleted = segmentRegistry

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistry.java
@@ -94,6 +94,20 @@ public interface SegmentRegistry<K, V> {
     void deleteSegment(SegmentId segmentId);
 
     /**
+     * Removes a retired segment after its route has already been removed from
+     * the key-to-segment map.
+     * <p>
+     * Implementations may use stronger cleanup semantics than normal cache
+     * eviction because retired split parents are no longer reachable through
+     * public routing.
+     *
+     * @param segmentId retired segment id to remove
+     */
+    default void deleteRetiredSegment(final SegmentId segmentId) {
+        deleteSegment(segmentId);
+    }
+
+    /**
      * Performs a bounded fail-fast attempt to delete the requested segment.
      *
      * @param segmentId segment id to remove

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
@@ -133,6 +133,24 @@ final class SegmentRegistryCache<K, V> {
                 || !entry.tryStartUnload(readyValue)) {
             return InvalidateStatus.BUSY;
         }
+        return unloadAndRemove(key, entry);
+    }
+
+    InvalidateStatus forceInvalidate(final SegmentId key) {
+        Vldtn.requireNonNull(key, "key");
+        final Entry<Segment<K, V>> entry = map.get(key);
+        if (entry == null) {
+            return InvalidateStatus.REMOVED;
+        }
+        final Segment<K, V> readyValue = entry.getReadyValue();
+        if (readyValue == null || !entry.tryStartUnload(readyValue)) {
+            return InvalidateStatus.BUSY;
+        }
+        return unloadAndRemove(key, entry);
+    }
+
+    private InvalidateStatus unloadAndRemove(final SegmentId key,
+            final Entry<Segment<K, V>> entry) {
         final Segment<K, V> value = entry.getValueForUnload();
         if (value == null) {
             entry.cancelUnload();

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -26,8 +26,8 @@ import org.slf4j.LoggerFactory;
  * @param <K> key type
  * @param <V> value type
  */
-final class SegmentRegistryImpl<K, V>
-        implements SegmentRegistry<K, V>, SegmentRegistryStatusAccess<K, V> {
+final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
+        implements SegmentRegistry<K, V> {
 
     private static final Logger logger = LoggerFactory
             .getLogger(SegmentRegistryImpl.class);
@@ -133,6 +133,12 @@ final class SegmentRegistryImpl<K, V>
     }
 
     @Override
+    public void deleteRetiredSegment(final SegmentId segmentId) {
+        blockingFacade.deleteRetiredSegment(segmentId);
+        blockingSegments.remove(segmentId);
+    }
+
+    @Override
     public boolean deleteSegmentIfAvailable(final SegmentId segmentId) {
         final boolean deleted = blockingFacade.deleteSegmentIfAvailable(
                 segmentId);
@@ -146,7 +152,7 @@ final class SegmentRegistryImpl<K, V>
      * {@inheritDoc}
      */
     @Override
-    public OperationResult<SegmentId> allocateSegmentId() {
+    OperationResult<SegmentId> allocateSegmentId() {
         final SegmentRegistryState state = gate.getState();
         if (state != SegmentRegistryState.READY) {
             return OperationResult.fromStatus(resultForState(state));
@@ -172,7 +178,7 @@ final class SegmentRegistryImpl<K, V>
      * @return result containing the segment or a status
      */
     @Override
-    public OperationResult<Segment<K, V>> tryLoadSegment(
+    OperationResult<Segment<K, V>> tryLoadSegment(
             final SegmentId segmentId) {
         return loadSegmentInternal(segmentId);
     }
@@ -183,7 +189,7 @@ final class SegmentRegistryImpl<K, V>
      * @return registry result containing the new segment or a status
      */
     @Override
-    public OperationResult<Segment<K, V>> tryCreateSegment() {
+    OperationResult<Segment<K, V>> tryCreateSegment() {
         final OperationResult<SegmentId> allocated = allocateSegmentId();
         if (!allocated.isOk()) {
             return OperationResult.fromStatus(allocated.getStatus());
@@ -248,7 +254,7 @@ final class SegmentRegistryImpl<K, V>
      * @param segmentId segment id to remove
      */
     @Override
-    public OperationResult<Void> tryDeleteSegment(
+    OperationResult<Void> tryDeleteSegment(
             final SegmentId segmentId) {
         Vldtn.requireNonNull(segmentId, SEGMENT_ID_PARAMETER);
         final SegmentRegistryState state = gate.getState();
@@ -257,6 +263,27 @@ final class SegmentRegistryImpl<K, V>
         }
         final SegmentRegistryCache.InvalidateStatus status = cache
                 .invalidate(segmentId);
+        if (status == SegmentRegistryCache.InvalidateStatus.BUSY) {
+            return OperationResult.busy();
+        }
+        try {
+            fileSystem.deleteSegmentFiles(segmentId);
+        } catch (final RuntimeException ex) {
+            return OperationResult.error();
+        }
+        return OperationResult.ok();
+    }
+
+    @Override
+    OperationResult<Void> tryDeleteRetiredSegment(
+            final SegmentId segmentId) {
+        Vldtn.requireNonNull(segmentId, SEGMENT_ID_PARAMETER);
+        final SegmentRegistryState state = gate.getState();
+        if (state != SegmentRegistryState.READY) {
+            return OperationResult.fromStatus(resultForState(state));
+        }
+        final SegmentRegistryCache.InvalidateStatus status = cache
+                .forceInvalidate(segmentId);
         if (status == SegmentRegistryCache.InvalidateStatus.BUSY) {
             return OperationResult.busy();
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryStatusAccess.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryStatusAccess.java
@@ -11,13 +11,15 @@ import org.hestiastore.index.segment.SegmentId;
  * @param <K> key type
  * @param <V> value type
  */
-interface SegmentRegistryStatusAccess<K, V> {
+abstract class SegmentRegistryStatusAccess<K, V> {
 
-    OperationResult<Segment<K, V>> tryLoadSegment(SegmentId segmentId);
+    abstract OperationResult<Segment<K, V>> tryLoadSegment(SegmentId segmentId);
 
-    OperationResult<SegmentId> allocateSegmentId();
+    abstract OperationResult<SegmentId> allocateSegmentId();
 
-    OperationResult<Segment<K, V>> tryCreateSegment();
+    abstract OperationResult<Segment<K, V>> tryCreateSegment();
 
-    OperationResult<Void> tryDeleteSegment(SegmentId segmentId);
+    abstract OperationResult<Void> tryDeleteSegment(SegmentId segmentId);
+
+    abstract OperationResult<Void> tryDeleteRetiredSegment(SegmentId segmentId);
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPublishCoordinatorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.SegmentRouteSplit;
@@ -73,8 +74,6 @@ class RouteSplitPublishCoordinatorTest {
     @Test
     void applyPreparedSplitFlushesMapBeforeDeletingParent() {
         when(keyToSegmentMap.tryReplaceRouteWithSplit(splitPlan)).thenReturn(true);
-        when(segmentRegistry.deleteSegmentIfAvailable(PARENT_SEGMENT_ID))
-                .thenReturn(true);
 
         coordinator.applyPreparedSplit(splitPlan);
 
@@ -82,7 +81,21 @@ class RouteSplitPublishCoordinatorTest {
         inOrder.verify(keyToSegmentMap).tryReplaceRouteWithSplit(splitPlan);
         inOrder.verify(keyToSegmentMap).flushIfDirty();
         inOrder.verify(segmentRegistry)
-                .deleteSegmentIfAvailable(PARENT_SEGMENT_ID);
+                .deleteRetiredSegment(PARENT_SEGMENT_ID);
+    }
+
+    @Test
+    void applyPreparedSplitKeepsPublishedChildrenWhenRetiredParentDeleteFails() {
+        when(keyToSegmentMap.tryReplaceRouteWithSplit(splitPlan)).thenReturn(true);
+        doThrow(new IndexException("cleanup timeout"))
+                .when(segmentRegistry).deleteRetiredSegment(PARENT_SEGMENT_ID);
+
+        assertTrue(coordinator.applyPreparedSplit(splitPlan));
+
+        verify(materializationService, never())
+                .deletePreparedSegment(LOWER_SEGMENT_ID);
+        verify(materializationService, never())
+                .deletePreparedSegment(UPPER_SEGMENT_ID);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/BlockingSegmentRegistryAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/BlockingSegmentRegistryAdapterTest.java
@@ -1,16 +1,16 @@
 package org.hestiastore.index.segmentregistry;
 
-import org.hestiastore.index.OperationResult;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.IndexException;
+import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.junit.jupiter.api.Test;
@@ -70,6 +70,20 @@ class BlockingSegmentRegistryAdapterTest {
     }
 
     @Test
+    void deleteRetiredSegment_retriesBusyUntilClosed() {
+        when(registry.tryDeleteRetiredSegment(SEGMENT_ID))
+                .thenReturn(OperationResult.busy())
+                .thenReturn(OperationResult.closed());
+        final BlockingSegmentRegistryAdapter<Integer, String> adapter =
+                new BlockingSegmentRegistryAdapter<>(registry,
+                        new BusyRetryPolicy(1, 50));
+
+        adapter.deleteRetiredSegment(SEGMENT_ID);
+
+        verify(registry, times(2)).tryDeleteRetiredSegment(SEGMENT_ID);
+    }
+
+    @Test
     void deleteSegmentIfAvailable_returnsFalseWhenRegistryStaysBusy() {
         when(registry.tryDeleteSegment(SEGMENT_ID))
                 .thenReturn(OperationResult.busy())
@@ -91,5 +105,29 @@ class BlockingSegmentRegistryAdapterTest {
 
         assertThrows(IndexException.class,
                 () -> adapter.loadSegment(SEGMENT_ID));
+    }
+
+    @Test
+    void deleteSegment_throwsWhenRegistryReturnsError() {
+        when(registry.tryDeleteSegment(SEGMENT_ID))
+                .thenReturn(OperationResult.error());
+        final BlockingSegmentRegistryAdapter<Integer, String> adapter =
+                new BlockingSegmentRegistryAdapter<>(registry,
+                        new BusyRetryPolicy(1, 50));
+
+        assertThrows(IndexException.class,
+                () -> adapter.deleteSegment(SEGMENT_ID));
+    }
+
+    @Test
+    void deleteRetiredSegment_throwsWhenRegistryReturnsError() {
+        when(registry.tryDeleteRetiredSegment(SEGMENT_ID))
+                .thenReturn(OperationResult.error());
+        final BlockingSegmentRegistryAdapter<Integer, String> adapter =
+                new BlockingSegmentRegistryAdapter<>(registry,
+                        new BusyRetryPolicy(1, 50));
+
+        assertThrows(IndexException.class,
+                () -> adapter.deleteRetiredSegment(SEGMENT_ID));
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
@@ -525,6 +525,85 @@ class SegmentRegistryCacheTest {
     }
 
     @Test
+    void forceInvalidateBypassesUnloadPredicateAndClosesValue() {
+        final AtomicBoolean closed = new AtomicBoolean();
+        final Segment<Integer, String> value = segment(1);
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                2, key -> value, segment -> closed.set(true), Runnable::run,
+                segment -> false);
+
+        assertSame(value, cache.get(id(1)));
+
+        assertEquals(SegmentRegistryCache.InvalidateStatus.REMOVED,
+                cache.forceInvalidate(id(1)));
+        assertTrue(closed.get(), "Forced invalidation should close value.");
+        assertTrue(cache.getIfReady(id(1)).isEmpty());
+    }
+
+    @Test
+    void forceInvalidateReturnsBusyWhileEntryLoading() throws Exception {
+        final CountDownLatch loadStarted = new CountDownLatch(1);
+        final CountDownLatch allowLoad = new CountDownLatch(1);
+        final Segment<Integer, String> value = segment(1);
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                10, key -> {
+                    loadStarted.countDown();
+                    awaitLatch(allowLoad);
+                    return value;
+                }, segment -> {
+                });
+
+        final Future<Segment<Integer, String>> loading = executor
+                .submit(() -> cache.get(id(1)));
+        assertTrue(loadStarted.await(1, TimeUnit.SECONDS));
+
+        assertEquals(SegmentRegistryCache.InvalidateStatus.BUSY,
+                cache.forceInvalidate(id(1)));
+
+        allowLoad.countDown();
+        assertSame(value, loading.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void forceInvalidateReturnsBusyWhileEntryUnloading() throws Exception {
+        final CountDownLatch unloadStarted = new CountDownLatch(1);
+        final CountDownLatch allowUnload = new CountDownLatch(1);
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                10, key -> segment(key.getId()), value -> {
+                    unloadStarted.countDown();
+                    awaitLatch(allowUnload);
+                });
+
+        assertEquals(id(1), cache.get(id(1)).getId());
+
+        final Future<SegmentRegistryCache.InvalidateStatus> invalidation =
+                executor.submit(() -> cache.forceInvalidate(id(1)));
+        assertTrue(unloadStarted.await(1, TimeUnit.SECONDS));
+
+        assertEquals(SegmentRegistryCache.InvalidateStatus.BUSY,
+                cache.forceInvalidate(id(1)));
+
+        allowUnload.countDown();
+        assertEquals(SegmentRegistryCache.InvalidateStatus.REMOVED,
+                invalidation.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void forceInvalidateCloseFailureCancelsUnloadAndKeepsEntryAvailable() {
+        final AtomicInteger loads = new AtomicInteger();
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                2, key -> segment(loads.incrementAndGet()), value -> {
+                    throw new IllegalStateException("close failed");
+                });
+
+        final Segment<Integer, String> first = cache.get(id(1));
+        assertEquals(SegmentRegistryCache.InvalidateStatus.BUSY,
+                cache.forceInvalidate(id(1)));
+        assertSame(first, cache.get(id(1)));
+        assertEquals(1, loads.get());
+    }
+
+    @Test
     void entryTransitionsFromLoadingToReadyToUnloading() {
         final SegmentRegistryCache.Entry<String> entry = new SegmentRegistryCache.Entry<>(
                 7L);

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
@@ -3,6 +3,7 @@ package org.hestiastore.index.segmentregistry;
 import static org.hestiastore.index.segment.SegmentTestHelper.closeAndAssertClosed;
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -23,6 +24,7 @@ import java.util.concurrent.locks.LockSupport;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.OperationStatus;
+import org.hestiastore.index.bytes.ByteSequences;
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
@@ -252,6 +254,80 @@ class SegmentRegistryImplTest {
         assertTrue(loaded.isEmpty());
         closeAndAssertClosed(created);
         removeCacheEntry(segmentId);
+    }
+
+    @Test
+    void deleteRetiredSegmentClosesAndDeletesDirtyReadySegment() {
+        final Segment<Integer, String> created = registry.tryCreateSegment()
+                .getValue();
+        final SegmentId segmentId = created.getId();
+
+        assertSame(OperationStatus.OK, created.put(1, "one").getStatus());
+        assertTrue(created.getNumberOfKeysInWriteCache() > 0);
+        assertTrue(directoryFacade.isFileExists(segmentId.getName()));
+
+        registry.deleteRetiredSegment(segmentId);
+
+        assertSame(SegmentState.CLOSED, created.getState());
+        assertFalse(directoryFacade.isFileExists(segmentId.getName()));
+        assertFalse(readCacheMap().containsKey(segmentId));
+    }
+
+    @Test
+    void tryDeleteRetiredSegmentReturnsBusyWhenEntryIsLoading() {
+        final SegmentId segmentId = SegmentId.of(1001);
+        final Object entry = createLoadingEntry(10L);
+        putCacheEntry(segmentId, entry);
+
+        final OperationResult<Void> result = registry
+                .tryDeleteRetiredSegment(segmentId);
+
+        assertSame(OperationStatus.BUSY, result.getStatus());
+        removeCacheEntry(segmentId);
+    }
+
+    @Test
+    void tryDeleteRetiredSegmentReturnsBusyWhenEntryIsUnloading() {
+        final Segment<Integer, String> created = registry.tryCreateSegment()
+                .getValue();
+        final SegmentId segmentId = created.getId();
+        final Object entry = getCacheEntry(segmentId);
+        assertTrue(invokeTryStartUnload(entry));
+
+        final OperationResult<Void> result = registry
+                .tryDeleteRetiredSegment(segmentId);
+
+        assertSame(OperationStatus.BUSY, result.getStatus());
+        closeAndAssertClosed(created);
+        removeCacheEntry(segmentId);
+    }
+
+    @Test
+    void tryDeleteRetiredSegmentDeletesDirectoryWithoutCacheEntry() {
+        final SegmentId segmentId = SegmentId.of(1002);
+        directoryFacade.mkdir(segmentId.getName());
+        assertTrue(directoryFacade.isFileExists(segmentId.getName()));
+
+        final OperationResult<Void> result = registry
+                .tryDeleteRetiredSegment(segmentId);
+
+        assertSame(OperationStatus.OK, result.getStatus());
+        assertFalse(directoryFacade.isFileExists(segmentId.getName()));
+    }
+
+    @Test
+    void tryDeleteRetiredSegmentReturnsErrorLikeNormalDeleteOnDeleteFailure() {
+        final SegmentId segmentId = SegmentId.of(1003);
+        ((MemDirectory) directoryFacade).setFileSequence(segmentId.getName(),
+                ByteSequences.wrap(new byte[] {1}));
+
+        final OperationResult<Void> normal = registry.tryDeleteSegment(
+                segmentId);
+        final OperationResult<Void> retired = registry.tryDeleteRetiredSegment(
+                segmentId);
+
+        assertSame(OperationStatus.ERROR, normal.getStatus());
+        assertSame(normal.getStatus(), retired.getStatus());
     }
 
     private void rebuildRegistry() {


### PR DESCRIPTION
## Summary
- add a retired split-parent deletion path that force-invalidates cached parents after route-map publish
- close dirty retired parents before deleting their segment directory
- keep ordinary eviction and recovery orphan cleanup behavior unchanged
- leave a completed split published when retired-parent cleanup still fails after the durable map flush

## Tests
- mvn -pl engine clean verify