### PR TITLE
Guard segment index operations after close

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapter.java
@@ -27,59 +27,70 @@ public final class SegmentIndexResourceClosingAdapter<K, V>
 
     @Override
     public void put(final K key, final V value) {
+        ensureOpen();
         delegate.put(key, value);
     }
 
     @Override
     public void put(final Entry<K, V> entry) {
+        ensureOpen();
         delegate.put(entry);
     }
 
     @Override
     public V get(final K key) {
+        ensureOpen();
         return delegate.get(key);
     }
 
     @Override
     public void delete(final K key) {
+        ensureOpen();
         delegate.delete(key);
     }
 
     @Override
     public Stream<Entry<K, V>> getStream(final SegmentWindow segmentWindows) {
+        ensureOpen();
         return delegate.getStream(segmentWindows);
     }
 
     @Override
     public Stream<Entry<K, V>> getStream(final SegmentWindow segmentWindows,
             final SegmentIteratorIsolation isolation) {
+        ensureOpen();
         return delegate.getStream(segmentWindows, isolation);
     }
 
     @Override
     public Stream<Entry<K, V>> getStream() {
+        ensureOpen();
         return delegate.getStream();
     }
 
     @Override
     public Stream<Entry<K, V>> getStream(
             final SegmentIteratorIsolation isolation) {
+        ensureOpen();
         return delegate.getStream(isolation);
     }
 
     @Override
     public EntryIterator<K, V> openSegmentIterator(
             final SegmentWindow segmentWindows) {
+        ensureOpen();
         return delegate.openSegmentIterator(segmentWindows);
     }
 
     @Override
     public void completeStartup() {
+        ensureOpen();
         delegate.completeStartup();
     }
 
     @Override
     public RuntimeTuning runtimeTuning() {
+        ensureOpen();
         return delegate.runtimeTuning();
     }
 
@@ -90,6 +101,7 @@ public final class SegmentIndexResourceClosingAdapter<K, V>
 
     @Override
     public SegmentIndexMaintenance maintenance() {
+        ensureOpen();
         return delegate.maintenance();
     }
 
@@ -97,6 +109,13 @@ public final class SegmentIndexResourceClosingAdapter<K, V>
     @Override
     protected void doClose() {
         delegate.close();
+    }
+
+    private void ensureOpen() {
+        if (wasClosed()) {
+            throw new IllegalStateException(
+                    "Can't perform operation on closed index.");
+        }
     }
 
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexResourceClosingAdapterTest.java
@@ -1,8 +1,11 @@
 package org.hestiastore.index.segmentindex.core.session;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +49,23 @@ class SegmentIndexResourceClosingAdapterTest {
 
         verify(delegate).openSegmentIterator(window);
         verify(delegate).completeStartup();
+    }
+
+    @Test
+    void putAfterCloseFailsBeforeDelegate() {
+        final IndexInternal<String, String> delegate = mockIndex();
+        final SegmentIndexResourceClosingAdapter<String, String> adapter = new SegmentIndexResourceClosingAdapter<>(
+                delegate);
+        adapter.close();
+
+        final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> adapter.put("key", "value"));
+
+        assertEquals("Can't perform operation on closed index.",
+                thrown.getMessage());
+        verify(delegate).close();
+        verify(delegate, never()).put("key", "value");
     }
 
     private static final class NoopSegmentIndex extends AbstractCloseableResource


### PR DESCRIPTION
## Summary
- add a lock-free public close guard to SegmentIndexResourceClosingAdapter operations
- keep runtime monitoring available after close for final state inspection
- add regression coverage for put after close failing before delegate access

## Tests
- mvn -pl engine -Dtest=SegmentIndexStateTest,SegmentIndexResourceClosingAdapterTest test
- mvn clean verify