### PR TITLE
Add close teardown and bounded lease drain

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseService.java
@@ -47,6 +47,11 @@ public interface SegmentLeaseService<K, V> {
     SegmentLease<K, V> acquireForWrite(K key);
 
     /**
+     * Waits until currently acquired segment leases are returned.
+     */
+    void drain();
+
+    /**
      * Attempts to acquire a foreground lease for the exact mapped segment id.
      *
      * @param segmentId segment id to load

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImpl.java
@@ -60,6 +60,11 @@ final class SegmentLeaseServiceImpl<K, V>
     }
 
     @Override
+    public void drain() {
+        segmentTopology.drain();
+    }
+
+    @Override
     public Optional<SegmentLease<K, V>> tryAcquireMappedSegment(
             final SegmentId segmentId) {
         final SegmentId nonNullSegmentId = requireSegmentId(segmentId);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinator.java
@@ -1,11 +1,10 @@
 package org.hestiastore.index.segmentindex.core.session;
 
-import org.hestiastore.index.F;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
-import org.hestiastore.index.segmentindex.core.operations.IndexOperationStats;
 import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
+import org.hestiastore.index.segmentindex.core.teardown.SegmentIndexTeardownPipeline;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,22 +46,10 @@ final class IndexCloseCoordinator<K, V> {
     }
 
     void close() {
-        close(stateMachine::beginClose);
-    }
-
-    private void close(final Runnable beginClose) {
         LOGGER.debug("Closing index '{}'.", indexName);
         try {
-            beginClose.run();
-            awaitForegroundOperations();
-            closeSplitRuntime();
-            sealAsyncMaintenanceAndWait();
-            sealAndFlushRuntimeState();
-            logOperationCounts();
-            releaseWalRuntime();
-            closeExecutorRegistry();
-            finishClosedState();
-            releaseDirectoryLock();
+            stateMachine.beginClose();
+            teardownPipeline().run(this);
             LOGGER.debug("Index '{}' closed.", indexName);
         } catch (final RuntimeException e) {
             stateMachine.markRuntimeFailure(e);
@@ -70,50 +57,32 @@ final class IndexCloseCoordinator<K, V> {
         }
     }
 
-    private void awaitForegroundOperations() {
-        operationGate.awaitOperationDrain();
+    private SegmentIndexTeardownPipeline<IndexCloseCoordinator<K, V>> teardownPipeline() {
+        return SegmentIndexTeardownPipeline
+                .of(IndexCloseTeardownSteps.<K, V>closeSteps());
     }
 
-    private void closeSplitRuntime() {
-        runtime.closeSplitRuntime();
+    SegmentIndexOperationGate operationGate() {
+        return operationGate;
     }
 
-    private void sealAsyncMaintenanceAndWait() {
-        runtime.sealAsyncMaintenanceAndWait();
+    SegmentIndexRuntime<K, V> runtime() {
+        return runtime;
     }
 
-    private void sealAndFlushRuntimeState() {
-        runtime.flushAndWait();
-        runtime.closeSegmentRegistry();
-        runtime.closeKeyToSegmentMapIfOpen();
+    IndexOperationStatsRecorder operationStatsRecorder() {
+        return operationStatsRecorder;
     }
 
-    private void finishClosedState() {
-        stateMachine.completeClose();
+    ExecutorRegistry executorRegistry() {
+        return executorRegistry;
     }
 
-    private void releaseWalRuntime() {
-        runtime.closeWalRuntime();
+    SegmentIndexStateMachine stateMachine() {
+        return stateMachine;
     }
 
-    private void closeExecutorRegistry() {
-        executorRegistry.close();
-    }
-
-    private void releaseDirectoryLock() {
-        directoryLock.close();
-    }
-
-    private void logOperationCounts() {
-        if (!LOGGER.isDebugEnabled()) {
-            return;
-        }
-        final IndexOperationStats stats =
-                operationStatsRecorder.statsSnapshot();
-        LOGGER.debug(String.format(
-                "Index is closing, where was %s gets, %s puts and %s deletes.",
-                F.fmt(stats.getGetCount()),
-                F.fmt(stats.getPutCount()),
-                F.fmt(stats.getDeleteCount())));
+    IndexDirectoryLock directoryLock() {
+        return directoryLock;
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseTeardownSteps.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexCloseTeardownSteps.java
@@ -1,0 +1,148 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hestiastore.index.F;
+import org.hestiastore.index.segmentindex.core.operations.IndexOperationStats;
+import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
+import org.hestiastore.index.segmentindex.core.teardown.SegmentIndexTeardownStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates one-use step lists for the full segment-index close flow.
+ */
+final class IndexCloseTeardownSteps {
+
+    private IndexCloseTeardownSteps() {
+    }
+
+    static <K, V> List<SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>>> closeSteps() {
+        final List<SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>>> steps =
+                new ArrayList<>();
+        steps.add(new AwaitForegroundOperations<>());
+        steps.add(new CloseSplitRuntime<>());
+        steps.add(new SealAsyncMaintenanceAndWait<>());
+        steps.add(new FlushAndWait<>());
+        steps.add(new CloseSegmentRegistry<>());
+        steps.add(new CloseKeyToSegmentMapIfOpen<>());
+        steps.add(new LogOperationCounts<>());
+        steps.add(new ReleaseWalRuntime<>());
+        steps.add(new CloseExecutorRegistry<>());
+        steps.add(new FinishClosedState<>());
+        steps.add(new ReleaseDirectoryLock<>());
+        return List.copyOf(steps);
+    }
+
+    private static final class AwaitForegroundOperations<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.operationGate().awaitOperationDrain();
+        }
+    }
+
+    private static final class CloseSplitRuntime<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().closeSplitRuntime();
+        }
+    }
+
+    private static final class SealAsyncMaintenanceAndWait<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().sealAsyncMaintenanceAndWait();
+        }
+    }
+
+    private static final class FlushAndWait<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().flushAndWait();
+        }
+    }
+
+    private static final class CloseSegmentRegistry<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().closeSegmentRegistry();
+        }
+    }
+
+    private static final class CloseKeyToSegmentMapIfOpen<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().closeKeyToSegmentMapIfOpen();
+        }
+    }
+
+    private static final class LogOperationCounts<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        private static final Logger LOGGER = LoggerFactory
+                .getLogger(LogOperationCounts.class);
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            final IndexOperationStatsRecorder recorder =
+                    context.operationStatsRecorder();
+            if (!LOGGER.isDebugEnabled()) {
+                return;
+            }
+            final IndexOperationStats stats = recorder.statsSnapshot();
+            LOGGER.debug(String.format(
+                    "Index is closing, where was %s gets, %s puts and %s deletes.",
+                    F.fmt(stats.getGetCount()), F.fmt(stats.getPutCount()),
+                    F.fmt(stats.getDeleteCount())));
+        }
+    }
+
+    private static final class ReleaseWalRuntime<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.runtime().closeWalRuntime();
+        }
+    }
+
+    private static final class CloseExecutorRegistry<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.executorRegistry().close();
+        }
+    }
+
+    private static final class FinishClosedState<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.stateMachine().completeClose();
+        }
+    }
+
+    private static final class ReleaseDirectoryLock<K, V>
+            implements SegmentIndexTeardownStep<IndexCloseCoordinator<K, V>> {
+
+        @Override
+        public void apply(final IndexCloseCoordinator<K, V> context) {
+            context.directoryLock().close();
+        }
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactory.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeFactory.java
@@ -162,6 +162,7 @@ final class SegmentIndexRuntimeFactory<K, V> {
             final SegmentIndexCoreStorage<K, V> coreStorage) {
         return SegmentTopology.<K>builder()
                 .snapshot(coreStorage.keyToSegmentMap().snapshot())
+                .retryPolicy(coreStorage.retryPolicy())
                 .build();
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownPipeline.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownPipeline.java
@@ -1,0 +1,64 @@
+package org.hestiastore.index.segmentindex.core.teardown;
+
+import java.util.List;
+
+import org.hestiastore.index.Vldtn;
+
+/**
+ * Runs segment-index teardown steps and preserves later close failures as
+ * suppressed exceptions on the first failure.
+ *
+ * @param <C> teardown context type
+ */
+public final class SegmentIndexTeardownPipeline<C> {
+
+    private final List<SegmentIndexTeardownStep<C>> closeSteps;
+
+    SegmentIndexTeardownPipeline(
+            final List<SegmentIndexTeardownStep<C>> closeSteps) {
+        this.closeSteps = List.copyOf(Vldtn.requireNonNull(closeSteps,
+                "closeSteps"));
+    }
+
+    /**
+     * Creates a segment-index teardown pipeline.
+     *
+     * @param <C>        teardown context type
+     * @param closeSteps close steps
+     * @return close teardown pipeline
+     */
+    public static <C> SegmentIndexTeardownPipeline<C> of(
+            final List<SegmentIndexTeardownStep<C>> closeSteps) {
+        return new SegmentIndexTeardownPipeline<>(closeSteps);
+    }
+
+    /**
+     * Runs every configured close step.
+     *
+     * @param context typed access to the closing index collaborators
+     */
+    public void run(final C context) {
+        final C nonNullContext = Vldtn.requireNonNull(context, "context");
+        RuntimeException firstFailure = null;
+        for (final SegmentIndexTeardownStep<C> closeStep : closeSteps) {
+            try {
+                closeStep.apply(nonNullContext);
+            } catch (final RuntimeException failure) {
+                firstFailure = recordFailure(firstFailure, failure);
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
+    }
+
+    private static RuntimeException recordFailure(
+            final RuntimeException firstFailure,
+            final RuntimeException failure) {
+        if (firstFailure == null) {
+            return failure;
+        }
+        firstFailure.addSuppressed(failure);
+        return firstFailure;
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownStep.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownStep.java
@@ -1,0 +1,16 @@
+package org.hestiastore.index.segmentindex.core.teardown;
+
+/**
+ * One close step in the segment-index teardown pipeline.
+ *
+ * @param <C> teardown context type
+ */
+public interface SegmentIndexTeardownStep<C> {
+
+    /**
+     * Applies this close step.
+     *
+     * @param context typed access to the closing index collaborators
+     */
+    void apply(C context);
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopology.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopology.java
@@ -39,6 +39,11 @@ public interface SegmentTopology<K> {
     RouteDrainResult tryBeginDrain(SegmentId segmentId);
 
     /**
+     * Waits until all currently acquired route leases are returned.
+     */
+    void drain();
+
+    /**
      * Reconciles runtime routes with the persisted route-map snapshot.
      *
      * @param snapshot route-map snapshot

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilder.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.segmentindex.core.topology;
 
+import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segmentindex.mapping.Snapshot;
 
@@ -11,6 +12,7 @@ import org.hestiastore.index.segmentindex.mapping.Snapshot;
 public final class SegmentTopologyBuilder<K> {
 
     private Snapshot<K> snapshot;
+    private BusyRetryPolicy retryPolicy;
 
     SegmentTopologyBuilder() {
     }
@@ -27,12 +29,25 @@ public final class SegmentTopologyBuilder<K> {
     }
 
     /**
+     * Sets the retry policy used while waiting for route leases to drain.
+     *
+     * @param retryPolicy retry policy
+     * @return this builder
+     */
+    public SegmentTopologyBuilder<K> retryPolicy(
+            final BusyRetryPolicy retryPolicy) {
+        this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
+        return this;
+    }
+
+    /**
      * Builds a segment topology.
      *
      * @return segment topology
      */
     public SegmentTopology<K> build() {
         return new SegmentTopologyImpl<>(
-                Vldtn.requireNonNull(snapshot, "snapshot"));
+                Vldtn.requireNonNull(snapshot, "snapshot"),
+                Vldtn.requireNonNull(retryPolicy, "retryPolicy"));
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
@@ -15,11 +16,16 @@ import org.hestiastore.index.segmentindex.mapping.Snapshot;
 
 final class SegmentTopologyImpl<K> implements SegmentTopology<K> {
 
+    private static final String OPERATION_DRAIN = "drainRouteLeases";
+
     private final Object monitor = new Object();
     private final Map<SegmentId, RouteEntry> routes = new HashMap<>();
+    private final BusyRetryPolicy retryPolicy;
     private long version;
 
-    SegmentTopologyImpl(final Snapshot<K> snapshot) {
+    SegmentTopologyImpl(final Snapshot<K> snapshot,
+            final BusyRetryPolicy retryPolicy) {
+        this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
         reconcile(snapshot);
     }
 
@@ -53,6 +59,14 @@ final class SegmentTopologyImpl<K> implements SegmentTopology<K> {
             monitor.notifyAll();
             return DefaultRouteDrainResult
                     .acquired(new DefaultRouteDrain(this, segmentId));
+        }
+    }
+
+    @Override
+    public void drain() {
+        final long startNanos = retryPolicy.startNanos();
+        while (hasInFlightLeasesSnapshot()) {
+            retryPolicy.backoffOrThrow(startNanos, OPERATION_DRAIN, null);
         }
     }
 
@@ -148,5 +162,15 @@ final class SegmentTopologyImpl<K> implements SegmentTopology<K> {
     private long inFlightCount(final SegmentId segmentId) {
         final RouteEntry entry = routes.get(segmentId);
         return entry == null ? 0L : entry.inFlight();
+    }
+
+    private boolean hasInFlightLeases() {
+        return routes.values().stream().anyMatch(RouteEntry::hasInFlight);
+    }
+
+    private boolean hasInFlightLeasesSnapshot() {
+        synchronized (monitor) {
+            return hasInFlightLeases();
+        }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -144,6 +144,14 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
             final Function<Segment<K, V>, OperationResult<T>> action) {
         final long startNanos = retryPolicy.startNanos();
         while (true) {
+            /**
+             * Problems:
+             * 
+             * - executton could be here waiting for stopping BUSY, but it have about 5 ms
+             * to move it to CLOSED state. Status CLOSED mean closing segment and unloading
+             * of segment from memory.
+             * 
+             */
             final Segment<K, V> currentSegment = loadSegment();
             final OperationResult<T> result = action.apply(currentSegment);
             if (result.getStatus() == OperationStatus.OK) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/segmentlease/SegmentLeaseServiceImplTest.java
@@ -60,7 +60,8 @@ class SegmentLeaseServiceImplTest {
                 new KeyToSegmentMapImpl<>(new MemDirectory(),
                         new TypeDescriptorInteger()));
         segmentTopology = SegmentTopology.<Integer>builder()
-                .snapshot(keyToSegmentMap.snapshot()).build();
+                .snapshot(keyToSegmentMap.snapshot()).retryPolicy(retryPolicy)
+                .build();
         service = new SegmentLeaseServiceImpl<>(keyToSegmentMap,
                 segmentRegistry, segmentTopology, retryPolicy);
     }
@@ -129,6 +130,18 @@ class SegmentLeaseServiceImplTest {
         }
 
         verify(blockingSegment).put(11, "v11");
+    }
+
+    @Test
+    void drainDelegatesToTopology() {
+        final SegmentTopology<Integer> topology = mockSegmentTopology();
+        final SegmentLeaseService<Integer, String> leaseService =
+                new SegmentLeaseServiceImpl<>(keyToSegmentMap, segmentRegistry,
+                        topology, retryPolicy);
+
+        leaseService.drain();
+
+        verify(topology).drain();
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseCoordinatorTest.java
@@ -1,10 +1,11 @@
 package org.hestiastore.index.segmentindex.core.session;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,33 +83,54 @@ class IndexCloseCoordinatorTest {
     }
 
     @Test
-    void close_marksErrorAndKeepsLockWhenRegistryCloseFails() {
-        doThrow(new IndexException("close failed")).when(runtime)
-                .closeSegmentRegistry();
+    void close_marksErrorAndReleasesResourcesWhenRegistryCloseFails() {
+        final IndexException failure = new IndexException("close failed");
+        doThrow(failure).when(runtime).closeSegmentRegistry();
 
-        assertThrows(IndexException.class, () -> closeCoordinator.close());
+        final IndexException thrown = assertThrows(IndexException.class,
+                () -> closeCoordinator.close());
 
+        assertSame(failure, thrown);
         verify(runtime).flushAndWait();
-        verify(runtime, never()).closeKeyToSegmentMapIfOpen();
-        verify(runtime, never()).closeWalRuntime();
-        verify(executorRegistry, never()).close();
-        verify(stateMachine, never()).completeClose();
-        verify(fileLock, never()).unlock();
-        verify(stateMachine).markRuntimeFailure(
-                org.mockito.ArgumentMatchers.any(IndexException.class));
+        verify(runtime).closeKeyToSegmentMapIfOpen();
+        verify(runtime).closeWalRuntime();
+        verify(executorRegistry).close();
+        verify(stateMachine).completeClose();
+        verify(fileLock).unlock();
+        verify(stateMachine).markRuntimeFailure(failure);
     }
 
     @Test
-    void close_keepsLockWhenExecutorShutdownFails() {
-        doThrow(new IndexException("executor timeout")).when(executorRegistry)
-                .close();
+    void close_releasesLockWhenExecutorShutdownFails() {
+        final IndexException failure = new IndexException("executor timeout");
+        doThrow(failure).when(executorRegistry).close();
 
-        assertThrows(IndexException.class, () -> closeCoordinator.close());
+        final IndexException thrown = assertThrows(IndexException.class,
+                () -> closeCoordinator.close());
 
+        assertSame(failure, thrown);
         verify(runtime).closeWalRuntime();
-        verify(stateMachine, never()).completeClose();
-        verify(fileLock, never()).unlock();
-        verify(stateMachine).markRuntimeFailure(
-                org.mockito.ArgumentMatchers.any(IndexException.class));
+        verify(stateMachine).completeClose();
+        verify(fileLock).unlock();
+        verify(stateMachine).markRuntimeFailure(failure);
+    }
+
+    @Test
+    void close_suppressesLaterFailuresOnFirstCloseFailure() {
+        final IndexException firstFailure = new IndexException(
+                "registry failed");
+        final IndexException secondFailure = new IndexException("wal failed");
+        doThrow(firstFailure).when(runtime).closeSegmentRegistry();
+        doThrow(secondFailure).when(runtime).closeWalRuntime();
+
+        final IndexException thrown = assertThrows(IndexException.class,
+                () -> closeCoordinator.close());
+
+        assertSame(firstFailure, thrown);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertSame(secondFailure, thrown.getSuppressed()[0]);
+        verify(executorRegistry).close();
+        verify(fileLock).unlock();
+        verify(stateMachine).markRuntimeFailure(firstFailure);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseTeardownStepsTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexCloseTeardownStepsTest.java
@@ -1,0 +1,105 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
+import org.hestiastore.index.segmentindex.core.operations.IndexOperationStatsRecorder;
+import org.hestiastore.index.segmentindex.core.teardown.SegmentIndexTeardownStep;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IndexCloseTeardownStepsTest {
+
+    @Mock
+    private IndexCloseCoordinator<Integer, String> context;
+
+    @Mock
+    private SegmentIndexOperationGate operationGate;
+
+    @Mock
+    private SegmentIndexRuntime<Integer, String> runtime;
+
+    @Mock
+    private IndexOperationStatsRecorder operationStatsRecorder;
+
+    @Mock
+    private ExecutorRegistry executorRegistry;
+
+    @Mock
+    private SegmentIndexStateMachine stateMachine;
+
+    @Mock
+    private IndexDirectoryLock directoryLock;
+
+    @Test
+    void closeSteps_returnsStandardStepCount() {
+        final var closeSteps = IndexCloseTeardownSteps
+                .<Integer, String>closeSteps();
+
+        assertEquals(11, closeSteps.size());
+    }
+
+    @Test
+    void closeSteps_runStandardCloseOrder() {
+        stubContext();
+        final var closeSteps = IndexCloseTeardownSteps
+                .<Integer, String>closeSteps();
+
+        closeSteps.forEach(step -> step.apply(context));
+
+        final InOrder inOrder = inOrder(context, operationGate, runtime,
+                executorRegistry, stateMachine, directoryLock);
+        inOrder.verify(context).operationGate();
+        inOrder.verify(operationGate).awaitOperationDrain();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).closeSplitRuntime();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).sealAsyncMaintenanceAndWait();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).flushAndWait();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).closeSegmentRegistry();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).closeKeyToSegmentMapIfOpen();
+        inOrder.verify(context).operationStatsRecorder();
+        inOrder.verify(context).runtime();
+        inOrder.verify(runtime).closeWalRuntime();
+        inOrder.verify(context).executorRegistry();
+        inOrder.verify(executorRegistry).close();
+        inOrder.verify(context).stateMachine();
+        inOrder.verify(stateMachine).completeClose();
+        inOrder.verify(context).directoryLock();
+        inOrder.verify(directoryLock).close();
+    }
+
+    @Test
+    void closeSteps_returnsImmutableList() {
+        final var closeSteps = IndexCloseTeardownSteps
+                .<Integer, String>closeSteps();
+        final SegmentIndexTeardownStep<IndexCloseCoordinator<Integer, String>> extraStep =
+                context -> {
+                    throw new AssertionError("not called");
+                };
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> closeSteps.add(extraStep));
+    }
+
+    private void stubContext() {
+        when(context.operationGate()).thenReturn(operationGate);
+        when(context.runtime()).thenReturn(runtime);
+        when(context.operationStatsRecorder()).thenReturn(
+                operationStatsRecorder);
+        when(context.executorRegistry()).thenReturn(executorRegistry);
+        when(context.stateMachine()).thenReturn(stateMachine);
+        when(context.directoryLock()).thenReturn(directoryLock);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownPipelineTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/teardown/SegmentIndexTeardownPipelineTest.java
@@ -1,0 +1,68 @@
+package org.hestiastore.index.segmentindex.core.teardown;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SegmentIndexTeardownPipelineTest {
+
+    @Test
+    void run_executesAllStepsWhenEarlierStepsFail() {
+        final List<String> calls = new ArrayList<>();
+        final RuntimeException firstFailure =
+                new IllegalStateException("first");
+        final RuntimeException secondFailure =
+                new IllegalStateException("second");
+        final SegmentIndexTeardownPipeline<String> pipeline =
+                new SegmentIndexTeardownPipeline<>(List.of(
+                        closeAction("one", calls, firstFailure),
+                        closeAction("two", calls, null),
+                        closeAction("three", calls, secondFailure)));
+
+        final RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> pipeline.run("context"));
+
+        assertSame(firstFailure, thrown);
+        assertEquals(List.of("one", "two", "three"), calls);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertSame(secondFailure, thrown.getSuppressed()[0]);
+    }
+
+    @Test
+    void run_completesWhenAllStepsSucceed() {
+        final List<String> calls = new ArrayList<>();
+        final SegmentIndexTeardownPipeline<String> pipeline =
+                new SegmentIndexTeardownPipeline<>(List.of(
+                        closeAction("one", calls, null),
+                        closeAction("two", calls, null)));
+
+        pipeline.run("context");
+
+        assertEquals(List.of("one", "two"), calls);
+    }
+
+    @Test
+    void run_rejectsNullContext() {
+        final SegmentIndexTeardownPipeline<String> pipeline =
+                SegmentIndexTeardownPipeline.of(List.of());
+
+        assertThrows(IllegalArgumentException.class, () -> pipeline.run(null));
+    }
+
+    private static SegmentIndexTeardownStep<String> closeAction(
+            final String name,
+            final List<String> calls,
+            final RuntimeException failure) {
+        return context -> {
+            calls.add(name);
+            if (failure != null) {
+                throw failure;
+            }
+        };
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyBuilderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentId;
@@ -18,12 +19,14 @@ import org.junit.jupiter.api.Test;
 class SegmentTopologyBuilderTest {
 
     private KeyToSegmentMap<Integer> keyToSegmentMap;
+    private BusyRetryPolicy retryPolicy;
 
     @BeforeEach
     void setUp() {
         keyToSegmentMap = new KeyToSegmentMapSynchronizedAdapter<>(
                 new KeyToSegmentMapImpl<>(new MemDirectory(),
                         new TypeDescriptorInteger()));
+        retryPolicy = new BusyRetryPolicy(1, 1000);
     }
 
     @AfterEach
@@ -39,7 +42,8 @@ class SegmentTopologyBuilderTest {
         final Snapshot<Integer> snapshot = keyToSegmentMap.snapshot();
 
         final SegmentTopology<Integer> topology = SegmentTopology
-                .<Integer>builder().snapshot(snapshot).build();
+                .<Integer>builder().snapshot(snapshot)
+                .retryPolicy(retryPolicy).build();
 
         final SegmentTopology.RouteLeaseResult leaseResult = topology
                 .tryAcquire(SegmentId.of(0), snapshot.version());
@@ -54,7 +58,16 @@ class SegmentTopologyBuilderTest {
     @Test
     void buildRejectsMissingSnapshot() {
         final SegmentTopologyBuilder<Integer> builder = SegmentTopology
-                .builder();
+                .<Integer>builder().retryPolicy(retryPolicy);
+
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void buildRejectsMissingRetryPolicy() {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final SegmentTopologyBuilder<Integer> builder = SegmentTopology
+                .<Integer>builder().snapshot(keyToSegmentMap.snapshot());
 
         assertThrows(IllegalArgumentException.class, builder::build);
     }
@@ -66,5 +79,14 @@ class SegmentTopologyBuilderTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> builder.snapshot(null));
+    }
+
+    @Test
+    void retryPolicyRejectsNullRetryPolicy() {
+        final SegmentTopologyBuilder<Integer> builder = SegmentTopology
+                .builder();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.retryPolicy(null));
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/topology/SegmentTopologyTest.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentindex.core.topology;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,6 +13,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.hestiastore.index.BusyRetryPolicy;
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentId;
@@ -28,6 +31,7 @@ class SegmentTopologyTest {
 
     private KeyToSegmentMap<Integer> keyToSegmentMap;
     private ExecutorService executor;
+    private BusyRetryPolicy retryPolicy;
 
     @BeforeEach
     void setUp() {
@@ -35,6 +39,7 @@ class SegmentTopologyTest {
                 new KeyToSegmentMapImpl<>(new MemDirectory(),
                         new TypeDescriptorInteger()));
         executor = Executors.newSingleThreadExecutor();
+        retryPolicy = new BusyRetryPolicy(1, 1000);
     }
 
     @AfterEach
@@ -90,6 +95,48 @@ class SegmentTopologyTest {
     }
 
     @Test
+    void drainWaitsForAllInflightLeases() throws Exception {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final SegmentTopology<Integer> topology = newTopology();
+        final SegmentTopology.RouteLease lease = topology
+                .tryAcquire(SegmentId.of(0), keyToSegmentMap.snapshot()
+                        .version())
+                .lease();
+        final CountDownLatch waiting = new CountDownLatch(1);
+
+        final Future<?> waitFuture = executor.submit(() -> {
+            waiting.countDown();
+            topology.drain();
+        });
+
+        assertTrue(waiting.await(5, TimeUnit.SECONDS));
+        assertFalse(waitFuture.isDone());
+
+        lease.close();
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            waitFuture.get(5, TimeUnit.SECONDS);
+        });
+    }
+
+    @Test
+    void drainTimesOutWhenInflightLeaseRemainsOpen() {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final SegmentTopology<Integer> topology = newTopology(
+                new BusyRetryPolicy(1, 1));
+        final SegmentTopology.RouteLease lease = topology
+                .tryAcquire(SegmentId.of(0), keyToSegmentMap.snapshot()
+                        .version())
+                .lease();
+
+        try {
+            assertThrows(IndexException.class, topology::drain);
+        } finally {
+            lease.close();
+        }
+    }
+
+    @Test
     void reconcilePublishesChildRoutesAndRetiresParentRoute() {
         keyToSegmentMap.extendMaxKeyIfNeeded(100);
         final SegmentTopology<Integer> topology = newTopology();
@@ -114,7 +161,8 @@ class SegmentTopologyTest {
         keyToSegmentMap.extendMaxKeyIfNeeded(100);
         final Snapshot<Integer> olderSnapshot = keyToSegmentMap.snapshot();
         final SegmentTopology<Integer> topology = SegmentTopology
-                .<Integer>builder().snapshot(olderSnapshot).build();
+                .<Integer>builder().snapshot(olderSnapshot)
+                .retryPolicy(retryPolicy).build();
         applySplitPlan();
         final Snapshot<Integer> newerSnapshot = keyToSegmentMap.snapshot();
         topology.reconcile(newerSnapshot);
@@ -134,8 +182,14 @@ class SegmentTopologyTest {
     }
 
     private SegmentTopology<Integer> newTopology() {
+        return newTopology(retryPolicy);
+    }
+
+    private SegmentTopology<Integer> newTopology(
+            final BusyRetryPolicy topologyRetryPolicy) {
         return SegmentTopology.<Integer>builder()
-                .snapshot(keyToSegmentMap.snapshot()).build();
+                .snapshot(keyToSegmentMap.snapshot())
+                .retryPolicy(topologyRetryPolicy).build();
     }
 
     private void applySplitPlan() {


### PR DESCRIPTION
## Summary
- add close teardown pipeline support around segment index shutdown
- add SegmentLeaseService.drain() and bounded topology drain using BusyRetryPolicy
- move drain retry policy ownership into SegmentTopologyImpl via the topology builder

## Tests
- mvn -pl engine -Dtest=SegmentTopologyTest,SegmentTopologyBuilderTest,SegmentLeaseServiceImplTest test
- mvn clean verify