### PR TITLE
Improve route split diagnostics and recount handling

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationService.java
@@ -22,6 +22,9 @@ import org.slf4j.LoggerFactory;
  */
 final class RouteSplitPreparationService<K, V> {
 
+    private static final long MIN_KEYS_PER_CHILD_SEGMENT = 3L;
+    private static final long MIN_VISIBLE_KEYS_FOR_FALLBACK_SPLIT =
+            MIN_KEYS_PER_CHILD_SEGMENT * 2L;
     private static final String SEGMENT_ARG = "segment";
     private static final Logger LOGGER = LoggerFactory
             .getLogger(RouteSplitPreparationService.class);
@@ -41,28 +44,46 @@ final class RouteSplitPreparationService<K, V> {
             final long splitThreshold) {
         final Segment<K, V> nonNullParentSegment = Vldtn
                 .requireNonNull(parentSegment, SEGMENT_ARG);
-        final long visibleCount = countVisibleEntries(nonNullParentSegment);
-        if (!isEligibleVisibleCount(visibleCount, splitThreshold)) {
+        final Long visibleCount = countVisibleEntries(nonNullParentSegment);
+        if (visibleCount == null) {
+            logEligibilityRecountAbortedBecauseParentClosed(
+                    nonNullParentSegment);
+            return null;
+        }
+        final long recountedVisibleCount = visibleCount.longValue();
+        if (!shouldContinueSplitAfterVisibleRecount(nonNullParentSegment,
+                recountedVisibleCount, splitThreshold)) {
+            logSplitAbortedAfterRecountBelowThreshold(nonNullParentSegment,
+                    recountedVisibleCount, splitThreshold);
             return null;
         }
         return materializeChildSegments(nonNullParentSegment,
-                targetLowerCount(visibleCount));
+                targetLowerCount(recountedVisibleCount));
     }
 
-    private boolean isEligibleVisibleCount(final long visibleCount,
+    private boolean shouldContinueSplitAfterVisibleRecount(
+            final Segment<K, V> parentSegment, final long visibleCount,
             final long splitThreshold) {
-        return visibleCount >= splitThreshold && visibleCount >= 2L;
+        if (visibleCount >= splitThreshold) {
+            return true;
+        }
+        if (visibleCount < MIN_VISIBLE_KEYS_FOR_FALLBACK_SPLIT) {
+            return false;
+        }
+        logSplitContinuingAfterBelowThresholdRecount(parentSegment,
+                visibleCount, splitThreshold);
+        return true;
     }
 
     private long targetLowerCount(final long visibleCount) {
         return Math.max(1L, visibleCount / 2L);
     }
 
-    private long countVisibleEntries(final Segment<K, V> segment) {
+    private Long countVisibleEntries(final Segment<K, V> segment) {
         try (EntryIterator<K, V> iterator = openIteratorWithRetry(segment,
                 SegmentIteratorIsolation.FULL_ISOLATION)) {
             if (iterator == null) {
-                return 0L;
+                return null;
             }
             long count = 0L;
             while (iterator.hasNext()) {
@@ -135,6 +156,36 @@ final class RouteSplitPreparationService<K, V> {
             LOGGER.debug(
                     "Route split aborted because parent iterator was invalidated during child materialization: segment='{}'",
                     parentSegment.getId());
+        }
+    }
+
+    private void logEligibilityRecountAbortedBecauseParentClosed(
+            final Segment<K, V> parentSegment) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split aborted because parent segment closed before eligibility recount completed: segment='{}'",
+                    parentSegment.getId());
+        }
+    }
+
+    private void logSplitAbortedAfterRecountBelowThreshold(
+            final Segment<K, V> parentSegment, final long visibleCount,
+            final long splitThreshold) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split aborted after eligibility recount fell below threshold: segment='{}' visibleKeys='{}' threshold='{}'",
+                    parentSegment.getId(), visibleCount, splitThreshold);
+        }
+    }
+
+    private void logSplitContinuingAfterBelowThresholdRecount(
+            final Segment<K, V> parentSegment, final long visibleCount,
+            final long splitThreshold) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split continuing after eligibility recount fell below threshold because minimum child size is satisfied: segment='{}' visibleKeys='{}' threshold='{}' minKeysPerChild='{}'",
+                    parentSegment.getId(), visibleCount, splitThreshold,
+                    MIN_KEYS_PER_CHILD_SEGMENT);
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitExecutionCoordinatorImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitExecutionCoordinatorImpl.java
@@ -17,6 +17,8 @@ import org.hestiastore.index.segmentindex.core.segmentlease.SegmentSplitLease;
 import org.hestiastore.index.segmentindex.mapping.KeyToSegmentMap;
 import org.hestiastore.index.segmentindex.mapping.SegmentRouteSplit;
 import org.hestiastore.index.segmentregistry.BlockingSegment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of split scheduling and split-publish admission.
@@ -27,6 +29,8 @@ import org.hestiastore.index.segmentregistry.BlockingSegment;
 final class SplitExecutionCoordinatorImpl<K, V>
         implements SplitExecutionCoordinator<K, V> {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(SplitExecutionCoordinatorImpl.class);
     private static final long SPLIT_RESCHEDULE_COOLDOWN_MILLIS = 500L;
     private static final long SPLIT_RESCHEDULE_COOLDOWN_NANOS = TimeUnit.MILLISECONDS
             .toNanos(SPLIT_RESCHEDULE_COOLDOWN_MILLIS);
@@ -240,9 +244,11 @@ final class SplitExecutionCoordinatorImpl<K, V>
             final long splitThreshold, final long observedKeyCount,
             final long startNanos) {
         boolean splitApplied = false;
+        RuntimeException failure = null;
         try {
             splitApplied = tryApplyPreparedSplit(segmentId, splitThreshold);
         } catch (final RuntimeException e) {
+            failure = e;
             splitFailure.compareAndSet(null, e);
             failureReporter.reportFailure(e);
         } finally {
@@ -251,6 +257,13 @@ final class SplitExecutionCoordinatorImpl<K, V>
         }
         final long durationNanos = Math.max(0L,
                 nanoTimeSupplier.getAsLong() - startNanos);
+        if (failure == null) {
+            logSplitFinished(segmentId, splitThreshold, observedKeyCount,
+                    splitApplied, durationNanos);
+        } else {
+            logSplitFailed(segmentId, splitThreshold, observedKeyCount,
+                    durationNanos, failure);
+        }
         observeSplitDuration(durationNanos);
         if (splitApplied) {
             splitAttemptStates.remove(segmentId);
@@ -282,10 +295,12 @@ final class SplitExecutionCoordinatorImpl<K, V>
         final Optional<SegmentSplitLease<K, V>> splitLease =
                 segmentLeaseService.tryAcquireForSplit(segmentId);
         if (splitLease.isEmpty()) {
+            logSplitSkippedBecauseDrainUnavailable(segmentId, splitThreshold);
             return false;
         }
         try (SegmentSplitLease<K, V> lease = splitLease.get()) {
             if (isClosedCandidate(lease.segment())) {
+                logSplitAbortedBecauseSegmentClosed(segmentId);
                 return false;
             }
             final SegmentRouteSplit<K> routeSplit = prepareSplit(
@@ -385,6 +400,49 @@ final class SplitExecutionCoordinatorImpl<K, V>
             return Long.MAX_VALUE;
         }
         return value * multiplier;
+    }
+
+    private void logSplitSkippedBecauseDrainUnavailable(
+            final SegmentId segmentId, final long splitThreshold) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split skipped because route drain could not be acquired: segment='{}' threshold='{}'",
+                    segmentId, splitThreshold);
+        }
+    }
+
+    private void logSplitAbortedBecauseSegmentClosed(
+            final SegmentId segmentId) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split aborted because parent segment was already closed after route drain: segment='{}'",
+                    segmentId);
+        }
+    }
+
+    private void logSplitFinished(final SegmentId segmentId,
+            final long splitThreshold, final long observedKeyCount,
+            final boolean splitApplied, final long durationNanos) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Route split finished: segment='{}' threshold='{}' observedKeyCount='{}' outcome='{}' durationMillis='{}'",
+                    segmentId, splitThreshold, observedKeyCount,
+                    splitApplied ? "published" : "not-published",
+                    nanosToMillis(durationNanos));
+        }
+    }
+
+    private void logSplitFailed(final SegmentId segmentId,
+            final long splitThreshold, final long observedKeyCount,
+            final long durationNanos, final RuntimeException failure) {
+        LOGGER.warn(
+                "Route split failed: segment='{}' threshold='{}' observedKeyCount='{}' durationMillis='{}'",
+                segmentId, splitThreshold, observedKeyCount,
+                nanosToMillis(durationNanos), failure);
+    }
+
+    private static long nanosToMillis(final long nanos) {
+        return TimeUnit.NANOSECONDS.toMillis(Math.max(0L, nanos));
     }
 
     private void markSplitStarted() {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitCoordinatorTest.java
@@ -104,6 +104,50 @@ class RouteSplitCoordinatorTest {
         verifyNoInteractions(materializationService);
     }
 
+    @Test
+    void tryPrepareSplitReturnsNullWhenVisibleRecountFallsBelowThreshold() {
+        when(parentHandle.getRuntime()).thenReturn(parentRuntime);
+        when(parentHandle.getId()).thenReturn(PARENT_SEGMENT_ID);
+        when(parentRuntime.getNumberOfKeysInCache()).thenReturn(4L);
+        when(parentHandle.getSegment()).thenReturn(parentSegment);
+        when(parentSegment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(iteratorResult(List.of(Entry.of(1, "a"),
+                        Entry.of(2, "b"), Entry.of(3, "c"))));
+
+        final SegmentRouteSplit<Integer> prepared = coordinator
+                .tryPrepareSplit(parentHandle, 4L);
+
+        assertNull(prepared);
+        verifyNoInteractions(materializationService);
+    }
+
+    @Test
+    void tryPrepareSplitContinuesWhenRecountFallsBelowThresholdButChildMinimumIsSatisfied() {
+        when(parentHandle.getRuntime()).thenReturn(parentRuntime);
+        when(parentHandle.getId()).thenReturn(PARENT_SEGMENT_ID);
+        when(parentRuntime.getNumberOfKeysInCache()).thenReturn(10L);
+        when(parentHandle.getSegment()).thenReturn(parentSegment);
+        when(parentSegment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(iteratorResult(List.of(Entry.of(1, "a"),
+                        Entry.of(2, "b"), Entry.of(3, "c"),
+                        Entry.of(4, "d"), Entry.of(5, "e"),
+                        Entry.of(6, "f"))))
+                .thenReturn(iteratorResult(List.of(Entry.of(1, "a"),
+                        Entry.of(2, "b"), Entry.of(3, "c"),
+                        Entry.of(4, "d"), Entry.of(5, "e"),
+                        Entry.of(6, "f"))));
+        when(materializationService.materializeRouteSplit(
+                eq(parentSegment), eq(3L), any()))
+                .thenReturn(splitPlan);
+
+        final SegmentRouteSplit<Integer> prepared = coordinator
+                .tryPrepareSplit(parentHandle, 10L);
+
+        assertNotNull(prepared);
+        verify(materializationService).materializeRouteSplit(
+                eq(parentSegment), eq(3L), any());
+    }
+
     private static List<Entry<Integer, String>> entries() {
         return List.of(Entry.of(1, "a"), Entry.of(2, "b"), Entry.of(3, "c"),
                 Entry.of(4, "d"));

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/RouteSplitPreparationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -71,9 +72,46 @@ class RouteSplitPreparationServiceTest {
         assertNull(prepared);
     }
 
+    @Test
+    void prepareReturnsMaterializedSplitWhenRecountFallsBelowThresholdButChildMinimumIsSatisfied() {
+        final SegmentRouteSplit<Integer> routeSplit = new SegmentRouteSplit<>(
+                SegmentId.of(1), SegmentId.of(2), SegmentId.of(3), 3, null);
+        when(parentSegment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(iteratorResult(entries(6)))
+                .thenReturn(iteratorResult(entries(6)));
+        when(materializationService.materializeRouteSplit(eq(parentSegment),
+                eq(3L), any())).thenReturn(routeSplit);
+
+        final SegmentRouteSplit<Integer> prepared = preparationService.prepare(
+                parentSegment, 10L);
+
+        assertNotNull(prepared);
+        verify(parentSegment, times(2))
+                .openIterator(SegmentIteratorIsolation.FULL_ISOLATION);
+        verify(materializationService).materializeRouteSplit(eq(parentSegment),
+                eq(3L), any());
+    }
+
+    @Test
+    void prepareReturnsNullWhenRecountFallsBelowThresholdAndChildMinimumIsNotSatisfied() {
+        when(parentSegment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(iteratorResult(entries(5)));
+
+        final SegmentRouteSplit<Integer> prepared = preparationService.prepare(
+                parentSegment, 10L);
+
+        assertNull(prepared);
+        verifyNoInteractions(materializationService);
+    }
+
     private static List<Entry<Integer, String>> entries() {
+        return entries(4);
+    }
+
+    private static List<Entry<Integer, String>> entries(final int count) {
         return List.of(Entry.of(1, "a"), Entry.of(2, "b"), Entry.of(3, "c"),
-                Entry.of(4, "d"));
+                Entry.of(4, "d"), Entry.of(5, "e"), Entry.of(6, "f"))
+                .subList(0, count);
     }
 
     private static OperationResult<EntryIterator<Integer, String>> iteratorResult(


### PR DESCRIPTION
## Summary
- improve route split logging around drain unavailability, closed parents, failures, and execution timing
- refine split preparation recount handling so natural visible-count drift only aborts when a valid child minimum can no longer be maintained
- add tests covering below-threshold recount continuation and abort cases

## Notes
- this addresses the investigation behind #265 and #283 through clearer index logging and route split code-structure improvements, not only by changing a single terminal behavior
- some oversized-segment and post-close observations are natural concurrent outcomes; the new logging makes those paths explicit for diagnosis

## Testing
- mvn clean verify

Closes #265
Closes #283