### PR TITLE
Handle missing directory listing during cleanup

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/directory/AbstractDirectory.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/AbstractDirectory.java
@@ -56,7 +56,13 @@ public abstract class AbstractDirectory implements Directory {
 
     @Override
     public Stream<String> getFileNames() {
-        return Arrays.stream(directory.list());
+        final String[] fileNames = directory.list();
+        if (fileNames == null) {
+            throw new IndexException(String.format(
+                    "Unable to list directory '%s'.",
+                    directory.getAbsolutePath()));
+        }
+        return Arrays.stream(fileNames);
     }
 
     @Override

--- a/engine/src/main/java/org/hestiastore/index/directory/Directory.java
+++ b/engine/src/main/java/org/hestiastore/index/directory/Directory.java
@@ -65,6 +65,12 @@ public interface Directory {
 
     boolean deleteFile(String fileName);
 
+    /**
+     * Lists the names currently present in this directory.
+     *
+     * @return stream of entry names
+     * Throws IndexException when entries cannot be listed.
+     */
     Stream<String> getFileNames();
 
     void renameFile(String currentFileName, String newFileName);

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCompacter.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCompacter.java
@@ -214,6 +214,10 @@ final class SegmentCompacter<K, V> {
         try (Stream<String> files = directory.getFileNames()) {
             files.filter(name -> name.startsWith(deltaPrefix))
                     .forEach(name -> deleteFile(directory, name));
+        } catch (final RuntimeException e) {
+            logger.warn(
+                    "Failed to list delta-cache files during compaction cleanup: segment='{}' cleanupVersion='{}' deltaPrefix='{}' directory='{}'",
+                    layout.getSegmentId(), version, deltaPrefix, directory, e);
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/directory/FsDirectoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/directory/FsDirectoryTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.directory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,5 +65,16 @@ class FsDirectoryTest {
 
         assertThrows(IndexException.class,
                 () -> directory.openSubDirectory("sub"));
+    }
+
+    @Test
+    void test_getFileNames_missing_directory_throwsIndexException() {
+        assertTrue(tempDir.delete());
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> directory.getFileNames());
+
+        assertEquals(String.format("Unable to list directory '%s'.",
+                tempDir.getAbsolutePath()), exception.getMessage());
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentCompacterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentCompacterTest.java
@@ -1,13 +1,19 @@
 package org.hestiastore.index.segment;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+
+import org.hestiastore.index.directory.FsDirectory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,6 +29,9 @@ class SegmentCompacterTest {
 
     @Mock
     private SegmentFiles<Integer, String> files;
+
+    @TempDir
+    private File tempDir;
 
     private SegmentCompacter<Integer, String> sc;
 
@@ -63,5 +72,21 @@ class SegmentCompacterTest {
 
         verify(segment).switchActiveVersion(2L);
         verify(versionController).changeVersion();
+    }
+
+    @Test
+    void cleanupOldVersion_ignores_missing_directory_listing() {
+        final FsDirectory directory = new FsDirectory(tempDir);
+        when(segment.getId()).thenReturn(SegmentId.of(1));
+        when(files.getActiveVersion()).thenReturn(1L);
+        when(files.getDirectory()).thenReturn(directory);
+        when(segment.getSegmentFiles()).thenReturn(files);
+
+        final SegmentCompacter.CompactionPlan<Integer, String> plan = sc
+                .prepareCompactionPlan(segment);
+        final Runnable cleanup = sc.buildCleanupTask(plan);
+        assertTrue(tempDir.delete());
+
+        assertDoesNotThrow(cleanup::run);
     }
 }


### PR DESCRIPTION
## Summary
- Handle null results from `File.list()` in filesystem-backed directory listings with an `IndexException` that includes the directory path.
- Keep compaction old-version cleanup best-effort when delta-cache file listing fails, so maintenance workers do not die.
- Add regression coverage for the missing-directory listing and cleanup paths.

## Tests
- `mvn -pl engine -Dtest=FsDirectoryTest,SegmentCompacterTest test`
- `mvn clean verify`

Closes #285