### PR TITLE
Avoid runtime-state reload during maintenance waits

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -140,6 +140,17 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
         return loaded;
     }
 
+    private SegmentState loadCurrentState() {
+        final Segment<K, V> currentSegment = segment;
+        if (currentSegment != null) {
+            final SegmentState state = currentSegment.getState();
+            if (state != SegmentState.CLOSED) {
+                return state;
+            }
+        }
+        return loadSegment().getState();
+    }
+
     private <T> T runBlocking(final String operation,
             final Function<Segment<K, V>, OperationResult<T>> action) {
         final long startNanos = retryPolicy.startNanos();
@@ -184,7 +195,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
         @Override
         public SegmentState getState() {
-            return loadSegment().getState();
+            return loadCurrentState();
         }
 
         @Override

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
@@ -13,6 +13,7 @@ import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentRuntimeLimits;
+import org.hestiastore.index.segment.SegmentState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,6 +93,37 @@ class DefaultBlockingSegmentTest {
         handle.getRuntime().updateRuntimeLimits(runtimeLimits);
 
         verify(segment).applyRuntimeLimits(runtimeLimits);
+    }
+
+    @Test
+    void runtimeStateUsesCurrentSegmentWithoutReloading() {
+        when(segment.getState()).thenReturn(SegmentState.MAINTENANCE_RUNNING);
+        final BlockingSegment<Integer, String> segmentHandle =
+                new DefaultBlockingSegment<>(SEGMENT_ID, () -> {
+                    throw new AssertionError("Segment should not reload");
+                }, new BusyRetryPolicy(1, 25), segment);
+
+        assertEquals(SegmentState.MAINTENANCE_RUNNING,
+                segmentHandle.getRuntime().getState());
+    }
+
+    @Test
+    void runtimeStateReloadsAfterCurrentSegmentCloses() {
+        final Segment<Integer, String> reloadedSegment = mockSegment();
+        final BlockingSegment<Integer, String> reloadedHandle = mockBlockingSegment();
+        when(segment.getState()).thenReturn(SegmentState.CLOSED);
+        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(reloadedHandle);
+        when(reloadedHandle.getSegment()).thenReturn(reloadedSegment);
+        when(reloadedSegment.getState()).thenReturn(SegmentState.READY);
+        final BlockingSegment<Integer, String> segmentHandle =
+                new DefaultBlockingSegment<>(SEGMENT_ID,
+                        () -> segmentRegistry.loadSegment(SEGMENT_ID)
+                                .getSegment(),
+                        new BusyRetryPolicy(1, 25), segment);
+
+        assertEquals(SegmentState.READY,
+                segmentHandle.getRuntime().getState());
+        verify(segmentRegistry).loadSegment(SEGMENT_ID);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- avoid reloading a segment while polling runtime state for accepted maintenance work
- reload only after the current segment reports CLOSED
- add direct coverage for runtime state polling and closed-segment reload

Fixes #291

## Tests
- mvn -q -f engine/pom.xml -Dtest=DefaultBlockingSegmentTest test
- 20x mvn -q -f engine/pom.xml -Dit.test=SegmentIndexConcurrencyStressIT#test_concurrent_load_with_autonomous_split_and_rotations -Dfailsafe.failIfNoSpecifiedTests=false -DskipTests=false failsafe:integration-test failsafe:verify
- mvn clean verify