### PR TITLE
Add shared runtime thread pools

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -85,7 +85,20 @@
                             <extraJars>
                                 <extraJar>${project.parent.basedir}/engine/target/engine-${project.version}.jar</extraJar>
                             </extraJars>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/versions/9/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                                 <transformer
                                     implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexGetBenchmark.java
@@ -73,8 +73,9 @@ public class SegmentIndexGetBenchmark extends AbstractSegmentIndexGetBenchmark {
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
                 .chunkStoreCache(cache -> cache
                         .pageLimit(chunkStoreCachePageLimit))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
-                        .indexThreads(1).registryLifecycleThreads(1)
+                .maintenance(maintenance -> maintenance
+                        .indexThreads(1)//
+                        .registryLifecycleThreads(1)//
                         .backgroundAutoEnabled(false));
         SegmentIndexBenchmarkSupport.addIntegrityAndCompressionFilters(builder,
                 snappy);

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexHotRoutePutBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexHotRoutePutBenchmark.java
@@ -94,8 +94,9 @@ public class SegmentIndexHotRoutePutBenchmark {
                 .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(4096)
                         .hashFunctions(2).falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
-                        .indexThreads(2).registryLifecycleThreads(1)
+                .maintenance(maintenance -> maintenance
+                        .indexThreads(2)//
+                        .registryLifecycleThreads(1)
                         .backgroundAutoEnabled(false))//
                 .build();
     }

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexLifecycleBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexLifecycleBenchmark.java
@@ -133,7 +133,7 @@ public class SegmentIndexLifecycleBenchmark {
                         .hashFunctions(3)
                         .falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
+                .maintenance(maintenance -> maintenance
                         .indexThreads(1).registryLifecycleThreads(1)
                         .backgroundAutoEnabled(false));
         SegmentIndexBenchmarkSupport.addIntegrityAndCompressionFilters(builder,

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMixedDrainBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMixedDrainBenchmark.java
@@ -119,7 +119,7 @@ public class SegmentIndexMixedDrainBenchmark {
                 .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(4096)
                         .hashFunctions(2).falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
+                .maintenance(maintenance -> maintenance
                         .indexThreads(2).registryLifecycleThreads(1)
                         .backgroundAutoEnabled(true))//
                 .build();

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
@@ -67,7 +67,7 @@ public class SegmentIndexMultiSegmentGetBenchmark
                         .hashFunctions(3)
                         .falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
+                .maintenance(maintenance -> maintenance
                         .indexThreads(2).registryLifecycleThreads(1)
                         .backgroundAutoEnabled(true));
         SegmentIndexBenchmarkSupport.addIntegrityAndCompressionFilters(builder,

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmark.java
@@ -127,7 +127,7 @@ public class SegmentIndexPersistedMutationBenchmark {
                         .hashFunctions(3)
                         .falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(8 * 1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1)
+                .maintenance(maintenance -> maintenance
                         .indexThreads(1).registryLifecycleThreads(1)
                         .backgroundAutoEnabled(false));
         SegmentIndexBenchmarkSupport.addIntegrityAndCompressionFilters(builder,

--- a/docs/architecture/concurrency.md
+++ b/docs/architecture/concurrency.md
@@ -63,9 +63,14 @@ These structures are shared across threads and require synchronization:
 ## Threads
 
 - Sync operations run on caller threads.
-- Segment maintenance runs on the segment maintenance executor.
-- Split planning runs on one dedicated split-planner thread.
-- Split materialization runs on the shared split-maintenance executor pool.
+- Segment maintenance runs on the shared `hestia-segment-maintenance-*`
+  executor.
+- Split planning runs on the index-owned
+  `hestia-<indexName>-split-policy-*` scheduler.
+- Split materialization runs on the shared `hestia-split-maintenance-*`
+  executor.
+- WAL group sync runs on `hestia-<indexName>-wal-group-sync-*` when GROUP_SYNC
+  durability is enabled with a positive delay.
 
 ## Implications
 

--- a/docs/architecture/segmentindex/segment-index-concurrency.md
+++ b/docs/architecture/segmentindex/segment-index-concurrency.md
@@ -27,8 +27,8 @@
 - Index operations are not globally serialized; concurrency is bounded by
   mapping updates, route-topology leases, and per-segment state machines.
 - Segment maintenance IO runs on the segment maintenance executor.
-- The maintenance executor is always created by SegmentRegistry from
-  `IndexConfiguration.maintenance().segmentThreads()` (default 10).
+- The segment maintenance executor is supplied by `HestiaStoreRuntime`
+  (default 10 workers).
 - Automatic post-write flush/compact is optional and enabled by default.
 - Segment BUSY is treated as transient and retried internally; callers do not
   see BUSY.
@@ -73,6 +73,7 @@
   the directory level.
 
 ## Maintenance & Splits
+
 - SegmentIndex evaluates split thresholds after successful writes and schedules
   follow-up maintenance only when `backgroundMaintenanceAutoEnabled` is true.
 - Successful writes and maintenance follow-ups emit split-service hints or
@@ -195,10 +196,19 @@ Notes:
 - Runtime route version: RouteTopology.version, reconciled from
   SegmentRouteMap snapshots.
 - Maintenance executor: SegmentRegistry.getMaintenanceExecutor() backed by
-  `IndexConfiguration.maintenance().segmentThreads()` (default 10).
-- Index maintenance pool: `index-maintenance-*` from ExecutorRegistry.
-- Split policy scheduler: `split-policy-*` from ExecutorRegistry.
-- Split worker pool: `split-maintenance-*` from ExecutorRegistry.
+  the `HestiaStoreRuntime` segment-maintenance pool.
+- Index maintenance pool: `hestia-<indexName>-index-maintenance-*` from
+  ExecutorRegistry.
+- Split policy scheduler: `hestia-<indexName>-split-policy-*` from
+  ExecutorRegistry.
+- Registry maintenance pool: `hestia-<indexName>-registry-maintenance-*` from
+  ExecutorRegistry.
+- WAL group-sync scheduler: `hestia-<indexName>-wal-group-sync-*` when
+  GROUP_SYNC WAL durability is enabled with a positive delay.
+- Shared segment maintenance pool: `hestia-segment-maintenance-*` from
+  HestiaStoreRuntime.
+- Shared split worker pool: `hestia-split-maintenance-*` from
+  HestiaStoreRuntime.
 - Split isolation: SegmentIteratorIsolation.FULL_ISOLATION.
 - Retry policy: `IndexConfiguration.maintenance().busyBackoffMillis()` and
   `IndexConfiguration.maintenance().busyTimeoutMillis()`.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -49,7 +49,6 @@ IndexConfiguration<Integer, Integer> conf = IndexConfiguration
         .indexSizeBytes(1024)
         .hashFunctions(1))
     .maintenance(maintenance -> maintenance
-        .segmentThreads(10)
         .indexThreads(10)
         .registryLifecycleThreads(3)
         .backgroundAutoEnabled(true)
@@ -67,6 +66,16 @@ IndexConfiguration<Integer, Integer> conf = IndexConfiguration
         .corruptionPolicy(WalCorruptionPolicy.TRUNCATE_INVALID_TAIL))
     .logging(logging -> logging
         .contextEnabled(false))
+    .build();
+```
+
+Shared runtime executor pools are configured on `HestiaStoreRuntime`, not in
+the persisted index configuration:
+
+```java
+HestiaStoreRuntime runtime = HestiaStoreRuntime.builder()
+    .segmentMaintenanceThreads(10)
+    .splitMaintenanceThreads(10)
     .build();
 ```
 
@@ -130,13 +139,13 @@ become eligible for split maintenance.
 
 ### Maintenance and busy-state waiting
 
-Maintenance settings control background workers and retry behavior used when an
-operation waits for an internal index state to become available.
+Maintenance settings control index-local workers and retry behavior used when
+an operation waits for an internal index state to become available. Shared
+segment-maintenance and split-maintenance workers are configured on
+`HestiaStoreRuntime`.
 
 - `maintenance(...).backgroundAutoEnabled()` enables automatic background
   maintenance scheduling.
-- `maintenance(...).segmentThreads()` sets the segment maintenance thread
-  count.
 - `maintenance(...).indexThreads()` sets the index maintenance thread count.
 - `maintenance(...).registryLifecycleThreads()` sets the registry lifecycle
   thread count.
@@ -232,7 +241,6 @@ the implementation supports runtime-safe reopening.
 | `writePath().maintenanceWriteCacheKeyLimit()` | Per-segment maintenance backlog limit | Yes |
 | `writePath().indexBufferedWriteKeyLimit()` | Index-wide buffered-write budget | No on open; use runtime tuning where supported |
 | `writePath().segmentSplitKeyThreshold()` | Routed segment split eligibility threshold | No on open |
-| `maintenance().segmentThreads()` | Segment maintenance thread count | Yes |
 | `maintenance().indexThreads()` | Index maintenance thread count | Yes |
 | `maintenance().registryLifecycleThreads()` | Registry lifecycle thread count | Yes |
 | `maintenance().busyBackoffMillis()` | Delay between checks while waiting for a busy internal state | Yes |
@@ -271,7 +279,6 @@ Some names preserve older partition terminology for compatibility.
 | `maxNumberOfKeysInSegment` | `segment().maxKeys()` |
 | `segmentSplitKeyThreshold` | `writePath().segmentSplitKeyThreshold()` |
 | `maxNumberOfSegmentsInCache` | `segment().cachedSegmentLimit()` |
-| `numberOfSegmentMaintenanceThreads` | `maintenance().segmentThreads()` |
 | `numberOfIndexMaintenanceThreads` | `maintenance().indexThreads()` |
 | `numberOfRegistryLifecycleThreads` | `maintenance().registryLifecycleThreads()` |
 | `indexBusyBackoffMillis` | `maintenance().busyBackoffMillis()` |

--- a/engine/src/integration-test/java/org/hestiastore/index/it/HestiaStoreRuntimeIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/HestiaStoreRuntimeIT.java
@@ -1,0 +1,66 @@
+package org.hestiastore.index.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segmentindex.HestiaStoreRuntime;
+import org.hestiastore.index.segmentindex.SegmentIndex;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.junit.jupiter.api.Test;
+
+class HestiaStoreRuntimeIT {
+
+    @Test
+    void sharedRuntimeKeepsBothIndexesDurableAfterClose() {
+        final Directory firstDirectory = new MemDirectory();
+        final Directory secondDirectory = new MemDirectory();
+
+        try (HestiaStoreRuntime runtime = HestiaStoreRuntime.builder()
+                .segmentMaintenanceThreads(1)
+                .splitMaintenanceThreads(1)
+                .build()) {
+            try (SegmentIndex<Integer, String> firstIndex = SegmentIndex
+                    .create(firstDirectory, configuration("shared-runtime-a"),
+                            runtime);
+                    SegmentIndex<Integer, String> secondIndex = SegmentIndex
+                            .create(secondDirectory,
+                                    configuration("shared-runtime-b"),
+                                    runtime)) {
+                firstIndex.put(1, "first-one");
+                firstIndex.put(2, "first-two");
+                secondIndex.put(1, "second-one");
+                secondIndex.put(3, "second-three");
+            }
+        }
+
+        try (SegmentIndex<Integer, String> firstIndex = SegmentIndex
+                .open(firstDirectory);
+                SegmentIndex<Integer, String> secondIndex = SegmentIndex
+                        .open(secondDirectory)) {
+            assertEquals("first-one", firstIndex.get(1));
+            assertEquals("first-two", firstIndex.get(2));
+            assertEquals("second-one", secondIndex.get(1));
+            assertEquals("second-three", secondIndex.get(3));
+        }
+    }
+
+    private static IndexConfiguration<Integer, String> configuration(
+            final String indexName) {
+        return IndexConfiguration.<Integer, String>builder()
+                .identity(identity -> identity.keyClass(Integer.class))
+                .identity(identity -> identity.valueClass(String.class))
+                .identity(identity -> identity
+                        .keyTypeDescriptor(new TypeDescriptorInteger()))
+                .identity(identity -> identity
+                        .valueTypeDescriptor(new TypeDescriptorShortString()))
+                .identity(identity -> identity.name(indexName))
+                .logging(logging -> logging.contextEnabled(false))
+                .maintenance(maintenance -> maintenance.indexThreads(1))
+                .maintenance(maintenance -> maintenance
+                        .registryLifecycleThreads(1))
+                .build();
+    }
+}

--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrencySerializationIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrencySerializationIT.java
@@ -139,10 +139,7 @@ class SegmentIndexConcurrencySerializationIT {
                                 .falsePositiveProbability()))//
                 .io(io -> io.diskBufferSizeBytes(
                         defaults.io().diskBufferSizeBytes()))//
-                .maintenance(maintenance -> maintenance
-                        .segmentThreads(
-                                defaults.maintenance().segmentThreads())
-                        .busyBackoffMillis(
+                .maintenance(maintenance -> maintenance.busyBackoffMillis(
                                 defaults.maintenance().busyBackoffMillis())
                         .busyTimeoutMillis(
                                 defaults.maintenance().busyTimeoutMillis())

--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
@@ -881,7 +881,7 @@ class SegmentIndexConcurrentIT {
                         .valueTypeDescriptor(new TypeDescriptorInteger())
                         .name(name))//
                 .maintenance(maintenance -> maintenance
-                        .backgroundAutoEnabled(true).segmentThreads(2)
+                        .backgroundAutoEnabled(true)
                         .indexThreads(2).registryLifecycleThreads(2)
                         .busyTimeoutMillis(120_000))//
                 .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(512)

--- a/engine/src/main/java/org/hestiastore/index/properties/IndexPropertiesSchema.java
+++ b/engine/src/main/java/org/hestiastore/index/properties/IndexPropertiesSchema.java
@@ -75,7 +75,6 @@ public final class IndexPropertiesSchema {
         public static final String PROP_MAX_NUMBER_OF_KEYS_IN_SEGMENT = "maxNumberOfKeysInSegment";
         public static final String PROP_SEGMENT_SPLIT_KEY_THRESHOLD = "segmentSplitKeyThreshold";
         public static final String PROP_MAX_NUMBER_OF_SEGMENTS_IN_CACHE = "maxNumberOfSegmentsInCache";
-        public static final String PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS = "numberOfSegmentMaintenanceThreads";
         public static final String PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS = "numberOfIndexMaintenanceThreads";
         public static final String PROP_NUMBER_OF_REGISTRY_LIFECYCLE_THREADS = "numberOfRegistryLifecycleThreads";
         public static final String PROP_INDEX_BUSY_BACKOFF_MILLIS = "indexBusyBackoffMillis";
@@ -384,10 +383,6 @@ public final class IndexPropertiesSchema {
 
     private static void addThreadingDefaults(
             final Map<String, DefaultValueProvider> defaults) {
-        defaults.put(
-                IndexConfigurationKeys.PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS,
-                view -> String.valueOf(
-                        IndexConfigurationDefaults.DEFAULT_SEGMENT_MAINTENANCE_THREADS));
         defaults.put(
                 IndexConfigurationKeys.PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS,
                 view -> String.valueOf(

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntime.java
@@ -1,0 +1,70 @@
+package org.hestiastore.index.segmentindex;
+
+import org.hestiastore.index.AbstractCloseableResource;
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
+import org.hestiastore.index.segmentindex.core.executorregistry.RuntimeExecutorPools;
+
+/**
+ * Process-level runtime resources that can be shared by multiple segment
+ * indexes.
+ * <p>
+ * Callers that pass a runtime to a segment index remain responsible for closing
+ * the runtime after all indexes using it have been closed.
+ * </p>
+ */
+public final class HestiaStoreRuntime extends AbstractCloseableResource {
+
+    private final String threadNamePrefix;
+    private final RuntimeExecutorPools executorPools;
+
+    HestiaStoreRuntime(final String threadNamePrefix,
+            final RuntimeExecutorPools executorPools) {
+        this.threadNamePrefix = Vldtn.requireNotBlank(threadNamePrefix,
+                "threadNamePrefix");
+        this.executorPools = Vldtn.requireNonNull(executorPools,
+                "executorPools");
+    }
+
+    /**
+     * Creates a new runtime builder.
+     *
+     * @return runtime builder
+     */
+    public static HestiaStoreRuntimeBuilder builder() {
+        return new HestiaStoreRuntimeBuilder();
+    }
+
+    ExecutorRegistry createExecutorRegistry(
+            final String indexName,
+            final boolean contextLoggingEnabled,
+            final int indexMaintenanceThreads,
+            final int registryMaintenanceThreads,
+            final int shutdownTimeoutMillis) {
+        ensureOpen();
+        return ExecutorRegistry.create(indexName, contextLoggingEnabled,
+                indexMaintenanceThreads, executorPools,
+                registryMaintenanceThreads, shutdownTimeoutMillis);
+    }
+
+    /**
+     * Returns the runtime-wide thread-name prefix.
+     *
+     * @return thread-name prefix
+     */
+    String threadNamePrefix() {
+        ensureOpen();
+        return threadNamePrefix;
+    }
+
+    private void ensureOpen() {
+        if (wasClosed()) {
+            throw new IllegalStateException("HestiaStoreRuntime already closed");
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        executorPools.close();
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeAccess.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeAccess.java
@@ -1,0 +1,57 @@
+package org.hestiastore.index.segmentindex;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
+import org.hestiastore.index.segmentindex.core.session.SegmentIndexRuntimeHandle;
+
+final class HestiaStoreRuntimeAccess {
+
+    private HestiaStoreRuntimeAccess() {
+    }
+
+    static SegmentIndexRuntimeHandle owned() {
+        return new RuntimeHandle(HestiaStoreRuntime.builder().build(), true);
+    }
+
+    static SegmentIndexRuntimeHandle borrowed(
+            final HestiaStoreRuntime runtime) {
+        return new RuntimeHandle(
+                Vldtn.requireNonNull(runtime, "runtime"), false);
+    }
+
+    private static final class RuntimeHandle
+            implements SegmentIndexRuntimeHandle {
+
+        private final HestiaStoreRuntime runtime;
+        private final boolean closeRuntime;
+
+        private RuntimeHandle(final HestiaStoreRuntime runtime,
+                final boolean closeRuntime) {
+            this.runtime = Vldtn.requireNonNull(runtime, "runtime");
+            this.closeRuntime = closeRuntime;
+        }
+
+        @Override
+        public ExecutorRegistry createExecutorRegistry(final String indexName,
+                final boolean contextLoggingEnabled,
+                final int indexMaintenanceThreads,
+                final int registryMaintenanceThreads,
+                final int shutdownTimeoutMillis) {
+            return runtime.createExecutorRegistry(indexName,
+                    contextLoggingEnabled, indexMaintenanceThreads,
+                    registryMaintenanceThreads, shutdownTimeoutMillis);
+        }
+
+        @Override
+        public String threadNamePrefix() {
+            return runtime.threadNamePrefix();
+        }
+
+        @Override
+        public void close() {
+            if (closeRuntime) {
+                runtime.close();
+            }
+        }
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeBuilder.java
@@ -1,0 +1,81 @@
+package org.hestiastore.index.segmentindex;
+
+import org.hestiastore.index.segmentindex.core.executorregistry.RuntimeExecutorPools;
+
+/**
+ * Fluent builder for {@link HestiaStoreRuntime} instances.
+ */
+public final class HestiaStoreRuntimeBuilder {
+
+    private static final String DEFAULT_THREAD_NAME_PREFIX = "hestia";
+    private static final int DEFAULT_SEGMENT_MAINTENANCE_THREADS = 10;
+    private static final int DEFAULT_SPLIT_MAINTENANCE_THREADS = 10;
+    private static final int DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = 30_000;
+
+    private String threadNamePrefix = DEFAULT_THREAD_NAME_PREFIX;
+    private int segmentMaintenanceThreads =
+            DEFAULT_SEGMENT_MAINTENANCE_THREADS;
+    private int splitMaintenanceThreads = DEFAULT_SPLIT_MAINTENANCE_THREADS;
+    private int shutdownTimeoutMillis = DEFAULT_SHUTDOWN_TIMEOUT_MILLIS;
+
+    HestiaStoreRuntimeBuilder() {
+    }
+
+    /**
+     * Sets the prefix used for runtime-owned thread names.
+     *
+     * @param value thread name prefix
+     * @return this builder
+     */
+    public HestiaStoreRuntimeBuilder threadNamePrefix(final String value) {
+        this.threadNamePrefix = value;
+        return this;
+    }
+
+    /**
+     * Sets the shared segment-maintenance worker count.
+     *
+     * @param value segment-maintenance worker count
+     * @return this builder
+     */
+    public HestiaStoreRuntimeBuilder segmentMaintenanceThreads(
+            final int value) {
+        this.segmentMaintenanceThreads = value;
+        return this;
+    }
+
+    /**
+     * Sets the shared split-maintenance worker count.
+     *
+     * @param value split-maintenance worker count
+     * @return this builder
+     */
+    public HestiaStoreRuntimeBuilder splitMaintenanceThreads(final int value) {
+        this.splitMaintenanceThreads = value;
+        return this;
+    }
+
+    /**
+     * Sets the runtime executor shutdown timeout in milliseconds.
+     *
+     * @param value shutdown timeout in milliseconds
+     * @return this builder
+     */
+    public HestiaStoreRuntimeBuilder shutdownTimeoutMillis(final int value) {
+        this.shutdownTimeoutMillis = value;
+        return this;
+    }
+
+    /**
+     * Builds a runtime with the collected settings.
+     *
+     * @return built runtime
+     */
+    public HestiaStoreRuntime build() {
+        return new HestiaStoreRuntime(threadNamePrefix,
+                RuntimeExecutorPools.create(threadNamePrefix,
+                        segmentMaintenanceThreads,
+                        splitMaintenanceThreads,
+                        shutdownTimeoutMillis));
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
@@ -13,6 +13,7 @@ import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
 import org.hestiastore.index.segmentindex.core.session.SegmentIndexBootstrapOperation;
+import org.hestiastore.index.segmentindex.core.session.SegmentIndexRuntimeHandle;
 
 /**
  * High-level contract for the segment-index layer that sits above individual
@@ -41,6 +42,25 @@ public interface SegmentIndex<K, V> extends CloseableResource {
     static <M, N> SegmentIndex<M, N> create(final Directory directory,
             final IndexConfiguration<M, N> indexConf) {
         return operation(directory, indexConf, null).create();
+    }
+
+    /**
+     * Creates a brand new index using caller-owned runtime resources.
+     * <p>
+     * The returned index does not own the supplied runtime. The caller remains
+     * responsible for closing the runtime after all indexes using it have been
+     * closed.
+     * </p>
+     *
+     * @param directory backing directory for the index
+     * @param indexConf requested configuration overrides
+     * @param runtime caller-owned shared runtime
+     * @return a newly created index instance
+     */
+    static <M, N> SegmentIndex<M, N> create(final Directory directory,
+            final IndexConfiguration<M, N> indexConf,
+            final HestiaStoreRuntime runtime) {
+        return operation(directory, indexConf, null, runtime).create();
     }
 
     /**
@@ -81,6 +101,25 @@ public interface SegmentIndex<K, V> extends CloseableResource {
     }
 
     /**
+     * Opens an existing index using caller-owned runtime resources.
+     * <p>
+     * The returned index does not own the supplied runtime. The caller remains
+     * responsible for closing the runtime after all indexes using it have been
+     * closed.
+     * </p>
+     *
+     * @param directory backing directory that already contains the index
+     * @param indexConf configuration overrides to apply
+     * @param runtime caller-owned shared runtime
+     * @return index instance backed by the updated configuration
+     */
+    static <M, N> SegmentIndex<M, N> open(final Directory directory,
+            final IndexConfiguration<M, N> indexConf,
+            final HestiaStoreRuntime runtime) {
+        return operation(directory, indexConf, null, runtime).open();
+    }
+
+    /**
      * Opens an existing index with an explicit chunk filter provider resolver.
      *
      * @param <M>                         key type
@@ -113,6 +152,20 @@ public interface SegmentIndex<K, V> extends CloseableResource {
     static <M, N> SegmentIndex<M, N> open(final Directory directory) {
         return SegmentIndex.<M, N>operation(directory, emptyConfiguration(),
                 null).open();
+    }
+
+    /**
+     * Opens an existing index using stored configuration and caller-owned
+     * runtime resources.
+     *
+     * @param directory backing directory with an existing index
+     * @param runtime caller-owned shared runtime
+     * @return index instance backed by the persisted configuration
+     */
+    static <M, N> SegmentIndex<M, N> open(final Directory directory,
+            final HestiaStoreRuntime runtime) {
+        return SegmentIndex.<M, N>operation(directory, emptyConfiguration(),
+                null, runtime).open();
     }
 
     /**
@@ -151,6 +204,20 @@ public interface SegmentIndex<K, V> extends CloseableResource {
     }
 
     /**
+     * Attempts to open an index using caller-owned runtime resources.
+     *
+     * @param directory backing directory that may contain an index
+     * @param runtime caller-owned shared runtime
+     * @return optional index instance if the configuration was found
+     */
+    static <M, N> Optional<SegmentIndex<M, N>> tryOpen(
+            final Directory directory,
+            final HestiaStoreRuntime runtime) {
+        return SegmentIndex.<M, N>operation(directory, emptyConfiguration(),
+                null, runtime).tryOpen();
+    }
+
+    /**
      * Attempts to open an index using an explicit chunk filter provider
      * resolver.
      *
@@ -174,11 +241,38 @@ public interface SegmentIndex<K, V> extends CloseableResource {
             final Directory directory,
             final IndexConfiguration<M, N> userProvidedConfiguration,
             final ChunkFilterProviderResolver chunkFilterProviderResolver) {
+        return operation(
+                Vldtn.requireNonNull(directory, "directory"),
+                Vldtn.requireNonNull(userProvidedConfiguration,
+                        "userProvidedConfiguration"),
+                chunkFilterProviderResolver,
+                HestiaStoreRuntimeAccess.owned());
+    }
+
+    private static <M, N> SegmentIndexBootstrapOperation<M, N> operation(
+            final Directory directory,
+            final IndexConfiguration<M, N> userProvidedConfiguration,
+            final ChunkFilterProviderResolver chunkFilterProviderResolver,
+            final HestiaStoreRuntime runtime) {
+        return operation(
+                Vldtn.requireNonNull(directory, "directory"),
+                Vldtn.requireNonNull(userProvidedConfiguration,
+                        "userProvidedConfiguration"),
+                chunkFilterProviderResolver,
+                HestiaStoreRuntimeAccess.borrowed(runtime));
+    }
+
+    private static <M, N> SegmentIndexBootstrapOperation<M, N> operation(
+            final Directory directory,
+            final IndexConfiguration<M, N> userProvidedConfiguration,
+            final ChunkFilterProviderResolver chunkFilterProviderResolver,
+            final SegmentIndexRuntimeHandle runtimeHandle) {
         return new SegmentIndexBootstrapOperation<>(
                 Vldtn.requireNonNull(directory, "directory"),
                 Vldtn.requireNonNull(userProvidedConfiguration,
                         "userProvidedConfiguration"),
-                chunkFilterProviderResolver);
+                chunkFilterProviderResolver,
+                Vldtn.requireNonNull(runtimeHandle, "runtimeHandle"));
     }
 
     private static ChunkFilterProviderResolver requireChunkFilterProviderResolver(

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationDefaults.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationDefaults.java
@@ -22,7 +22,6 @@ public interface IndexConfigurationDefaults {
     double DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_PROBABILITY = 0.01;
 
     int DEFAULT_DISK_IO_BUFFER_SIZE_BYTES = 1024 * 8;
-    int DEFAULT_SEGMENT_MAINTENANCE_THREADS = 10;
     int DEFAULT_INDEX_MAINTENANCE_THREADS = 10;
     int DEFAULT_REGISTRY_LIFECYCLE_THREADS = 3;
     int DEFAULT_INDEX_BUSY_BACKOFF_MILLIS = 5;
@@ -112,7 +111,6 @@ public interface IndexConfigurationDefaults {
      */
     default IndexMaintenanceConfiguration maintenance() {
         return new IndexMaintenanceConfiguration(
-                DEFAULT_SEGMENT_MAINTENANCE_THREADS,
                 DEFAULT_INDEX_MAINTENANCE_THREADS,
                 DEFAULT_REGISTRY_LIFECYCLE_THREADS,
                 DEFAULT_INDEX_BUSY_BACKOFF_MILLIS,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexMaintenanceConfiguration.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexMaintenanceConfiguration.java
@@ -5,29 +5,22 @@ package org.hestiastore.index.segmentindex.configuration.api;
  */
 public final class IndexMaintenanceConfiguration {
 
-    private final Integer segmentThreads;
     private final Integer indexThreads;
     private final Integer registryLifecycleThreads;
     private final Integer busyBackoffMillis;
     private final Integer busyTimeoutMillis;
     private final Boolean backgroundAutoEnabled;
 
-    public IndexMaintenanceConfiguration(final Integer segmentThreads,
-            final Integer indexThreads,
+    public IndexMaintenanceConfiguration(final Integer indexThreads,
             final Integer registryLifecycleThreads,
             final Integer busyBackoffMillis,
             final Integer busyTimeoutMillis,
             final Boolean backgroundAutoEnabled) {
-        this.segmentThreads = segmentThreads;
         this.indexThreads = indexThreads;
         this.registryLifecycleThreads = registryLifecycleThreads;
         this.busyBackoffMillis = busyBackoffMillis;
         this.busyTimeoutMillis = busyTimeoutMillis;
         this.backgroundAutoEnabled = backgroundAutoEnabled;
-    }
-
-    public Integer segmentThreads() {
-        return segmentThreads;
     }
 
     public Integer indexThreads() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexMaintenanceConfigurationBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/api/IndexMaintenanceConfigurationBuilder.java
@@ -8,7 +8,6 @@ package org.hestiastore.index.segmentindex.configuration.api;
  */
 public final class IndexMaintenanceConfigurationBuilder<K, V> {
 
-    private Integer segmentThreads;
     private Integer indexThreads;
     private Integer registryLifecycleThreads;
     private Integer busyBackoffMillis;
@@ -16,18 +15,6 @@ public final class IndexMaintenanceConfigurationBuilder<K, V> {
     private Boolean backgroundAutoEnabled;
 
     IndexMaintenanceConfigurationBuilder() {
-    }
-
-    /**
-     * Sets segment maintenance thread count.
-     *
-     * @param value segment maintenance threads
-     * @return this section builder
-     */
-    public IndexMaintenanceConfigurationBuilder<K, V> segmentThreads(
-            final Integer value) {
-        this.segmentThreads = value;
-        return this;
     }
 
     /**
@@ -91,7 +78,7 @@ public final class IndexMaintenanceConfigurationBuilder<K, V> {
     }
 
     IndexMaintenanceConfiguration build() {
-        return new IndexMaintenanceConfiguration(segmentThreads, indexThreads,
+        return new IndexMaintenanceConfiguration(indexThreads,
                 registryLifecycleThreads, busyBackoffMillis, busyTimeoutMillis,
                 backgroundAutoEnabled);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexConfigurationResolver.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexConfigurationResolver.java
@@ -187,8 +187,6 @@ public final class EffectiveIndexConfigurationResolver {
         final IndexMaintenanceConfiguration defaultMaintenance =
                 defaults.maintenance();
         return new EffectiveIndexMaintenanceConfiguration(
-                intOr(maintenance.segmentThreads(),
-                        defaultMaintenance.segmentThreads()),
                 intOr(maintenance.indexThreads(),
                         defaultMaintenance.indexThreads()),
                 intOr(maintenance.registryLifecycleThreads(),
@@ -267,8 +265,6 @@ public final class EffectiveIndexConfigurationResolver {
             final EffectiveIndexConfiguration<K, V> stored,
             final IndexConfiguration<K, V> request) {
         return new EffectiveIndexMaintenanceConfiguration(
-                intOr(request.maintenance().segmentThreads(),
-                        stored.maintenance().segmentThreads()),
                 intOr(request.maintenance().indexThreads(),
                         stored.maintenance().indexThreads()),
                 intOr(request.maintenance().registryLifecycleThreads(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexMaintenanceConfiguration.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexMaintenanceConfiguration.java
@@ -7,19 +7,16 @@ import org.hestiastore.index.Vldtn;
  */
 public final class EffectiveIndexMaintenanceConfiguration {
 
-    private final int segmentThreads;
     private final int indexThreads;
     private final int registryLifecycleThreads;
     private final int busyBackoffMillis;
     private final int busyTimeoutMillis;
     private final boolean backgroundAutoEnabled;
 
-    public EffectiveIndexMaintenanceConfiguration(final int segmentThreads,
-            final int indexThreads, final int registryLifecycleThreads,
+    public EffectiveIndexMaintenanceConfiguration(final int indexThreads,
+            final int registryLifecycleThreads,
             final int busyBackoffMillis, final int busyTimeoutMillis,
             final boolean backgroundAutoEnabled) {
-        this.segmentThreads = Vldtn.requireGreaterThanZero(segmentThreads,
-                "segmentThreads");
         this.indexThreads = Vldtn.requireGreaterThanZero(indexThreads,
                 "indexThreads");
         this.registryLifecycleThreads = Vldtn.requireGreaterThanZero(
@@ -29,10 +26,6 @@ public final class EffectiveIndexMaintenanceConfiguration {
         this.busyTimeoutMillis = Vldtn.requireGreaterThanZero(
                 busyTimeoutMillis, "busyTimeoutMillis");
         this.backgroundAutoEnabled = backgroundAutoEnabled;
-    }
-
-    public int segmentThreads() {
-        return segmentThreads;
     }
 
     public int indexThreads() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationManager.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationManager.java
@@ -100,7 +100,6 @@ public class IndexConfigurationManager<K, V> {
                 configuration.bloomFilter().hashFunctions(),
                 configuration.bloomFilter().indexSizeBytes(),
                 configuration.bloomFilter().falsePositiveProbability(),
-                configuration.maintenance().segmentThreads(),
                 configuration.maintenance().indexThreads(),
                 configuration.maintenance().registryLifecycleThreads(),
                 configuration.maintenance().busyBackoffMillis(),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationStore.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationStore.java
@@ -55,7 +55,6 @@ public class IndexConfigurationStore<K, V> {
     private static final String PROP_MAX_NUMBER_OF_KEYS_IN_SEGMENT = IndexPropertiesSchema.IndexConfigurationKeys.PROP_MAX_NUMBER_OF_KEYS_IN_SEGMENT;
     private static final String PROP_SEGMENT_SPLIT_KEY_THRESHOLD = IndexPropertiesSchema.IndexConfigurationKeys.PROP_SEGMENT_SPLIT_KEY_THRESHOLD;
     private static final String PROP_MAX_NUMBER_OF_SEGMENTS_IN_CACHE = IndexPropertiesSchema.IndexConfigurationKeys.PROP_MAX_NUMBER_OF_SEGMENTS_IN_CACHE;
-    private static final String PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS = IndexPropertiesSchema.IndexConfigurationKeys.PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS;
     private static final String PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS = IndexPropertiesSchema.IndexConfigurationKeys.PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS;
     private static final String PROP_NUMBER_OF_REGISTRY_LIFECYCLE_THREADS = IndexPropertiesSchema.IndexConfigurationKeys.PROP_NUMBER_OF_REGISTRY_LIFECYCLE_THREADS;
     private static final String PROP_INDEX_BUSY_BACKOFF_MILLIS = IndexPropertiesSchema.IndexConfigurationKeys.PROP_INDEX_BUSY_BACKOFF_MILLIS;
@@ -183,9 +182,6 @@ public class IndexConfigurationStore<K, V> {
                         falsePositiveProbability),
                 new EffectiveIndexMaintenanceConfiguration(
                         getOrDefault(propsView,
-                                PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS,
-                                IndexConfigurationDefaults.DEFAULT_SEGMENT_MAINTENANCE_THREADS),
-                        getOrDefault(propsView,
                                 PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS,
                                 IndexConfigurationDefaults.DEFAULT_INDEX_MAINTENANCE_THREADS),
                         getOrDefault(propsView,
@@ -260,9 +256,6 @@ public class IndexConfigurationStore<K, V> {
                 segment.chunkKeyLimit());
         writer.setInt(PROP_MAX_NUMBER_OF_DELTA_CACHE_FILES,
                 segment.deltaCacheFileLimit());
-        final int maintenanceThreads = maintenance.segmentThreads();
-        writer.setInt(PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS,
-                maintenanceThreads);
         final int indexMaintenanceThreads = maintenance.indexThreads();
         writer.setInt(PROP_NUMBER_OF_INDEX_MAINTENANCE_THREADS,
                 indexMaintenanceThreads);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningState.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningState.java
@@ -12,17 +12,18 @@ import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndex
  * Holds runtime-tunable index settings and exposes immutable snapshots.
  */
 public final class RuntimeTuningState {
-
     private final String indexName;
     private final EnumMap<RuntimeTuningKey, RuntimeTuningValue> baseline;
     private final EnumMap<RuntimeTuningKey, RuntimeTuningValue> overrides =
             new EnumMap<>(RuntimeTuningKey.class);
     private final AtomicLong revision = new AtomicLong(0L);
+    private volatile Map<RuntimeTuningKey, RuntimeTuningValue> effective;
 
     private RuntimeTuningState(final String indexName,
             final EnumMap<RuntimeTuningKey, RuntimeTuningValue> baseline) {
         this.indexName = Vldtn.requireNonNull(indexName, "indexName");
         this.baseline = Vldtn.requireNonNull(baseline, "baseline");
+        this.effective = effectiveFromOverrides(overrides);
     }
 
     public static <K, V> RuntimeTuningState fromConfiguration(
@@ -59,8 +60,8 @@ public final class RuntimeTuningState {
     }
 
     synchronized RuntimeTuningSnapshot snapshotCurrent() {
-        return RuntimeTuningSnapshot.fromValues(indexName,
-                effectiveFromOverrides(overrides), revision.get(), Instant.now());
+        return RuntimeTuningSnapshot.fromValues(indexName, effective,
+                revision.get(), Instant.now());
     }
 
     synchronized RuntimeTuningSnapshot snapshotOriginal() {
@@ -70,10 +71,18 @@ public final class RuntimeTuningState {
 
     synchronized RuntimeTuningSnapshot apply(
             final Map<RuntimeTuningKey, RuntimeTuningValue> patchValues) {
-        overrides.putAll(patchValues);
+        final EnumMap<RuntimeTuningKey, RuntimeTuningValue> nextOverrides =
+                new EnumMap<>(RuntimeTuningKey.class);
+        nextOverrides.putAll(overrides);
+        nextOverrides.putAll(patchValues);
+        final EnumMap<RuntimeTuningKey, RuntimeTuningValue> nextEffective =
+                effectiveFromOverrides(nextOverrides);
         final long nextRevision = revision.incrementAndGet();
-        return RuntimeTuningSnapshot.fromValues(indexName,
-                effectiveFromOverrides(overrides), nextRevision, Instant.now());
+        overrides.clear();
+        overrides.putAll(nextOverrides);
+        effective = nextEffective;
+        return RuntimeTuningSnapshot.fromValues(indexName, nextEffective,
+                nextRevision, Instant.now());
     }
 
     synchronized Map<RuntimeTuningKey, RuntimeTuningValue> previewEffective(
@@ -91,51 +100,82 @@ public final class RuntimeTuningState {
                 previewEffective(patchValues), revision.get(), Instant.now());
     }
 
-    synchronized RuntimeTuningValue effectiveValue(final RuntimeTuningKey key) {
-        final RuntimeTuningValue override = overrides.get(key);
-        if (override != null) {
-            return override;
-        }
-        return baseline.get(key);
+    RuntimeTuningValue effectiveValue(final RuntimeTuningKey key) {
+        return effective.get(key);
     }
 
-    public synchronized int cachedSegmentLimit() {
+    /**
+     * Returns the effective maximum number of cached segments.
+     *
+     * @return effective cached segment limit
+     */
+    public int cachedSegmentLimit() {
         return effectiveValue(RuntimeTuningKey.MAX_NUMBER_OF_SEGMENTS_IN_CACHE)
                 .asInt();
     }
 
-    public synchronized int cacheKeyLimit() {
+    /**
+     * Returns the effective segment cache key limit.
+     *
+     * @return effective segment cache key limit
+     */
+    public int cacheKeyLimit() {
         return effectiveValue(
                 RuntimeTuningKey.MAX_NUMBER_OF_KEYS_IN_SEGMENT_CACHE).asInt();
     }
 
-    public synchronized int segmentWriteCacheKeyLimit() {
+    /**
+     * Returns the effective active segment write cache key limit.
+     *
+     * @return effective active segment write cache key limit
+     */
+    public int segmentWriteCacheKeyLimit() {
         return effectiveValue(RuntimeTuningKey.SEGMENT_WRITE_CACHE_KEY_LIMIT)
                 .asInt();
     }
 
-    public synchronized int segmentWriteCacheKeyLimitDuringMaintenance() {
+    /**
+     * Returns the effective maintenance segment write cache key limit.
+     *
+     * @return effective maintenance segment write cache key limit
+     */
+    public int segmentWriteCacheKeyLimitDuringMaintenance() {
         return effectiveValue(
                 RuntimeTuningKey.SEGMENT_WRITE_CACHE_KEY_LIMIT_DURING_MAINTENANCE)
-                        .asInt();
+                .asInt();
     }
 
-    public synchronized int indexBufferedWriteKeyLimit() {
+    /**
+     * Returns the effective index buffered write key limit.
+     *
+     * @return effective index buffered write key limit
+     */
+    public int indexBufferedWriteKeyLimit() {
         return effectiveValue(RuntimeTuningKey.INDEX_BUFFERED_WRITE_KEY_LIMIT)
                 .asInt();
     }
 
-    public synchronized int segmentSplitKeyThreshold() {
+    /**
+     * Returns the effective segment split key threshold.
+     *
+     * @return effective segment split key threshold
+     */
+    public int segmentSplitKeyThreshold() {
         return effectiveValue(RuntimeTuningKey.SEGMENT_SPLIT_KEY_THRESHOLD)
                 .asInt();
     }
 
-    public synchronized int chunkStoreCachePageLimit() {
+    /**
+     * Returns the effective chunk store cache page limit.
+     *
+     * @return effective chunk store cache page limit
+     */
+    public int chunkStoreCachePageLimit() {
         return effectiveValue(RuntimeTuningKey.CHUNK_STORE_CACHE_PAGE_LIMIT)
                 .asInt();
     }
 
-    synchronized long revision() {
+    long revision() {
         return revision.get();
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistry.java
@@ -15,16 +15,12 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
 
     private static final String MESSAGE_ALREADY_CLOSED = "ExecutorRegistry already closed";
     private static final String ARG_INDEX_MAINTENANCE_THREADS = "indexMaintenanceThreads";
-    private static final String ARG_SPLIT_MAINTENANCE_THREADS = "splitMaintenanceThreads";
-    private static final String ARG_SEGMENT_MAINTENANCE_THREADS = "numberOfSegmentMaintenanceThreads";
     private static final String ARG_REGISTRY_MAINTENANCE_THREADS = "registryMaintenanceThreads";
     private static final String ARG_SHUTDOWN_TIMEOUT_MILLIS = "shutdownTimeoutMillis";
     private static final String ARG_INDEX_NAME = "indexName";
-    private static final String THREAD_NAME_PREFIX_INDEX_MAINTENANCE = "index-maintenance-";
-    private static final String THREAD_NAME_PREFIX_SPLIT_MAINTENANCE = "split-maintenance-";
-    private static final String THREAD_NAME_PREFIX_SPLIT_POLICY = "split-policy-";
-    private static final String THREAD_NAME_PREFIX_SEGMENT_MAINTENANCE = "segment-maintenance-";
-    private static final String THREAD_NAME_PREFIX_REGISTRY_MAINTENANCE = "registry-maintenance-";
+    private static final String POOL_NAME_INDEX_MAINTENANCE = "index-maintenance";
+    private static final String POOL_NAME_SPLIT_POLICY = "split-policy";
+    private static final String POOL_NAME_REGISTRY_MAINTENANCE = "registry-maintenance";
 
     private final ExecutorTopology topology;
     private final ExecutorRuntimeMonitor runtimeMonitor;
@@ -39,11 +35,11 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
     /**
      * Creates an executor registry for one index runtime.
      *
-     * @param indexName index name used for logging context
+     * @param indexName index name used for logging context and index-owned thread
+     *        names
      * @param contextLoggingEnabled true when MDC context wrapping is enabled
      * @param indexMaintenanceThreads index-maintenance worker count
-     * @param splitMaintenanceThreads split-maintenance worker count
-     * @param segmentMaintenanceThreads segment-maintenance worker count
+     * @param runtimeExecutorPools runtime-owned shared executor pools
      * @param registryMaintenanceThreads registry-maintenance worker count
      * @param shutdownTimeoutMillis executor shutdown timeout
      * @return executor registry
@@ -52,8 +48,7 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
             final String indexName,
             final boolean contextLoggingEnabled,
             final int indexMaintenanceThreads,
-            final int splitMaintenanceThreads,
-            final int segmentMaintenanceThreads,
+            final RuntimeExecutorPools runtimeExecutorPools,
             final int registryMaintenanceThreads,
             final int shutdownTimeoutMillis) {
         final ObservedThreadPoolFactory threadPoolFactory =
@@ -61,28 +56,41 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
         final ExecutorContextDecorator contextDecorator =
                 new ExecutorContextDecorator(contextLoggingEnabled,
                         contextIndexName(indexName, contextLoggingEnabled));
+        final RuntimeExecutorPools validatedRuntimeExecutorPools = Vldtn
+                .requireNonNull(runtimeExecutorPools, "runtimeExecutorPools");
+        final String validatedIndexName = Vldtn.requireNotBlank(indexName,
+                ARG_INDEX_NAME);
+        final String threadNamePrefix =
+                validatedRuntimeExecutorPools.threadNamePrefix();
         final ObservedThreadPool indexMaintenanceThreadPool =
                 createIndexMaintenanceThreadPool(threadPoolFactory,
-                        indexMaintenanceThreads);
+                        indexMaintenanceThreads,
+                        poolThreadNamePrefix(threadNamePrefix,
+                                validatedIndexName,
+                                POOL_NAME_INDEX_MAINTENANCE));
         final ObservedThreadPool splitMaintenanceThreadPool =
-                createSplitMaintenanceThreadPool(threadPoolFactory,
-                        splitMaintenanceThreads);
+                validatedRuntimeExecutorPools.splitMaintenanceThreadPool();
         final ObservedThreadPool stableSegmentMaintenanceThreadPool =
-                createStableSegmentMaintenanceThreadPool(threadPoolFactory,
-                        segmentMaintenanceThreads);
+                validatedRuntimeExecutorPools.segmentMaintenanceThreadPool();
         return new ExecutorRegistry(
                 new ExecutorTopology(
                         contextAwareObservedExecutor(contextDecorator,
                                 indexMaintenanceThreadPool),
                         contextAwareObservedExecutor(contextDecorator,
                                 splitMaintenanceThreadPool),
-                        createSplitPolicyScheduler(threadPoolFactory),
+                        createSplitPolicyScheduler(threadPoolFactory,
+                                poolThreadNamePrefix(threadNamePrefix,
+                                        validatedIndexName,
+                                        POOL_NAME_SPLIT_POLICY)),
                         contextAwareObservedExecutor(contextDecorator,
                                 stableSegmentMaintenanceThreadPool),
                         contextDecorator.decorate(
                                 createRegistryMaintenanceExecutor(
                                         threadPoolFactory,
-                                        registryMaintenanceThreads)),
+                                        registryMaintenanceThreads,
+                                        poolThreadNamePrefix(threadNamePrefix,
+                                                validatedIndexName,
+                                                POOL_NAME_REGISTRY_MAINTENANCE))),
                         Vldtn.requireGreaterThanZero(shutdownTimeoutMillis,
                                 ARG_SHUTDOWN_TIMEOUT_MILLIS)),
                 new ExecutorRuntimeMonitor(indexMaintenanceThreadPool,
@@ -178,26 +186,11 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
 
     private static ObservedThreadPool createIndexMaintenanceThreadPool(
             final ObservedThreadPoolFactory threadPoolFactory,
-            final int threadCount) {
+            final int threadCount,
+            final String threadNamePrefix) {
         return threadPoolFactory.createAbortingPool(threadCount,
                 ARG_INDEX_MAINTENANCE_THREADS,
-                THREAD_NAME_PREFIX_INDEX_MAINTENANCE);
-    }
-
-    private static ObservedThreadPool createStableSegmentMaintenanceThreadPool(
-            final ObservedThreadPoolFactory threadPoolFactory,
-            final int threadCount) {
-        return threadPoolFactory.createCallerRunsPool(threadCount,
-                ARG_SEGMENT_MAINTENANCE_THREADS,
-                THREAD_NAME_PREFIX_SEGMENT_MAINTENANCE);
-    }
-
-    private static ObservedThreadPool createSplitMaintenanceThreadPool(
-            final ObservedThreadPoolFactory threadPoolFactory,
-            final int threadCount) {
-        return threadPoolFactory.createAbortingPool(threadCount,
-                ARG_SPLIT_MAINTENANCE_THREADS,
-                THREAD_NAME_PREFIX_SPLIT_MAINTENANCE);
+                threadNamePrefix);
     }
 
     private static ExecutorService contextAwareObservedExecutor(
@@ -208,25 +201,30 @@ public final class ExecutorRegistry extends AbstractCloseableResource {
 
     private static ExecutorService createRegistryMaintenanceExecutor(
             final ObservedThreadPoolFactory threadPoolFactory,
-            final int registryMaintenanceThreadCount) {
+            final int registryMaintenanceThreadCount,
+            final String threadNamePrefix) {
         return Executors.newFixedThreadPool(
                 ObservedThreadPoolFactory.configuredThreadCount(
                         registryMaintenanceThreadCount,
                         ARG_REGISTRY_MAINTENANCE_THREADS),
-                threadPoolFactory.daemonThreadFactory(
-                        THREAD_NAME_PREFIX_REGISTRY_MAINTENANCE));
+                threadPoolFactory.daemonThreadFactory(threadNamePrefix));
     }
 
     private static ScheduledExecutorService createSplitPolicyScheduler(
-            final ObservedThreadPoolFactory threadPoolFactory) {
+            final ObservedThreadPoolFactory threadPoolFactory,
+            final String threadNamePrefix) {
         final ScheduledThreadPoolExecutor executor =
                 new ScheduledThreadPoolExecutor(1,
-                        threadPoolFactory.daemonThreadFactory(
-                                THREAD_NAME_PREFIX_SPLIT_POLICY));
+                        threadPoolFactory.daemonThreadFactory(threadNamePrefix));
         executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
         executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         executor.setRemoveOnCancelPolicy(true);
         return executor;
+    }
+
+    private static String poolThreadNamePrefix(final String prefix,
+            final String indexName, final String poolName) {
+        return prefix + "-" + indexName + "-" + poolName + "-";
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorShutdown.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorShutdown.java
@@ -1,0 +1,67 @@
+package org.hestiastore.index.segmentindex.core.executorregistry;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.index.IndexException;
+
+/**
+ * Shared shutdown helper for executor owners that aggregate close failures.
+ */
+final class ExecutorShutdown {
+
+    private ExecutorShutdown() {
+    }
+
+    /**
+     * Shuts down one executor and appends timeout/interruption failures to the
+     * current failure chain.
+     *
+     * @param executorName executor name used in diagnostics
+     * @param executor executor service to close
+     * @param shutdownTimeoutMillis await timeout in milliseconds
+     * @param failure current failure, or {@code null}
+     * @return current or appended failure
+     */
+    static RuntimeException shutdownAndAwait(final String executorName,
+            final ExecutorService executor,
+            final int shutdownTimeoutMillis,
+            final RuntimeException failure) {
+        RuntimeException nextFailure = failure;
+        executor.shutdown();
+        boolean interrupted = false;
+        try {
+            if (!executor.awaitTermination(shutdownTimeoutMillis,
+                    TimeUnit.MILLISECONDS)) {
+                executor.shutdownNow();
+                nextFailure = appendFailure(nextFailure, new IndexException(
+                        String.format(
+                                "Executor '%s' did not terminate within %d ms.",
+                                executorName, shutdownTimeoutMillis)));
+            }
+        } catch (final InterruptedException e) {
+            interrupted = true;
+            executor.shutdownNow();
+            nextFailure = appendFailure(nextFailure, new IndexException(
+                    String.format("Executor '%s' shutdown was interrupted.",
+                            executorName),
+                    e));
+        } catch (final RuntimeException e) {
+            nextFailure = appendFailure(nextFailure, e);
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return nextFailure;
+    }
+
+    private static RuntimeException appendFailure(final RuntimeException failure,
+            final RuntimeException nextFailure) {
+        if (failure == null) {
+            return nextFailure;
+        }
+        failure.addSuppressed(nextFailure);
+        return failure;
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopology.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopology.java
@@ -2,9 +2,7 @@ package org.hestiastore.index.segmentindex.core.executorregistry;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
-import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 
 /**
@@ -62,57 +60,12 @@ final class ExecutorTopology {
 
     RuntimeException shutdownExecutorsInCloseOrder() {
         RuntimeException failure = null;
-        failure = shutdownAndAwait("indexMaintenance",
-                indexMaintenanceExecutor, failure);
-        failure = shutdownAndAwait("splitMaintenance",
-                splitMaintenanceExecutor, failure);
-        failure = shutdownAndAwait("splitPolicy",
-                splitPolicyScheduler, failure);
-        failure = shutdownAndAwait("segmentMaintenance",
-                stableSegmentMaintenanceExecutor, failure);
-        failure = shutdownAndAwait("registryMaintenance",
-                registryMaintenanceExecutor, failure);
-        return failure;
-    }
-
-    private RuntimeException shutdownAndAwait(final String executorName,
-            final ExecutorService executor,
-            final RuntimeException failure) {
-        RuntimeException nextFailure = failure;
-        executor.shutdown();
-        boolean interrupted = false;
-        try {
-            if (!executor.awaitTermination(shutdownTimeoutMillis,
-                    TimeUnit.MILLISECONDS)) {
-                executor.shutdownNow();
-                nextFailure = appendFailure(nextFailure, new IndexException(
-                        String.format(
-                                "Executor '%s' did not terminate within %d ms.",
-                                executorName, shutdownTimeoutMillis)));
-            }
-        } catch (final InterruptedException e) {
-            interrupted = true;
-            executor.shutdownNow();
-            nextFailure = appendFailure(nextFailure, new IndexException(
-                    String.format("Executor '%s' shutdown was interrupted.",
-                            executorName),
-                    e));
-        } catch (final RuntimeException e) {
-            nextFailure = appendFailure(nextFailure, e);
-        } finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
-        return nextFailure;
-    }
-
-    private RuntimeException appendFailure(final RuntimeException failure,
-            final RuntimeException nextFailure) {
-        if (failure == null) {
-            return nextFailure;
-        }
-        failure.addSuppressed(nextFailure);
+        failure = ExecutorShutdown.shutdownAndAwait("indexMaintenance",
+                indexMaintenanceExecutor, shutdownTimeoutMillis, failure);
+        failure = ExecutorShutdown.shutdownAndAwait("splitPolicy",
+                splitPolicyScheduler, shutdownTimeoutMillis, failure);
+        failure = ExecutorShutdown.shutdownAndAwait("registryMaintenance",
+                registryMaintenanceExecutor, shutdownTimeoutMillis, failure);
         return failure;
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/RuntimeExecutorPools.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/RuntimeExecutorPools.java
@@ -1,0 +1,111 @@
+package org.hestiastore.index.segmentindex.core.executorregistry;
+
+import org.hestiastore.index.AbstractCloseableResource;
+import org.hestiastore.index.Vldtn;
+
+/**
+ * Owns process-level executor pools shared by one or more segment indexes.
+ */
+public final class RuntimeExecutorPools extends AbstractCloseableResource {
+
+    private static final String ARG_THREAD_NAME_PREFIX = "threadNamePrefix";
+    private static final String ARG_SEGMENT_MAINTENANCE_THREADS = "segmentMaintenanceThreads";
+    private static final String ARG_SPLIT_MAINTENANCE_THREADS = "splitMaintenanceThreads";
+    private static final String ARG_SHUTDOWN_TIMEOUT_MILLIS = "shutdownTimeoutMillis";
+    private static final String POOL_NAME_SEGMENT_MAINTENANCE = "segment-maintenance";
+    private static final String POOL_NAME_SPLIT_MAINTENANCE = "split-maintenance";
+
+    private final String threadNamePrefix;
+    private final ObservedThreadPool segmentMaintenanceThreadPool;
+    private final ObservedThreadPool splitMaintenanceThreadPool;
+    private final int shutdownTimeoutMillis;
+
+    RuntimeExecutorPools(
+            final String threadNamePrefix,
+            final ObservedThreadPool segmentMaintenanceThreadPool,
+            final ObservedThreadPool splitMaintenanceThreadPool,
+            final int shutdownTimeoutMillis) {
+        this.threadNamePrefix = Vldtn.requireNotBlank(threadNamePrefix,
+                ARG_THREAD_NAME_PREFIX);
+        this.segmentMaintenanceThreadPool = Vldtn.requireNonNull(
+                segmentMaintenanceThreadPool, "segmentMaintenanceThreadPool");
+        this.splitMaintenanceThreadPool = Vldtn.requireNonNull(
+                splitMaintenanceThreadPool, "splitMaintenanceThreadPool");
+        this.shutdownTimeoutMillis = Vldtn.requireGreaterThanZero(
+                shutdownTimeoutMillis, ARG_SHUTDOWN_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Creates shared runtime executor pools.
+     *
+     * @param threadNamePrefix common thread-name prefix
+     * @param segmentMaintenanceThreads segment-maintenance worker count
+     * @param splitMaintenanceThreads split-maintenance worker count
+     * @param shutdownTimeoutMillis shutdown timeout in milliseconds
+     * @return shared runtime executor pools
+     */
+    public static RuntimeExecutorPools create(
+            final String threadNamePrefix,
+            final int segmentMaintenanceThreads,
+            final int splitMaintenanceThreads,
+            final int shutdownTimeoutMillis) {
+        final String validatedThreadNamePrefix = Vldtn.requireNotBlank(
+                threadNamePrefix, ARG_THREAD_NAME_PREFIX);
+        final ObservedThreadPoolFactory threadPoolFactory =
+                new ObservedThreadPoolFactory();
+        return new RuntimeExecutorPools(
+                validatedThreadNamePrefix,
+                threadPoolFactory.createCallerRunsPool(
+                        segmentMaintenanceThreads,
+                        ARG_SEGMENT_MAINTENANCE_THREADS,
+                        poolThreadNamePrefix(validatedThreadNamePrefix,
+                                POOL_NAME_SEGMENT_MAINTENANCE)),
+                threadPoolFactory.createAbortingPool(splitMaintenanceThreads,
+                        ARG_SPLIT_MAINTENANCE_THREADS,
+                        poolThreadNamePrefix(validatedThreadNamePrefix,
+                                POOL_NAME_SPLIT_MAINTENANCE)),
+                shutdownTimeoutMillis);
+    }
+
+    String threadNamePrefix() {
+        return threadNamePrefix;
+    }
+
+    ObservedThreadPool segmentMaintenanceThreadPool() {
+        ensureOpen();
+        return segmentMaintenanceThreadPool;
+    }
+
+    ObservedThreadPool splitMaintenanceThreadPool() {
+        ensureOpen();
+        return splitMaintenanceThreadPool;
+    }
+
+    private void ensureOpen() {
+        if (wasClosed()) {
+            throw new IllegalStateException(
+                    "RuntimeExecutorPools already closed");
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        RuntimeException failure = null;
+        failure = ExecutorShutdown.shutdownAndAwait(
+                POOL_NAME_SPLIT_MAINTENANCE,
+                splitMaintenanceThreadPool.executor(), shutdownTimeoutMillis,
+                failure);
+        failure = ExecutorShutdown.shutdownAndAwait(
+                POOL_NAME_SEGMENT_MAINTENANCE,
+                segmentMaintenanceThreadPool.executor(), shutdownTimeoutMillis,
+                failure);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static String poolThreadNamePrefix(final String prefix,
+            final String poolName) {
+        return prefix + "-" + poolName + "-";
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
@@ -63,6 +63,7 @@ public final class SegmentIndexBootstrapOperation<K, V> {
     private final Directory directory;
     private final IndexConfiguration<K, V> userProvidedConfiguration;
     private final ChunkFilterProviderResolver chunkFilterProviderResolver;
+    private final SegmentIndexRuntimeHandle runtimeHandle;
 
     /**
      * Creates one bootstrap operation for a segment index.
@@ -71,14 +72,18 @@ public final class SegmentIndexBootstrapOperation<K, V> {
      * @param userProvidedConfiguration user configuration overrides
      * @param chunkFilterProviderResolver optional chunk filter provider
      *        resolver
+     * @param runtimeHandle runtime ownership handle
      */
     public SegmentIndexBootstrapOperation(final Directory directory,
             final IndexConfiguration<K, V> userProvidedConfiguration,
-            final ChunkFilterProviderResolver chunkFilterProviderResolver) {
+            final ChunkFilterProviderResolver chunkFilterProviderResolver,
+            final SegmentIndexRuntimeHandle runtimeHandle) {
         this.directory = Vldtn.requireNonNull(directory, "directory");
         this.userProvidedConfiguration = Vldtn.requireNonNull(
                 userProvidedConfiguration, "userProvidedConfiguration");
         this.chunkFilterProviderResolver = chunkFilterProviderResolver;
+        this.runtimeHandle = Vldtn.requireNonNull(runtimeHandle,
+                "runtimeHandle");
     }
 
     /**
@@ -122,6 +127,7 @@ public final class SegmentIndexBootstrapOperation<K, V> {
         try {
             if (!checkExistingConfiguration(mode,
                     configurationStorage.exists())) {
+                runtimeHandle.close();
                 return Optional.empty();
             }
             sessionResources.acquireDirectoryLock(directory);
@@ -206,12 +212,10 @@ public final class SegmentIndexBootstrapOperation<K, V> {
     private void createExecutorRegistry(
             final BootstrapState<K, V> state) {
         final EffectiveIndexConfiguration<K, V> configuration = state.getConfiguration();
-        state.setExecutorRegistry(ExecutorRegistry.create(
+        state.setExecutorRegistry(runtimeHandle.createExecutorRegistry(
                 configuration.identity().name(),
                 configuration.logging().contextEnabled(),
                 configuration.maintenance().indexThreads(),
-                configuration.maintenance().indexThreads(),
-                configuration.maintenance().segmentThreads(),
                 configuration.maintenance().registryLifecycleThreads(),
                 configuration.maintenance().busyTimeoutMillis()));
     }
@@ -318,7 +322,9 @@ public final class SegmentIndexBootstrapOperation<K, V> {
         }
         state.setRuntimeWalRuntime(WalRuntime.open(directory, wal,
                 state.getKeyTypeDescriptor(),
-                state.getValueTypeDescriptor()));
+                state.getValueTypeDescriptor(),
+                runtimeHandle.threadNamePrefix(),
+                state.getConfiguration().identity().name()));
     }
 
     private void createMaintenance(
@@ -415,6 +421,7 @@ public final class SegmentIndexBootstrapOperation<K, V> {
             final BootstrapState<K, V> state,
             final SegmentIndexRuntimeResources<K, V> sessionResources) {
         sessionResources.setExecutorRegistry(state.getExecutorRegistry());
+        sessionResources.setRuntimeHandle(runtimeHandle);
         state.markRuntimeCloseOwnershipTransferred();
     }
 
@@ -471,7 +478,18 @@ public final class SegmentIndexBootstrapOperation<K, V> {
             currentFailure = closeSegmentRegistry(state, currentFailure);
             currentFailure = closeKeyToSegmentMap(state, currentFailure);
         }
-        return closeExecutorRegistry(state, currentFailure);
+        currentFailure = closeExecutorRegistry(state, currentFailure);
+        return closeRuntimeHandle(currentFailure);
+    }
+
+    private RuntimeException closeRuntimeHandle(
+            final RuntimeException failure) {
+        try {
+            runtimeHandle.close();
+            return failure;
+        } catch (final RuntimeException cleanupFailure) {
+            return appendCleanupFailure(failure, cleanupFailure);
+        }
     }
 
     private RuntimeException closeTransferredRuntime(

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeHandle.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeHandle.java
@@ -1,0 +1,39 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
+
+/**
+ * Internal bridge between public runtime ownership and segment-index bootstrap.
+ */
+public interface SegmentIndexRuntimeHandle {
+
+    /**
+     * Creates the executor registry used by one index instance.
+     *
+     * @param indexName index name used for logging context and index-owned thread
+     *        names
+     * @param contextLoggingEnabled true when MDC context wrapping is enabled
+     * @param indexMaintenanceThreads index-maintenance worker count
+     * @param registryMaintenanceThreads registry-maintenance worker count
+     * @param shutdownTimeoutMillis executor shutdown timeout
+     * @return executor registry for one index instance
+     */
+    ExecutorRegistry createExecutorRegistry(
+            String indexName,
+            boolean contextLoggingEnabled,
+            int indexMaintenanceThreads,
+            int registryMaintenanceThreads,
+            int shutdownTimeoutMillis);
+
+    /**
+     * Returns the runtime-wide thread-name prefix.
+     *
+     * @return thread-name prefix
+     */
+    String threadNamePrefix();
+
+    /**
+     * Releases the runtime when it is owned by the index.
+     */
+    void close();
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeResources.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeResources.java
@@ -33,6 +33,7 @@ public final class SegmentIndexRuntimeResources<K, V>
 
     private IndexDirectoryLock directoryLock;
     private ExecutorRegistry executorRegistry;
+    private SegmentIndexRuntimeHandle runtimeHandle;
 
     public void acquireDirectoryLock(final Directory directory) {
         directoryLock = new IndexDirectoryLock(directory);
@@ -54,6 +55,16 @@ public final class SegmentIndexRuntimeResources<K, V>
     public void setExecutorRegistry(final ExecutorRegistry executorRegistry) {
         this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
                 "executorRegistry");
+    }
+
+    /**
+     * Installs the runtime ownership handle used by the close flow.
+     *
+     * @param runtimeHandle runtime ownership handle
+     */
+    public void setRuntimeHandle(final SegmentIndexRuntimeHandle runtimeHandle) {
+        this.runtimeHandle = Vldtn.requireNonNull(runtimeHandle,
+                "runtimeHandle");
     }
 
     /**
@@ -90,6 +101,10 @@ public final class SegmentIndexRuntimeResources<K, V>
 
     ExecutorRegistry executorRegistry() {
         return Vldtn.requireNonNull(executorRegistry, "executorRegistry");
+    }
+
+    SegmentIndexRuntimeHandle runtimeHandle() {
+        return Vldtn.requireNonNull(runtimeHandle, "runtimeHandle");
     }
 
     public SplitStatsRecorder splitStatsRecorder() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssembler.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssembler.java
@@ -105,6 +105,7 @@ public final class SegmentIndexSessionAssembler {
                 coreStorageRuntime,
                 coreStorageRuntime.getStorageService(),
                 resources.executorRegistry(),
+                resources.runtimeHandle(),
                 resources.directoryLock());
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SessionCloseCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SessionCloseCoordinator.java
@@ -30,6 +30,7 @@ final class SessionCloseCoordinator<K, V> {
     private final OpenedStorageRuntime<K, V> coreStorageRuntime;
     private final StorageCoordinator<K, V> storageService;
     private final ExecutorRegistry executorRegistry;
+    private final SegmentIndexRuntimeHandle runtimeHandle;
     private final IndexDirectoryLock directoryLock;
 
     SessionCloseCoordinator(final String indexName,
@@ -41,6 +42,7 @@ final class SessionCloseCoordinator<K, V> {
             final OpenedStorageRuntime<K, V> coreStorageRuntime,
             final StorageCoordinator<K, V> storageService,
             final ExecutorRegistry executorRegistry,
+            final SegmentIndexRuntimeHandle runtimeHandle,
             final IndexDirectoryLock directoryLock) {
         this.indexName = Vldtn.requireNonNull(indexName, "indexName");
         this.stateMachine = Vldtn.requireNonNull(stateMachine,
@@ -58,6 +60,8 @@ final class SessionCloseCoordinator<K, V> {
                 "storageService");
         this.executorRegistry = Vldtn.requireNonNull(executorRegistry,
                 "executorRegistry");
+        this.runtimeHandle = Vldtn.requireNonNull(runtimeHandle,
+                "runtimeHandle");
         this.directoryLock = Vldtn.requireNonNull(directoryLock,
                 "directoryLock");
     }
@@ -113,6 +117,11 @@ final class SessionCloseCoordinator<K, V> {
         }
         try {
             executorRegistry.close();
+        } catch (final RuntimeException failure) {
+            firstFailure = recordFailure(firstFailure, failure);
+        }
+        try {
+            runtimeHandle.close();
         } catch (final RuntimeException failure) {
             firstFailure = recordFailure(firstFailure, failure);
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRuntime.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/wal/WalRuntime.java
@@ -37,6 +37,12 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
      */
     public static final String WAL_DIRECTORY = WalMetadataCatalog.WAL_DIRECTORY;
 
+    private static final String DEFAULT_THREAD_NAME_PREFIX = "hestia";
+    private static final String DEFAULT_INDEX_NAME = "standalone";
+    private static final String POOL_NAME_WAL_GROUP_SYNC = "wal-group-sync";
+    private static final String ARG_THREAD_NAME_PREFIX = "threadNamePrefix";
+    private static final String ARG_INDEX_NAME = "indexName";
+
     /**
      * WAL operation kind.
      */
@@ -216,6 +222,11 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
 
     /**
      * Creates WAL runtime for the given index directory.
+     * <p>
+     * Direct WAL runtimes use the {@code hestia-standalone-wal-group-sync-*}
+     * thread-name scope. Segment indexes should use the overload that accepts the
+     * runtime thread-name prefix and index name.
+     * </p>
      *
      * @param <K>             key type
      * @param <V>             value type
@@ -229,13 +240,57 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
             final IndexWalConfiguration wal,
             final TypeDescriptor<K> keyDescriptor,
             final TypeDescriptor<V> valueDescriptor) {
+        return openWithGroupSyncThreadNamePrefix(indexDirectory, wal,
+                keyDescriptor, valueDescriptor,
+                poolThreadNamePrefix(DEFAULT_THREAD_NAME_PREFIX,
+                        DEFAULT_INDEX_NAME,
+                        POOL_NAME_WAL_GROUP_SYNC));
+    }
+
+    /**
+     * Creates WAL runtime for the given index directory and index-owned thread
+     * name scope.
+     *
+     * @param <K>              key type
+     * @param <V>              value type
+     * @param indexDirectory   index directory
+     * @param wal              WAL config
+     * @param keyDescriptor    key descriptor
+     * @param valueDescriptor  value descriptor
+     * @param threadNamePrefix runtime-wide thread-name prefix
+     * @param indexName        index name used in index-owned thread names
+     * @return runtime instance
+     */
+    public static <K, V> WalRuntime<K, V> open(final Directory indexDirectory,
+            final IndexWalConfiguration wal,
+            final TypeDescriptor<K> keyDescriptor,
+            final TypeDescriptor<V> valueDescriptor,
+            final String threadNamePrefix,
+            final String indexName) {
+        return openWithGroupSyncThreadNamePrefix(indexDirectory, wal,
+                keyDescriptor, valueDescriptor,
+                poolThreadNamePrefix(
+                        Vldtn.requireNotBlank(threadNamePrefix,
+                                ARG_THREAD_NAME_PREFIX),
+                        Vldtn.requireNotBlank(indexName, ARG_INDEX_NAME),
+                        POOL_NAME_WAL_GROUP_SYNC));
+    }
+
+    private static <K, V> WalRuntime<K, V> openWithGroupSyncThreadNamePrefix(
+            final Directory indexDirectory,
+            final IndexWalConfiguration wal,
+            final TypeDescriptor<K> keyDescriptor,
+            final TypeDescriptor<V> valueDescriptor,
+            final String groupSyncThreadNamePrefix) {
         final Directory directory = Vldtn.requireNonNull(indexDirectory,
                 "indexDirectory");
         final IndexWalConfiguration resolvedWal = requireEnabledWal(wal);
         final Directory walDirectory = directory.openSubDirectory(WAL_DIRECTORY);
         final WalRuntime<K, V> runtime = createRuntime(resolvedWal,
                 WalStorageFactory.create(walDirectory), keyDescriptor,
-                valueDescriptor);
+                valueDescriptor,
+                Vldtn.requireNotBlank(groupSyncThreadNamePrefix,
+                        "groupSyncThreadNamePrefix"));
         runtime.metadataCatalog.ensureFormatMarker();
         return runtime;
     }
@@ -252,7 +307,8 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
     private static <K, V> WalRuntime<K, V> createRuntime(
             final IndexWalConfiguration wal,
             final WalStorage storage, final TypeDescriptor<K> keyDescriptor,
-            final TypeDescriptor<V> valueDescriptor) {
+            final TypeDescriptor<V> valueDescriptor,
+            final String groupSyncThreadNamePrefix) {
         final Object monitor = new Object();
         final WalRuntimeMetrics metrics = new WalRuntimeMetrics();
         final AtomicBoolean closed = new AtomicBoolean();
@@ -276,12 +332,14 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
                         recordCodec, segmentCatalog, metrics);
         return new WalRuntime<>(monitor, metrics, closed, metadataCatalog,
                 segmentCatalog, syncPolicy, writer, recoveryManager,
-                newGroupSyncExecutor(wal, syncPolicy));
+                newGroupSyncExecutor(wal, syncPolicy,
+                        groupSyncThreadNamePrefix));
     }
 
     private static ScheduledExecutorService newGroupSyncExecutor(
             final IndexWalConfiguration wal,
-            final WalSyncPolicy syncPolicy) {
+            final WalSyncPolicy syncPolicy,
+            final String groupSyncThreadNamePrefix) {
         if (!wal.isGroupSyncDurabilityMode()
                 || wal.getGroupSyncDelayMillis() <= 0) {
             return null;
@@ -289,11 +347,22 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
         final ScheduledExecutorService executor =
                 Executors.newSingleThreadScheduledExecutor(
                         new NamedDaemonThreadFactory(
-                                "hestiastore-wal-group-sync"));
+                                groupSyncThreadNamePrefix));
         executor.scheduleWithFixedDelay(syncPolicy::syncGroupPendingSafely,
                 wal.getGroupSyncDelayMillis(), wal.getGroupSyncDelayMillis(),
                 TimeUnit.MILLISECONDS);
         return executor;
+    }
+
+    private static String poolThreadNamePrefix(final String prefix,
+            final String poolName) {
+        return prefix + "-" + poolName;
+    }
+
+    private static String poolThreadNamePrefix(final String prefix,
+            final String indexName,
+            final String poolName) {
+        return prefix + "-" + indexName + "-" + poolName;
     }
 
     /**
@@ -434,7 +503,7 @@ public final class WalRuntime<K, V> implements WalMonitoringView, AutoCloseable 
         private final AtomicLong sequence = new AtomicLong(0L);
 
         NamedDaemonThreadFactory(final String namePrefix) {
-            this.namePrefix = Vldtn.requireNonNull(namePrefix, "namePrefix");
+            this.namePrefix = Vldtn.requireNotBlank(namePrefix, "namePrefix");
         }
 
         @Override

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/HestiaStoreRuntimeTest.java
@@ -1,0 +1,117 @@
+package org.hestiastore.index.segmentindex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.junit.jupiter.api.Test;
+
+class HestiaStoreRuntimeTest {
+
+    @Test
+    void indexCloseDoesNotCloseCallerOwnedRuntime() {
+        try (HestiaStoreRuntime runtime = HestiaStoreRuntime.builder()
+                .segmentMaintenanceThreads(1)
+                .splitMaintenanceThreads(1)
+                .build()) {
+            try (SegmentIndex<Integer, String> index = SegmentIndex.create(
+                    new MemDirectory(), buildConf("shared-runtime-index"),
+                    runtime)) {
+                index.put(1, "one");
+            }
+
+            assertFalse(runtime.wasClosed());
+
+            try (SegmentIndex<Integer, String> index = SegmentIndex.create(
+                    new MemDirectory(),
+                    buildConf("shared-runtime-reused-index"), runtime)) {
+                index.put(2, "two");
+            }
+        }
+    }
+
+    @Test
+    void closedRuntimeIsRejectedByIndexCreate() {
+        final HestiaStoreRuntime runtime = HestiaStoreRuntime.builder()
+                .segmentMaintenanceThreads(1)
+                .splitMaintenanceThreads(1)
+                .build();
+        runtime.close();
+
+        final IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> SegmentIndex.create(new MemDirectory(),
+                        buildConf("closed-runtime-index"), runtime));
+
+        assertEquals("HestiaStoreRuntime already closed", error.getMessage());
+    }
+
+    @Test
+    void builderRejectsInvalidExecutorSettings() {
+        final IllegalArgumentException segmentThreadsError = assertThrows(
+                IllegalArgumentException.class,
+                () -> HestiaStoreRuntime.builder()
+                        .segmentMaintenanceThreads(0)
+                        .build());
+        assertEquals(
+                "Property 'segmentMaintenanceThreads' must be greater than 0",
+                segmentThreadsError.getMessage());
+
+        final IllegalArgumentException splitThreadsError = assertThrows(
+                IllegalArgumentException.class,
+                () -> HestiaStoreRuntime.builder()
+                        .splitMaintenanceThreads(0)
+                        .build());
+        assertEquals(
+                "Property 'splitMaintenanceThreads' must be greater than 0",
+                splitThreadsError.getMessage());
+
+        final IllegalArgumentException prefixError = assertThrows(
+                IllegalArgumentException.class,
+                () -> HestiaStoreRuntime.builder()
+                        .threadNamePrefix(" ")
+                        .build());
+        assertEquals("Property 'threadNamePrefix' must not be blank.",
+                prefixError.getMessage());
+    }
+
+    private static IndexConfiguration<Integer, String> buildConf(
+            final String indexName) {
+        return IndexConfiguration.<Integer, String>builder()
+                .identity(identity -> identity.keyClass(Integer.class))
+                .identity(identity -> identity.valueClass(String.class))
+                .identity(identity -> identity
+                        .keyTypeDescriptor(new TypeDescriptorInteger()))
+                .identity(identity -> identity
+                        .valueTypeDescriptor(new TypeDescriptorShortString()))
+                .identity(identity -> identity.name(indexName))
+                .logging(logging -> logging.contextEnabled(false))
+                .segment(segment -> segment.cacheKeyLimit(10))
+                .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(5))
+                .writePath(writePath -> writePath
+                        .maintenanceWriteCacheKeyLimit(6))
+                .segment(segment -> segment.chunkKeyLimit(2))
+                .segment(segment -> segment.maxKeys(100))
+                .segment(segment -> segment.cachedSegmentLimit(3))
+                .bloomFilter(bloomFilter -> bloomFilter.hashFunctions(1))
+                .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(1024))
+                .bloomFilter(bloomFilter -> bloomFilter
+                        .falsePositiveProbability(0.01D))
+                .io(io -> io.diskBufferSizeBytes(1024))
+                .maintenance(maintenance -> maintenance.indexThreads(1))
+                .maintenance(maintenance -> maintenance
+                        .registryLifecycleThreads(1))
+                .filters(filters -> filters
+                        .encodingFilters(List.of(new ChunkFilterDoNothing())))
+                .filters(filters -> filters
+                        .decodingFilters(List.of(new ChunkFilterDoNothing())))
+                .build();
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexStaticFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexStaticFactoryTest.java
@@ -105,7 +105,6 @@ class SegmentIndexStaticFactoryTest {
                 .bloomFilter(bloomFilter -> bloomFilter.falsePositiveProbability(0.01D))
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance.registryLifecycleThreads(1))
                 .filters(filters -> filters.encodingFilterRegistrations(List.of()))
                 .filters(filters -> filters.decodingFilterRegistrations(List.of()))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationBuilderTest.java
@@ -48,7 +48,7 @@ class IndexConfigurationBuilderTest {
                 .bloomFilter(bloom -> bloom.hashFunctions(2)
                         .indexSizeBytes(1024)
                         .falsePositiveProbability(0.05D))
-                .maintenance(maintenance -> maintenance.segmentThreads(2)
+                .maintenance(maintenance -> maintenance
                         .indexThreads(3).registryLifecycleThreads(4)
                         .busyBackoffMillis(5).busyTimeoutMillis(6)
                         .backgroundAutoEnabled(false))
@@ -86,8 +86,6 @@ class IndexConfigurationBuilderTest {
                 grouped.bloomFilter().indexSizeBytes());
         assertEquals(0.05D,
                 grouped.bloomFilter().falsePositiveProbability());
-        assertEquals(Integer.valueOf(2),
-                grouped.maintenance().segmentThreads());
         assertEquals(Integer.valueOf(3), grouped.maintenance().indexThreads());
         assertEquals(Integer.valueOf(4),
                 grouped.maintenance().registryLifecycleThreads());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationBuilderValidationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationBuilderValidationTest.java
@@ -439,15 +439,6 @@ class IndexConfigurationBuilderValidationTest {
     }
 
     @Test
-    void test_segmentThreads_setsValue() {
-        final IndexConfiguration<Integer, String> config = newBuilder()
-                .maintenance(maintenance -> maintenance.segmentThreads(2))
-                .build();
-
-        assertEquals(2, config.maintenance().segmentThreads());
-    }
-
-    @Test
     void test_indexThreads_setsValue() {
         final IndexConfiguration<Integer, String> config = newBuilder()
                 .maintenance(maintenance -> maintenance.indexThreads(3))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationContractTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationContractTest.java
@@ -43,9 +43,6 @@ class IndexConfigurationContractTest {
         assertEquals(Boolean.TRUE,
                 contract.maintenance().backgroundAutoEnabled());
         assertEquals(0, contract.chunkStoreCache().pageLimit());
-        assertEquals(
-                IndexConfigurationDefaults.DEFAULT_SEGMENT_MAINTENANCE_THREADS,
-                contract.maintenance().segmentThreads());
 
         final List<ChunkFilterSpec> encoding =
                 contract.filters().encodingChunkFilterSpecs();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/api/IndexConfigurationTest.java
@@ -68,10 +68,6 @@ class IndexConfigurationTest {
                 .build();
 
         assertEquals(null, config.maintenance().backgroundAutoEnabled());
-        assertEquals(
-                IndexConfigurationDefaults.DEFAULT_SEGMENT_MAINTENANCE_THREADS,
-                EffectiveIndexConfigurationResolver.resolveForCreate(config)
-                        .maintenance().segmentThreads());
         assertTrue(EffectiveIndexConfigurationResolver.resolveForCreate(config)
                 .maintenance().backgroundAutoEnabled());
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexConfigurationResolverTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/effective/EffectiveIndexConfigurationResolverTest.java
@@ -41,7 +41,6 @@ class EffectiveIndexConfigurationResolverTest {
                 .identity(identity -> identity.name("renamed-index"))
                 .segment(segment -> segment.cacheKeyLimit(12))
                 .chunkStoreCache(cache -> cache.pageLimit(7))
-                .maintenance(maintenance -> maintenance.segmentThreads(2))
                 .logging(logging -> logging.contextEnabled(false)).build();
 
         final EffectiveIndexConfiguration<Integer, String> effective = EffectiveIndexConfigurationResolver
@@ -55,7 +54,6 @@ class EffectiveIndexConfigurationResolverTest {
                 effective.segment().maxKeys());
         assertEquals(12, effective.segment().cacheKeyLimit());
         assertEquals(7, effective.chunkStoreCache().pageLimit());
-        assertEquals(2, effective.maintenance().segmentThreads());
         assertFalse(effective.logging().contextEnabled());
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationStoreTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/persistence/IndexConfigurationStoreTest.java
@@ -62,7 +62,6 @@ class IndexConfigurationStoreTest {
         assertEquals(9, loaded.writePath().indexBufferedWriteKeyLimit());
         assertEquals(11, loaded.segment().maxKeys());
         assertEquals(10, loaded.writePath().segmentSplitKeyThreshold());
-        assertEquals(7, loaded.maintenance().segmentThreads());
         assertFalse(loaded.maintenance().backgroundAutoEnabled());
         assertEquals(0, loaded.chunkStoreCache().pageLimit());
     }
@@ -93,7 +92,7 @@ class IndexConfigurationStoreTest {
                                 .indexSizeBytes(1024)
                                 .falsePositiveProbability(0.05D))
                         .maintenance(maintenance -> maintenance
-                                .segmentThreads(2).indexThreads(3)
+                                .indexThreads(3)
                                 .registryLifecycleThreads(4)
                                 .busyBackoffMillis(5)
                                 .busyTimeoutMillis(6)
@@ -321,8 +320,6 @@ class IndexConfigurationStoreTest {
                 true);
         final var view = store.snapshot();
 
-        assertEquals(7, view.getInt(
-                IndexPropertiesSchema.IndexConfigurationKeys.PROP_NUMBER_OF_SEGMENT_MAINTENANCE_THREADS));
         assertFalse(view.getBoolean(
                 IndexPropertiesSchema.IndexConfigurationKeys.PROP_BACKGROUND_MAINTENANCE_AUTO_ENABLED));
         assertNull(view.getString(LEGACY_SEGMENT_MAINTENANCE_AUTO_ENABLED));
@@ -434,7 +431,6 @@ class IndexConfigurationStoreTest {
                 .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(1024))//
                 .bloomFilter(bloomFilter -> bloomFilter.falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(7))//
                 .logging(logging -> logging.contextEnabled(false))//
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))//
                 .filters(filters -> filters
@@ -496,7 +492,6 @@ class IndexConfigurationStoreTest {
                 .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(1024))//
                 .bloomFilter(bloomFilter -> bloomFilter.falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(7))//
                 .logging(logging -> logging.contextEnabled(false))//
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))//
                 .filters(filters -> filters
@@ -545,7 +540,6 @@ class IndexConfigurationStoreTest {
                 .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(1024))//
                 .bloomFilter(bloomFilter -> bloomFilter.falsePositiveProbability(0.01D))//
                 .io(io -> io.diskBufferSizeBytes(1024))//
-                .maintenance(maintenance -> maintenance.segmentThreads(7))//
                 .logging(logging -> logging.contextEnabled(false))//
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))//
                 .filters(filters -> filters.encodingFilters(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/persistence/SegmentIndexConfigurationStorageTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/persistence/SegmentIndexConfigurationStorageTest.java
@@ -48,7 +48,6 @@ class SegmentIndexConfigurationStorageTest {
     private static final int MAX_KEYS_SEGMENT = 20000;
     private static final int MAX_KEYS_BEFORE_SPLIT = 30000;
     private static final int MAX_SEGMENTS_CACHE = 8;
-    private static final int NUMBER_OF_STABLE_SEGMENT_MAINTENANCE_THREADS = 5;
     private static final int NUMBER_OF_REGISTRY_LIFECYCLE_THREADS = 4;
     private static final String INDEX_NAME = "specialIndex01";
     private static final int BLOOM_FILTER_HASH = 3;
@@ -73,8 +72,6 @@ class SegmentIndexConfigurationStorageTest {
                 .writePath(writePath -> writePath.segmentSplitKeyThreshold(
                         MAX_KEYS_BEFORE_SPLIT))//
                 .segment(segment -> segment.cachedSegmentLimit(8))//
-                .maintenance(maintenance -> maintenance.segmentThreads(
-                        NUMBER_OF_STABLE_SEGMENT_MAINTENANCE_THREADS))//
                 .maintenance(maintenance -> maintenance.registryLifecycleThreads(
                         NUMBER_OF_REGISTRY_LIFECYCLE_THREADS))//
                 .identity(identity -> identity.name(INDEX_NAME))//
@@ -107,8 +104,6 @@ class SegmentIndexConfigurationStorageTest {
         assertEquals(MAX_KEYS_BEFORE_SPLIT,
                 ret.writePath().segmentSplitKeyThreshold());
         assertEquals(MAX_SEGMENTS_CACHE, ret.segment().cachedSegmentLimit());
-        assertEquals(NUMBER_OF_STABLE_SEGMENT_MAINTENANCE_THREADS,
-                ret.maintenance().segmentThreads());
         assertEquals(NUMBER_OF_REGISTRY_LIFECYCLE_THREADS,
                 ret.maintenance().registryLifecycleThreads());
         assertEquals(INDEX_NAME, ret.identity().name());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningConfigurationMapperTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningConfigurationMapperTest.java
@@ -89,7 +89,7 @@ class RuntimeTuningConfigurationMapperTest {
                 new EffectiveIndexSegmentConfiguration(1_000, 25, 30, 5, 3),
                 new EffectiveIndexWritePathConfiguration(10, 15, 60, 500),
                 new EffectiveIndexBloomFilterConfiguration(2, 2_048, 0.01d),
-                new EffectiveIndexMaintenanceConfiguration(2, 3, 4, 5, 30,
+                new EffectiveIndexMaintenanceConfiguration(3, 4, 5, 30,
                         true),
                 new EffectiveIndexIoConfiguration(4_096),
                 new EffectiveIndexLoggingConfiguration(true),

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningPatchApplierTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/tuning/RuntimeTuningPatchApplierTest.java
@@ -103,6 +103,32 @@ class RuntimeTuningPatchApplierTest {
     }
 
     @Test
+    void applyPublishesValuesToRuntimeStateAccessors() {
+        final RuntimeTuningResult result = applier.apply(RuntimeTuningPatch
+                .builder()
+                .expectedRevision(0L)
+                .cachedSegmentLimit(4)
+                .cacheKeyLimit(12)
+                .segmentWriteCacheKeyLimit(6)
+                .segmentWriteCacheKeyLimitDuringMaintenance(8)
+                .indexBufferedWriteKeyLimit(16)
+                .segmentSplitKeyThreshold(60)
+                .chunkStoreCachePageLimit(2)
+                .build());
+
+        assertTrue(result.applied());
+        assertEquals(1L, runtimeTuningState.revision());
+        assertEquals(4, runtimeTuningState.cachedSegmentLimit());
+        assertEquals(12, runtimeTuningState.cacheKeyLimit());
+        assertEquals(6, runtimeTuningState.segmentWriteCacheKeyLimit());
+        assertEquals(8,
+                runtimeTuningState.segmentWriteCacheKeyLimitDuringMaintenance());
+        assertEquals(16, runtimeTuningState.indexBufferedWriteKeyLimit());
+        assertEquals(60, runtimeTuningState.segmentSplitKeyThreshold());
+        assertEquals(2, runtimeTuningState.chunkStoreCachePageLimit());
+    }
+
+    @Test
     void sideEffectFailureDoesNotMutateRuntimeState() {
         doThrow(new IllegalStateException("failed")).when(segmentRegistry)
                 .updateCacheLimit(anyInt());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryFixture.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryFixture.java
@@ -8,25 +8,49 @@ import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
  * Test helper for creating executor registries from full index configuration
  * objects.
  */
-public final class ExecutorRegistryFixture {
+public final class ExecutorRegistryFixture implements AutoCloseable {
 
-    private ExecutorRegistryFixture() {
+    private final ExecutorRegistry executorRegistry;
+    private final RuntimeExecutorPools runtimeExecutorPools;
+
+    private ExecutorRegistryFixture(final ExecutorRegistry executorRegistry,
+            final RuntimeExecutorPools runtimeExecutorPools) {
+        this.executorRegistry = executorRegistry;
+        this.runtimeExecutorPools = runtimeExecutorPools;
     }
 
-    public static ExecutorRegistry from(
+    public static ExecutorRegistryFixture from(
             final IndexConfiguration<?, ?> configuration) {
         return from(EffectiveIndexConfigurationResolver.resolveForCreate(
                 configuration));
     }
 
-    public static ExecutorRegistry from(
+    public static ExecutorRegistryFixture from(
             final EffectiveIndexConfiguration<?, ?> configuration) {
-        return ExecutorRegistry.create(configuration.identity().name(),
+        final RuntimeExecutorPools runtimePools = RuntimeExecutorPools.create(
+                "hestia-test", 1, 1,
+                configuration.maintenance().busyTimeoutMillis());
+        return new ExecutorRegistryFixture(ExecutorRegistry.create(
+                configuration.identity().name(),
                 configuration.logging().contextEnabled(),
                 configuration.maintenance().indexThreads(),
-                configuration.maintenance().indexThreads(),
-                configuration.maintenance().segmentThreads(),
+                runtimePools,
                 configuration.maintenance().registryLifecycleThreads(),
-                configuration.maintenance().busyTimeoutMillis());
+                configuration.maintenance().busyTimeoutMillis()),
+                runtimePools);
+    }
+
+    public ExecutorRegistry executorRegistry() {
+        return executorRegistry;
+    }
+
+    @Override
+    public void close() {
+        if (!executorRegistry.wasClosed()) {
+            executorRegistry.close();
+        }
+        if (!runtimeExecutorPools.wasClosed()) {
+            runtimeExecutorPools.close();
+        }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorRegistryTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.executorregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,9 +17,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ExecutorRegistryTest {
+
+    private RuntimeExecutorPools runtimeExecutorPools;
+
+    @AfterEach
+    void tearDown() {
+        if (runtimeExecutorPools != null
+                && !runtimeExecutorPools.wasClosed()) {
+            runtimeExecutorPools.close();
+        }
+    }
 
     @Test
     void createUsesProvidedValues() {
@@ -38,9 +50,10 @@ class ExecutorRegistryTest {
     void createRejectsNonPositiveSegmentMaintenanceThreads() {
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> newRegistry(0, 1, 1));
+                () -> RuntimeExecutorPools.create("hestia-test", 0, 1,
+                        30_000));
         assertEquals(
-                "Property 'numberOfSegmentMaintenanceThreads' must be greater than 0",
+                "Property 'segmentMaintenanceThreads' must be greater than 0",
                 ex.getMessage());
     }
 
@@ -58,8 +71,8 @@ class ExecutorRegistryTest {
     void createRejectsNonPositiveSplitMaintenanceThreads() {
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> ExecutorRegistry.create("executor-registry-test",
-                        false, 1, 0, 1, 1, 30_000));
+                () -> RuntimeExecutorPools.create("hestia-test", 1, 0,
+                        30_000));
         assertEquals(
                 "Property 'splitMaintenanceThreads' must be greater than 0",
                 ex.getMessage());
@@ -79,14 +92,18 @@ class ExecutorRegistryTest {
     void createRejectsBlankIndexNameWhenContextLoggingEnabled() {
         final IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> ExecutorRegistry.create("  ", true, 1, 1, 1, 1,
-                        30_000));
+                () -> {
+                    runtimeExecutorPools = RuntimeExecutorPools.create(
+                            "hestia-test", 1, 1, 30_000);
+                    ExecutorRegistry.create("  ", true, 1,
+                            runtimeExecutorPools, 1, 30_000);
+                });
         assertEquals("Property 'indexName' must not be blank.",
                 ex.getMessage());
     }
 
     @Test
-    void closeShutsDownAllExecutors() {
+    void closeShutsDownIndexOwnedExecutors() {
         final ExecutorRegistry registry = newRegistry(1, 1, 1);
         final ExecutorService indexMaintenance = registry
                 .getIndexMaintenanceExecutor();
@@ -102,9 +119,9 @@ class ExecutorRegistryTest {
         registry.close();
 
         assertTrue(indexMaintenance.isShutdown());
-        assertTrue(splitMaintenance.isShutdown());
+        assertFalse(splitMaintenance.isShutdown());
         assertTrue(splitPolicyScheduler.isShutdown());
-        assertTrue(stableSegmentMaintenance.isShutdown());
+        assertFalse(stableSegmentMaintenance.isShutdown());
         assertTrue(registryMaintenance.isShutdown());
     }
 
@@ -158,8 +175,8 @@ class ExecutorRegistryTest {
         registry.close();
 
         assertTrue(indexMaintenance.isShutdown());
-        assertTrue(splitMaintenance.isShutdown());
-        assertTrue(stableSegmentMaintenance.isShutdown());
+        assertFalse(splitMaintenance.isShutdown());
+        assertFalse(stableSegmentMaintenance.isShutdown());
     }
 
     @Test
@@ -199,13 +216,16 @@ class ExecutorRegistryTest {
                     .getRegistryMaintenanceExecutor()
                     .submit(() -> Thread.currentThread().isDaemon()).get();
 
-            assertTrue(indexMaintenanceName.startsWith("index-maintenance-"));
-            assertTrue(splitMaintenanceName.startsWith("split-maintenance-"));
-            assertTrue(splitPolicyName.startsWith("split-policy-"));
+            assertTrue(indexMaintenanceName.startsWith(
+                    "hestia-test-executor-registry-test-index-maintenance-"));
+            assertTrue(splitMaintenanceName
+                    .startsWith("hestia-test-split-maintenance-"));
+            assertTrue(splitPolicyName.startsWith(
+                    "hestia-test-executor-registry-test-split-policy-"));
             assertTrue(stableSegmentMaintenanceName
-                    .startsWith("segment-maintenance-"));
-            assertTrue(
-                    registryMaintenanceName.startsWith("registry-maintenance-"));
+                    .startsWith("hestia-test-segment-maintenance-"));
+            assertTrue(registryMaintenanceName.startsWith(
+                    "hestia-test-executor-registry-test-registry-maintenance-"));
             assertTrue(indexMaintenanceDaemon);
             assertTrue(splitMaintenanceDaemon);
             assertTrue(splitPolicyDaemon);
@@ -219,14 +239,15 @@ class ExecutorRegistryTest {
     @Test
     void stableSegmentMaintenanceExecutorUsesConfiguredThreadCount()
             throws InterruptedException {
-        final int stableSegmentMaintenanceThreads = 4;
-        final ExecutorRegistry registry = newRegistry(stableSegmentMaintenanceThreads, 1, 1);
+        final int segmentMaintenanceThreads = 4;
+        final ExecutorRegistry registry = newRegistry(segmentMaintenanceThreads,
+                1, 1);
         final CountDownLatch started = new CountDownLatch(
-                stableSegmentMaintenanceThreads);
+                segmentMaintenanceThreads);
         final CountDownLatch release = new CountDownLatch(1);
         try {
             final List<java.util.concurrent.Future<String>> futures = java.util.stream.IntStream
-                    .range(0, stableSegmentMaintenanceThreads)
+                    .range(0, segmentMaintenanceThreads)
                     .mapToObj(i -> registry
                             .getStableSegmentMaintenanceExecutor().submit(() -> {
                                 started.countDown();
@@ -251,7 +272,7 @@ class ExecutorRegistryTest {
                             e.getCause());
                 }
             }).collect(Collectors.toSet());
-            assertEquals(stableSegmentMaintenanceThreads,
+            assertEquals(segmentMaintenanceThreads,
                     threadNames.size());
         } finally {
             release.countDown();
@@ -352,13 +373,23 @@ class ExecutorRegistryTest {
         }
     }
 
-    private static ExecutorRegistry newRegistry(
-            final int stableSegmentMaintenanceThreads,
+    private ExecutorRegistry newRegistry(
+            final int segmentMaintenanceThreads,
             final int indexMaintenanceThreads,
             final int registryMaintenanceThreads) {
+        runtimeExecutorPools = RuntimeExecutorPools.create("hestia-test",
+                segmentMaintenanceThreads, 1, 30_000);
+        return newRegistry(indexMaintenanceThreads, registryMaintenanceThreads,
+                runtimeExecutorPools);
+    }
+
+    private ExecutorRegistry newRegistry(
+            final int indexMaintenanceThreads,
+            final int registryMaintenanceThreads,
+            final RuntimeExecutorPools runtimeExecutorPools) {
         return ExecutorRegistry.create("executor-registry-test", false,
-                indexMaintenanceThreads, indexMaintenanceThreads,
-                stableSegmentMaintenanceThreads, registryMaintenanceThreads,
+                indexMaintenanceThreads, runtimeExecutorPools,
+                registryMaintenanceThreads,
                 30_000);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopologyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ExecutorTopologyTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.executorregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,12 +41,12 @@ class ExecutorTopologyTest {
         final RuntimeException failure = topology.shutdownExecutorsInCloseOrder();
 
         assertEquals(null, failure);
-        assertEquals(List.of("index", "split", "scheduler", "stable",
-                "registry"), shutdownOrder);
+        assertEquals(List.of("index", "scheduler", "registry"),
+                shutdownOrder);
         assertTrue(indexMaintenance.isShutdown());
-        assertTrue(splitMaintenance.isShutdown());
+        assertFalse(splitMaintenance.isShutdown());
         assertTrue(splitPolicyScheduler.isShutdown());
-        assertTrue(stableSegmentMaintenance.isShutdown());
+        assertFalse(stableSegmentMaintenance.isShutdown());
         assertTrue(registryMaintenance.isShutdown());
     }
 
@@ -77,9 +78,10 @@ class ExecutorTopologyTest {
         assertTrue(failure.getMessage().contains("indexMaintenance"));
         assertTrue(failure.getMessage().contains("1 ms"));
         assertTrue(indexMaintenance.shutdownNowCalled());
-        assertEquals(List.of("index", "index", "split", "scheduler",
-                "stable", "registry"),
+        assertEquals(List.of("index", "index", "scheduler", "registry"),
                 shutdownOrder);
+        assertFalse(splitMaintenance.isShutdown());
+        assertFalse(stableSegmentMaintenance.isShutdown());
     }
 
     private static final class NeverTerminatingExecutorService

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexStateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexStateTest.java
@@ -11,7 +11,6 @@ import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +30,7 @@ class IndexStateTest {
         final IndexConfiguration<Integer, String> conf = buildConf();
         index = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
-                tdi, tds, effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                tdi, tds, effective(conf));
     }
 
     @AfterEach

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
@@ -34,7 +34,6 @@ import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -247,8 +246,7 @@ class SegmentIndexAsyncMaintenanceTest {
         final IndexConfiguration<Integer, String> conf = buildConf();
         return SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
-                tdi, tds, effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                tdi, tds, effective(conf));
     }
 
     private IndexConfiguration<Integer, String> buildConf() {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
@@ -29,6 +29,8 @@ import org.hestiastore.index.segmentindex.configuration.persistence.IndexConfigu
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfigurationBuilder;
 import org.hestiastore.index.segmentindex.configuration.api.IndexWalConfiguration;
+import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
+import org.hestiastore.index.segmentindex.core.executorregistry.RuntimeExecutorPools;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
@@ -272,7 +274,38 @@ class SegmentIndexBootstrapOperationTest {
             final IndexConfiguration<Integer, String> configuration,
             final ChunkFilterProviderResolver resolver) {
         return new SegmentIndexBootstrapOperation<>(directory, configuration,
-                resolver);
+                resolver, runtimeHandle());
+    }
+
+    private static SegmentIndexRuntimeHandle runtimeHandle() {
+        final RuntimeExecutorPools executorPools = RuntimeExecutorPools.create(
+                "hestia-test", 1, 1, 30_000);
+        return new SegmentIndexRuntimeHandle() {
+            @Override
+            public ExecutorRegistry createExecutorRegistry(
+                    final String indexName,
+                    final boolean contextLoggingEnabled,
+                    final int indexMaintenanceThreads,
+                    final int registryMaintenanceThreads,
+                    final int shutdownTimeoutMillis) {
+                return ExecutorRegistry.create(indexName,
+                        contextLoggingEnabled, indexMaintenanceThreads,
+                        executorPools, registryMaintenanceThreads,
+                        shutdownTimeoutMillis);
+            }
+
+            @Override
+            public String threadNamePrefix() {
+                return "hestia-test";
+            }
+
+            @Override
+            public void close() {
+                if (!executorPools.wasClosed()) {
+                    executorPools.close();
+                }
+            }
+        };
     }
 
     private static IndexConfiguration<Integer, String> buildConf(
@@ -321,8 +354,6 @@ class SegmentIndexBootstrapOperationTest {
                         .maintenance(maintenance -> maintenance
                                 .backgroundAutoEnabled(false))
                         .maintenance(maintenance -> maintenance
-                                .segmentThreads(1))
-                        .maintenance(maintenance -> maintenance
                                 .registryLifecycleThreads(
                                         registryLifecycleThreads))
                         .filters(filters -> filters.encodingFilters(
@@ -360,7 +391,6 @@ class SegmentIndexBootstrapOperationTest {
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance
                         .backgroundAutoEnabled(false))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance
                         .registryLifecycleThreads(1))
                 .filters(filters -> filters.encodingFilters(
@@ -398,7 +428,6 @@ class SegmentIndexBootstrapOperationTest {
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance
                         .backgroundAutoEnabled(false))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance
                         .registryLifecycleThreads(1))
                 .filters(filters -> filters.addEncodingFilter(spec))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeTestAccess.java
@@ -1,23 +1,18 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
-import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.directory.Directory;
-import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.persistence.IndexConfigurationStore;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.execution.MappedSegmentMaintenanceService;
-import org.hestiastore.index.segmentindex.core.execution.IndexOperationStatsRecorder;
 import org.hestiastore.index.segmentindex.core.execution.PointOperationCoordinator;
 import org.hestiastore.index.segmentindex.core.execution.SegmentIteratorService;
 import org.hestiastore.index.segmentindex.core.split.SplitRuntime;
@@ -40,20 +35,12 @@ public final class SegmentIndexRuntimeTestAccess {
             final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
-            final IndexConfiguration<K, V> conf,
-            final ExecutorRegistry executorRegistry) {
+            final IndexConfiguration<K, V> conf) {
         Vldtn.requireNonNull(keyTypeDescriptor, "keyTypeDescriptor");
         Vldtn.requireNonNull(valueTypeDescriptor, "valueTypeDescriptor");
-        try {
-            new IndexConfigurationStore<K, V>(directoryFacade)
-                    .save(effective(conf));
-            final SegmentIndex<K, V> index = SegmentIndex.open(directoryFacade);
-            return new OpenedRuntime<>(index, runtimeFromIndex(index));
-        } finally {
-            if (!executorRegistry.wasClosed()) {
-                executorRegistry.close();
-            }
-        }
+        new IndexConfigurationStore<K, V>(directoryFacade).save(effective(conf));
+        final SegmentIndex<K, V> index = SegmentIndex.open(directoryFacade);
+        return new OpenedRuntime<>(index, runtimeFromIndex(index));
     }
 
     public static Object runtime(final Object runtime) {
@@ -140,30 +127,13 @@ public final class SegmentIndexRuntimeTestAccess {
         return castRuntimeView(runtime).runtimeTuning();
     }
 
-    public static <K, V> void closeRuntime(
-            final SegmentIndexRuntimeView<K, V> runtime,
-            final String indexName, final ExecutorRegistry executorRegistry) {
-        final SegmentIndexStateMachine stateMachine = new SegmentIndexStateMachine();
-        stateMachine.markReady();
-        new SessionCloseCoordinator<>(indexName, stateMachine,
-                mock(SessionOperationGate.class),
-                new IndexOperationStatsRecorder(),
-                runtime.splitService(),
-                runtime.maintenance(),
-                runtime.coreStorageRuntime(),
-                runtime.coreStorageRuntime().getStorageService(),
-                executorRegistry,
-                new IndexDirectoryLock(new MemDirectory()))
-                .close();
-    }
-
-    public static void closeRuntime(final Object runtime,
-            final String indexName, final ExecutorRegistry executorRegistry) {
+    public static void closeRuntime(final Object runtime) {
         if (runtime instanceof OpenedRuntime<?, ?> openedRuntime) {
             openedRuntime.index.close();
             return;
         }
-        closeRuntime(castRuntimeView(runtime), indexName, executorRegistry);
+        throw new IllegalArgumentException(
+                "Only opened runtime handles can be closed.");
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeViewTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexRuntimeViewTest.java
@@ -9,8 +9,6 @@ import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,27 +18,21 @@ class SegmentIndexRuntimeViewTest {
     private final TypeDescriptorInteger tdi = new TypeDescriptorInteger();
     private final TypeDescriptorShortString tds = new TypeDescriptorShortString();
 
-    private ExecutorRegistry executorRegistry;
     private Object openedRuntime;
     private Object runtime;
 
     @BeforeEach
     void setUp() {
         final IndexConfiguration<Integer, String> conf = buildConf();
-        executorRegistry = ExecutorRegistryFixture.from(conf);
         openedRuntime = SegmentIndexRuntimeTestAccess.openRuntime(
-                new MemDirectory(), tdi, tds, conf, executorRegistry);
+                new MemDirectory(), tdi, tds, conf);
         runtime = SegmentIndexRuntimeTestAccess.runtime(openedRuntime);
     }
 
     @AfterEach
     void tearDown() {
         if (openedRuntime != null) {
-            SegmentIndexRuntimeTestAccess.closeRuntime(openedRuntime,
-                    "runtime-view-test", executorRegistry);
-        }
-        if (executorRegistry != null && !executorRegistry.wasClosed()) {
-            executorRegistry.close();
+            SegmentIndexRuntimeTestAccess.closeRuntime(openedRuntime);
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssemblerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssemblerTest.java
@@ -130,6 +130,7 @@ class SegmentIndexSessionAssemblerTest {
         final SegmentIndexRuntimeResources<Integer, String> resources = new SegmentIndexRuntimeResources<>();
         resources.acquireDirectoryLock(new MemDirectory());
         resources.setExecutorRegistry(mock(ExecutorRegistry.class));
+        resources.setRuntimeHandle(mock(SegmentIndexRuntimeHandle.class));
         return resources;
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionBehaviorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionBehaviorTest.java
@@ -18,8 +18,6 @@ import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,27 +27,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SegmentIndexSessionBehaviorTest {
 
-    private ExecutorRegistry executorRegistry;
     private SegmentIndex<Integer, String> index;
 
     @BeforeEach
     void setUp() {
         final IndexConfiguration<Integer, String> conf = buildConf();
-        executorRegistry = ExecutorRegistryFixture.from(conf);
         index = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
                 new TypeDescriptorInteger(),
-                new TypeDescriptorShortString(), effective(conf),
-                executorRegistry);
+                new TypeDescriptorShortString(), effective(conf));
     }
 
     @AfterEach
     void tearDown() {
         if (index != null && !index.wasClosed()) {
             index.close();
-        }
-        if (executorRegistry != null && !executorRegistry.wasClosed()) {
-            executorRegistry.close();
         }
     }
 
@@ -67,11 +59,9 @@ class SegmentIndexSessionBehaviorTest {
     void closeReleasesDirectoryLock() {
         final MemDirectory directory = new MemDirectory();
         final IndexConfiguration<Integer, String> conf = buildConf();
-        final ExecutorRegistry registry = ExecutorRegistryFixture.from(conf);
         try (SegmentIndex<Integer, String> lockedIndex = SegmentIndexSessionTestSupport.createStarted(directory,
                         new TypeDescriptorInteger(),
-                        new TypeDescriptorShortString(), effective(conf),
-                        registry)) {
+                        new TypeDescriptorShortString(), effective(conf))) {
             assertTrue(directory.isFileExists(".lock"));
         }
 
@@ -82,21 +72,13 @@ class SegmentIndexSessionBehaviorTest {
     void failedOpenKeepsDirectoryLock() {
         final MemDirectory directory = spy(new MemDirectory());
         final IndexConfiguration<Integer, String> conf = buildConf();
-        final ExecutorRegistry registry = ExecutorRegistryFixture.from(conf);
         doThrow(new IllegalStateException("open failed")).when(directory)
                 .openSubDirectory(anyString());
 
-        try {
-            assertThrows(RuntimeException.class,
-                    () -> SegmentIndexSessionTestSupport.createStarted(directory,
-                            new TypeDescriptorInteger(),
-                            new TypeDescriptorShortString(), effective(conf),
-                            registry));
-        } finally {
-            if (!registry.wasClosed()) {
-                registry.close();
-            }
-        }
+        assertThrows(RuntimeException.class,
+                () -> SegmentIndexSessionTestSupport.createStarted(directory,
+                        new TypeDescriptorInteger(),
+                        new TypeDescriptorShortString(), effective(conf)));
 
         assertTrue(directory.isFileExists(".lock"));
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionConcurrencyTest.java
@@ -24,7 +24,6 @@ import org.hestiastore.index.segmentindex.monitoring.model.SegmentIndexRuntimeSn
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningPatch;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningResult;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,8 +38,7 @@ class SegmentIndexSessionConcurrencyTest {
         index = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
                 new TypeDescriptorInteger(),
-                new TypeDescriptorShortString(), effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                new TypeDescriptorShortString(), effective(conf));
     }
 
     @AfterEach
@@ -192,8 +190,7 @@ class SegmentIndexSessionConcurrencyTest {
         index = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
                 new TypeDescriptorInteger(),
-                new TypeDescriptorShortString(), effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                new TypeDescriptorShortString(), effective(conf));
     }
 
     private void seedStableRange(final int count) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionPutTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionPutTest.java
@@ -24,7 +24,6 @@ import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.api.IndexWalConfiguration;
 import org.hestiastore.index.segmentindex.configuration.api.WalDurabilityMode;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -216,8 +215,8 @@ class SegmentIndexSessionPutTest {
             index.close();
         }
         directory = new MemDirectory();
-        index = SegmentIndexSessionTestSupport.createStarted(directory, tdi, tds, effective(conf),
-                ExecutorRegistryFixture.from(conf));
+        index = SegmentIndexSessionTestSupport.createStarted(directory, tdi,
+                tds, effective(conf));
 
         index.put(1, "one");
         index.put(2, "two");
@@ -240,8 +239,8 @@ class SegmentIndexSessionPutTest {
         directory = new MemDirectory();
         final IndexConfiguration<Integer, String> conf = buildConf(
                 maxKeysInSegment, segmentWriteCacheKeyLimit, wal);
-        index = SegmentIndexSessionTestSupport.createStarted(directory, tdi, tds, effective(conf),
-                ExecutorRegistryFixture.from(conf));
+        index = SegmentIndexSessionTestSupport.createStarted(directory, tdi,
+                tds, effective(conf));
     }
 
     private IndexConfiguration<Integer, String> buildConf(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
@@ -22,7 +22,6 @@ import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -112,8 +111,7 @@ class SegmentIndexSessionRetryTest {
     private SegmentIndex<Integer, String> newIndex() {
         final IndexConfiguration<Integer, String> conf = buildConf();
         return SegmentIndexSessionTestSupport.createStarted(
-                new MemDirectory(), tdi, tds, effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                new MemDirectory(), tdi, tds, effective(conf));
     }
 
     private IndexConfiguration<Integer, String> buildConf() {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTest.java
@@ -24,7 +24,6 @@ import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndex
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.core.execution.PointOperationCoordinator;
 import org.hestiastore.index.segmentindex.core.execution.SegmentIteratorService;
 import org.hestiastore.index.segmentindex.SegmentIndexMaintenance;
@@ -42,8 +41,7 @@ class SegmentIndexSessionTest {
         final IndexConfiguration<Integer, String> conf = buildConf();
         index = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
-                new TypeDescriptorInteger(), new TypeDescriptorShortString(), effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                new TypeDescriptorInteger(), new TypeDescriptorShortString(), effective(conf));
     }
 
     @AfterEach

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTestSupport.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTestSupport.java
@@ -6,7 +6,6 @@ import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.persistence.IndexConfigurationStore;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 
 final class SegmentIndexSessionTestSupport {
 
@@ -18,17 +17,10 @@ final class SegmentIndexSessionTestSupport {
             final Directory directory,
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
-            final EffectiveIndexConfiguration<K, V> configuration,
-            final ExecutorRegistry executorRegistry) {
+            final EffectiveIndexConfiguration<K, V> configuration) {
         Vldtn.requireNonNull(keyTypeDescriptor, "keyTypeDescriptor");
         Vldtn.requireNonNull(valueTypeDescriptor, "valueTypeDescriptor");
-        try {
-            new IndexConfigurationStore<K, V>(directory).save(configuration);
-            return SegmentIndex.open(directory);
-        } finally {
-            if (!executorRegistry.wasClosed()) {
-                executorRegistry.close();
-            }
-        }
+        new IndexConfigurationStore<K, V>(directory).save(configuration);
+        return SegmentIndex.open(directory);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexStateTest.java
@@ -13,7 +13,6 @@ import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +28,7 @@ class SegmentIndexStateTest {
         index = SegmentIndex.create(new MemDirectory(), conf);
         errorIndex = SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(),
-                new TypeDescriptorInteger(), new TypeDescriptorShortString(), effective(conf),
-                ExecutorRegistryFixture.from(conf));
+                new TypeDescriptorInteger(), new TypeDescriptorShortString(), effective(conf));
     }
 
     @AfterEach

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SessionCloseCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SessionCloseCoordinatorTest.java
@@ -59,6 +59,9 @@ class SessionCloseCoordinatorTest {
     @Mock
     private ExecutorRegistry executorRegistry;
 
+    @Mock
+    private SegmentIndexRuntimeHandle runtimeHandle;
+
     private SessionCloseCoordinator<Integer, String> closeCoordinator;
 
     @BeforeEach
@@ -74,6 +77,7 @@ class SessionCloseCoordinatorTest {
                 stateMachine, operationGate, new IndexOperationStatsRecorder(),
                 splitService, maintenance, coreStorageRuntime,
                 storageService, executorRegistry,
+                runtimeHandle,
                 new IndexDirectoryLock(directory));
     }
 
@@ -83,7 +87,7 @@ class SessionCloseCoordinatorTest {
 
         final InOrder inOrder = inOrder(awaitOperationDrain, splitService,
                 maintenance, coreStorageRuntime, storageService, stateMachine,
-                executorRegistry, fileLock);
+                executorRegistry, runtimeHandle, fileLock);
         inOrder.verify(stateMachine).beginClose();
         inOrder.verify(awaitOperationDrain).run();
         inOrder.verify(splitService).close();
@@ -92,6 +96,7 @@ class SessionCloseCoordinatorTest {
         inOrder.verify(coreStorageRuntime).closeCoreStorage();
         inOrder.verify(storageService).closeWal();
         inOrder.verify(executorRegistry).close();
+        inOrder.verify(runtimeHandle).close();
         inOrder.verify(stateMachine).completeClose();
         inOrder.verify(fileLock).unlock();
     }
@@ -108,6 +113,7 @@ class SessionCloseCoordinatorTest {
         verify(maintenance).flushAndWait();
         verify(storageService).closeWal();
         verify(executorRegistry).close();
+        verify(runtimeHandle).close();
         verify(stateMachine).completeClose();
         verify(fileLock).unlock();
         verify(stateMachine).markRuntimeFailure(failure);
@@ -123,6 +129,7 @@ class SessionCloseCoordinatorTest {
 
         assertSame(failure, thrown);
         verify(storageService).closeWal();
+        verify(runtimeHandle).close();
         verify(stateMachine).completeClose();
         verify(fileLock).unlock();
         verify(stateMachine).markRuntimeFailure(failure);
@@ -143,6 +150,7 @@ class SessionCloseCoordinatorTest {
         assertEquals(1, thrown.getSuppressed().length);
         assertSame(secondFailure, thrown.getSuppressed()[0]);
         verify(executorRegistry).close();
+        verify(runtimeHandle).close();
         verify(fileLock).unlock();
         verify(stateMachine).markRuntimeFailure(firstFailure);
     }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/PreparedSegmentMaterializerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/PreparedSegmentMaterializerTest.java
@@ -207,7 +207,6 @@ class PreparedSegmentMaterializerTest {
                 .filters(filters -> filters.encodingFilters(List.of(new ChunkFilterDoNothing())))//
                 .filters(filters -> filters.decodingFilters(List.of(new ChunkFilterDoNothing())))//
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))//
-                .maintenance(maintenance -> maintenance.segmentThreads(1))//
                 .maintenance(maintenance -> maintenance.indexThreads(1))//
                 .maintenance(maintenance -> maintenance.busyBackoffMillis(1))//
                 .maintenance(maintenance -> maintenance.busyTimeoutMillis(1000))//

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/IndexRuntimeSnapshotProjectionTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/IndexRuntimeSnapshotProjectionTest.java
@@ -17,7 +17,6 @@ import org.hestiastore.index.segment.SegmentRuntimeSnapshot;
 import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.core.execution.MaintenanceStatsSnapshot;
 import org.hestiastore.index.segmentindex.core.execution.OperationStatsSnapshot;
@@ -31,11 +30,11 @@ import org.junit.jupiter.api.Test;
 
 class IndexRuntimeSnapshotProjectionTest {
 
-    private ExecutorRegistry executorRegistry;
+    private ExecutorRegistryFixture executorRegistry;
 
     @AfterEach
     void tearDown() {
-        if (executorRegistry != null && !executorRegistry.wasClosed()) {
+        if (executorRegistry != null) {
             executorRegistry.close();
         }
     }
@@ -63,7 +62,8 @@ class IndexRuntimeSnapshotProjectionTest {
                                 9),
                         new ChunkStoreCacheStats(5, 2, 4L, 6L, 7L, 8L, 9L,
                                 10L),
-                        stableSegmentRuntime, executorRegistry.statsSnapshot(),
+                        stableSegmentRuntime,
+                        executorRegistry.executorRegistry().statsSnapshot(),
                         new SplitStats(3L, 2, 0, 0L, 0L), WalMonitoring.empty(),
                         new MaintenanceStatsSnapshot(0L, 0L, 0L, 0L, 0L, 0L), 5L, 7L,
                         17L, 10, 5, 6, 7, SegmentIndexState.READY);
@@ -118,7 +118,6 @@ class IndexRuntimeSnapshotProjectionTest {
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))
                 .maintenance(maintenance -> maintenance.indexThreads(1))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance.registryLifecycleThreads(1))
                 .filters(filters -> filters.encodingFilters(List.of(new ChunkFilterDoNothing())))
                 .filters(filters -> filters.decodingFilters(List.of(new ChunkFilterDoNothing())))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/RuntimeMonitoringDataTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/RuntimeMonitoringDataTest.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 
 import org.hestiastore.index.chunkstorecache.ChunkStoreCacheStats;
 import org.hestiastore.index.segmentindex.SegmentIndexState;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryStats;
 import org.hestiastore.index.segmentindex.core.execution.MaintenanceStatsSnapshot;
@@ -21,11 +20,11 @@ import org.junit.jupiter.api.function.Executable;
 
 class RuntimeMonitoringDataTest {
 
-    private ExecutorRegistry executorRegistry;
+    private ExecutorRegistryFixture executorRegistry;
 
     @AfterEach
     void tearDown() {
-        if (executorRegistry != null && !executorRegistry.wasClosed()) {
+        if (executorRegistry != null) {
             executorRegistry.close();
         }
     }
@@ -99,6 +98,6 @@ class RuntimeMonitoringDataTest {
                     SegmentIndexMetricsTestConfigurationFactory.build(
                             "collected-runtime-monitoring-data"));
         }
-        return executorRegistry.statsSnapshot();
+        return executorRegistry.executorRegistry().statsSnapshot();
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/SegmentIndexMetricsTestConfigurationFactory.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/SegmentIndexMetricsTestConfigurationFactory.java
@@ -38,7 +38,6 @@ final class SegmentIndexMetricsTestConfigurationFactory {
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))
                 .maintenance(maintenance -> maintenance.indexThreads(1))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance.registryLifecycleThreads(1))
                 .filters(filters -> filters.encodingFilters(List.of(new ChunkFilterDoNothing())))
                 .filters(filters -> filters.decodingFilters(List.of(new ChunkFilterDoNothing())))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/SegmentIndexRuntimeSnapshotCollectorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/monitoring/SegmentIndexRuntimeSnapshotCollectorTest.java
@@ -26,7 +26,6 @@ import org.hestiastore.index.segmentindex.core.SegmentIndexStateView;
 import org.hestiastore.index.segmentindex.core.SegmentIndexStateMachine;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningState;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
-import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistry;
 import org.hestiastore.index.segmentindex.core.executorregistry.ExecutorRegistryFixture;
 import org.hestiastore.index.segmentindex.core.execution.MaintenanceStatsRecorder;
 import org.hestiastore.index.segmentindex.core.execution.IndexOperationStatsRecorder;
@@ -80,7 +79,7 @@ class SegmentIndexRuntimeSnapshotCollectorTest {
     private AtomicLong compactRequestHighWaterMark;
     private AtomicLong flushRequestHighWaterMark;
     private AtomicLong lastAppliedWalLsn;
-    private ExecutorRegistry executorRegistry;
+    private ExecutorRegistryFixture executorRegistry;
     private SegmentIndexRuntimeSnapshotCollector<Integer, String> collector;
 
     @BeforeEach
@@ -94,7 +93,7 @@ class SegmentIndexRuntimeSnapshotCollectorTest {
         executorRegistry = ExecutorRegistryFixture.from(conf);
         collector = SegmentIndexRuntimeSnapshotCollector.create(
                 effective(conf), keyToSegmentMap, segmentRegistry,
-                splitService, executorRegistry,
+                splitService, executorRegistry.executorRegistry(),
                 RuntimeTuningState.fromConfiguration(effective(conf)),
                 new LruChunkStoreCache<>(0), WalMonitoringView.empty(),
                 operationStatsRecorder, maintenanceStatsRecorder,
@@ -104,7 +103,7 @@ class SegmentIndexRuntimeSnapshotCollectorTest {
 
     @AfterEach
     void tearDown() {
-        if (executorRegistry != null && !executorRegistry.wasClosed()) {
+        if (executorRegistry != null) {
             executorRegistry.close();
         }
     }
@@ -183,7 +182,8 @@ class SegmentIndexRuntimeSnapshotCollectorTest {
                 .assertThrows(IllegalArgumentException.class,
                         () -> SegmentIndexRuntimeSnapshotCollector.create(null,
                                 keyToSegmentMap, segmentRegistry,
-                                splitService, executorRegistry,
+                                splitService,
+                                executorRegistry.executorRegistry(),
                                 runtimeTuningState, chunkStoreCache,
                                 walMonitoringView,
                                 operationStatsRecorder,
@@ -217,7 +217,6 @@ class SegmentIndexRuntimeSnapshotCollectorTest {
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance.backgroundAutoEnabled(false))
                 .maintenance(maintenance -> maintenance.indexThreads(1))
-                .maintenance(maintenance -> maintenance.segmentThreads(1))
                 .maintenance(maintenance -> maintenance.registryLifecycleThreads(1))
                 .filters(filters -> filters.encodingFilters(List.of(new ChunkFilterDoNothing())))
                 .filters(filters -> filters.decodingFilters(List.of(new ChunkFilterDoNothing())))

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalRuntimeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalRuntimeTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiPredicate;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
@@ -66,6 +67,64 @@ class WalRuntimeTest {
                 () -> openWithStorage(IndexWalConfiguration.EMPTY,
                         new WalStorageMem(new MemDirectory()),
                         STRING_DESCRIPTOR, STRING_DESCRIPTOR));
+    }
+
+    @Test
+    void openUsesDefaultWalRuntimeGroupSyncThreadName() {
+        final IndexWalConfiguration wal = IndexWalConfiguration.builder()
+                .durability(WalDurabilityMode.GROUP_SYNC)
+                .groupSyncDelayMillis(1).build();
+
+        try (WalRuntime<String, String> ignored = WalRuntime.open(
+                new MemDirectory(), effective(wal), STRING_DESCRIPTOR,
+                STRING_DESCRIPTOR)) {
+            assertTrue(awaitThreadNameStartingWith(
+                    "hestia-standalone-wal-group-sync-"));
+        }
+    }
+
+    @Test
+    void openUsesIndexSpecificGroupSyncThreadName() {
+        final IndexWalConfiguration wal = IndexWalConfiguration.builder()
+                .durability(WalDurabilityMode.GROUP_SYNC)
+                .groupSyncDelayMillis(1).build();
+
+        try (WalRuntime<String, String> ignored = WalRuntime.open(
+                new MemDirectory(), effective(wal), STRING_DESCRIPTOR,
+                STRING_DESCRIPTOR, "hestia-test", "orders")) {
+            assertTrue(awaitThreadNameStartingWith(
+                    "hestia-test-orders-wal-group-sync-"));
+        }
+    }
+
+    @Test
+    void openRejectsBlankThreadNamePrefixForGroupSyncThreadName() {
+        final IndexWalConfiguration wal = IndexWalConfiguration.builder()
+                .durability(WalDurabilityMode.GROUP_SYNC)
+                .groupSyncDelayMillis(1).build();
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> WalRuntime.open(new MemDirectory(), effective(wal),
+                        STRING_DESCRIPTOR, STRING_DESCRIPTOR, " ", "orders"));
+
+        assertEquals("Property 'threadNamePrefix' must not be blank.",
+                exception.getMessage());
+    }
+
+    @Test
+    void openRejectsBlankIndexNameForGroupSyncThreadName() {
+        final IndexWalConfiguration wal = IndexWalConfiguration.builder()
+                .durability(WalDurabilityMode.GROUP_SYNC)
+                .groupSyncDelayMillis(1).build();
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> WalRuntime.open(new MemDirectory(), effective(wal),
+                        STRING_DESCRIPTOR, STRING_DESCRIPTOR, "hestia", " "));
+
+        assertEquals("Property 'indexName' must not be blank.",
+                exception.getMessage());
     }
 
     @Test
@@ -1671,6 +1730,22 @@ class WalRuntimeTest {
             assertEquals(expectedState, finalRecovered);
             assertEquals(expectedMaxLsn, recovery.maxLsn());
         }
+    }
+
+    private static boolean awaitThreadNameStartingWith(final String prefix) {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (threadNameStartingWithExists(prefix)) {
+                return true;
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+        }
+        return threadNameStartingWithExists(prefix);
+    }
+
+    private static boolean threadNameStartingWithExists(final String prefix) {
+        return Thread.getAllStackTraces().keySet().stream().map(Thread::getName)
+                .anyMatch(name -> name.startsWith(prefix));
     }
 
     private static void applyReplayRecord(final Map<String, String> state,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalRuntimeTestSupport.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/wal/WalRuntimeTestSupport.java
@@ -83,7 +83,7 @@ final class WalRuntimeTestSupport {
         final ScheduledExecutorService executor =
                 Executors.newSingleThreadScheduledExecutor(
                         new NamedDaemonThreadFactory(
-                                "hestiastore-wal-group-sync"));
+                                "hestia-wal-runtime-test-wal-group-sync"));
         executor.scheduleWithFixedDelay(syncPolicy::syncGroupPendingSafely,
                 wal.getGroupSyncDelayMillis(), wal.getGroupSyncDelayMillis(),
                 TimeUnit.MILLISECONDS);

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentFactoryTest.java
@@ -153,7 +153,7 @@ class SegmentFactoryTest {
                         .falsePositiveProbability(0.01))
                 .io(io -> io.diskBufferSizeBytes(1024))
                 .maintenance(maintenance -> maintenance
-                        .backgroundAutoEnabled(false).segmentThreads(1)
+                        .backgroundAutoEnabled(false)
                         .indexThreads(1).busyBackoffMillis(1)
                         .busyTimeoutMillis(1000))
                 .logging(logging -> logging.contextEnabled(false))
@@ -260,7 +260,7 @@ class SegmentFactoryTest {
                         .decodingFilters(List.of(new ChunkFilterDoNothing())))//
                 .maintenance(maintenance -> maintenance
                         .backgroundAutoEnabled(false)//
-                        .segmentThreads(1)//
+                        //
                         .indexThreads(1)//
                         .busyBackoffMillis(1)//
                         .busyTimeoutMillis(1000))//

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentLoadCloseOperationsTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentLoadCloseOperationsTest.java
@@ -182,7 +182,7 @@ class SegmentLoadCloseOperationsTest {
                         .decodingFilters(FILTERS))//
                 .maintenance(maintenance -> maintenance
                         .backgroundAutoEnabled(false)//
-                        .segmentThreads(1)//
+                        //
                         .indexThreads(1)//
                         .busyBackoffMillis(1)//
                         .busyTimeoutMillis(1000))//

--- a/index-tools/src/main/java/org/hestiastore/indextools/IndexConfigurationManifest.java
+++ b/index-tools/src/main/java/org/hestiastore/indextools/IndexConfigurationManifest.java
@@ -19,7 +19,6 @@ class IndexConfigurationManifest {
     private Integer segmentSplitKeyThreshold;
     private Integer maxNumberOfKeysInSegment;
     private Integer maxNumberOfSegmentsInCache;
-    private Integer numberOfSegmentMaintenanceThreads;
     private Integer numberOfIndexMaintenanceThreads;
     private Integer numberOfRegistryLifecycleThreads;
     private Integer indexBusyBackoffMillis;
@@ -154,15 +153,6 @@ class IndexConfigurationManifest {
     public void setMaxNumberOfSegmentsInCache(
             final Integer maxNumberOfSegmentsInCache) {
         this.maxNumberOfSegmentsInCache = maxNumberOfSegmentsInCache;
-    }
-
-    public Integer getNumberOfSegmentMaintenanceThreads() {
-        return numberOfSegmentMaintenanceThreads;
-    }
-
-    public void setNumberOfSegmentMaintenanceThreads(
-            final Integer numberOfSegmentMaintenanceThreads) {
-        this.numberOfSegmentMaintenanceThreads = numberOfSegmentMaintenanceThreads;
     }
 
     public Integer getNumberOfIndexMaintenanceThreads() {

--- a/index-tools/src/main/java/org/hestiastore/indextools/IndexConfigurationMapper.java
+++ b/index-tools/src/main/java/org/hestiastore/indextools/IndexConfigurationMapper.java
@@ -53,8 +53,6 @@ final class IndexConfigurationMapper {
                 segment.maxKeys());
         manifest.setMaxNumberOfSegmentsInCache(
                 segment.cachedSegmentLimit());
-        manifest.setNumberOfSegmentMaintenanceThreads(
-                maintenance.segmentThreads());
         manifest.setNumberOfIndexMaintenanceThreads(
                 maintenance.indexThreads());
         manifest.setNumberOfRegistryLifecycleThreads(
@@ -118,8 +116,6 @@ final class IndexConfigurationMapper {
                         .segmentSplitKeyThreshold(manifest
                                 .getSegmentSplitKeyThreshold()))
                 .maintenance(maintenance -> maintenance
-                        .segmentThreads(
-                                manifest.getNumberOfSegmentMaintenanceThreads())
                         .indexThreads(
                                 manifest.getNumberOfIndexMaintenanceThreads())
                         .registryLifecycleThreads(manifest

--- a/index-tools/src/test/java/org/hestiastore/indextools/IndexToolTest.java
+++ b/index-tools/src/test/java/org/hestiastore/indextools/IndexToolTest.java
@@ -151,7 +151,7 @@ class IndexToolTest {
                                 .indexSizeBytes(1024)
                                 .falsePositiveProbability(0.05D))
                         .maintenance(maintenance -> maintenance
-                                .segmentThreads(2).indexThreads(3)
+                                .indexThreads(3)
                                 .registryLifecycleThreads(4)
                                 .busyBackoffMillis(5)
                                 .busyTimeoutMillis(6)

--- a/monitoring-rest-json/src/main/java/org/hestiastore/management/restjson/ManagementAgentServer.java
+++ b/monitoring-rest-json/src/main/java/org/hestiastore/management/restjson/ManagementAgentServer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -95,6 +96,8 @@ public final class ManagementAgentServer
     private static final String UNKNOWN_INDEX_PREFIX = "Unknown index: ";
     private static final String AUDIT_REJECTED = "REJECTED";
     private static final String AUDIT_FAILED = "FAILED";
+    private static final String REQUEST_THREAD_NAME_PREFIX =
+            "hestia-management-http-";
     private static final int MAX_AUDIT_RECORDS = 10_000;
     private static final int MAX_ACTION_REPLAYS = 10_000;
     private static final int MAX_REQUEST_BODY_BYTES = 1_048_576;
@@ -218,17 +221,26 @@ public final class ManagementAgentServer
                 0);
         final int workers = Math.max(2,
                 Math.min(16, Runtime.getRuntime().availableProcessors() * 2));
-        final AtomicInteger threadCounter = new AtomicInteger(1);
         this.requestExecutor = Executors.newFixedThreadPool(workers,
-                runnable -> {
-                    final Thread thread = new Thread(runnable,
-                            "monitoring-rest-json-http-"
-                                    + threadCounter.getAndIncrement());
-                    thread.setDaemon(false);
-                    return thread;
-                });
+                requestThreadFactory());
         this.server.setExecutor(requestExecutor);
         registerRoutes();
+    }
+
+    /**
+     * Creates the HTTP request thread factory for the management server.
+     *
+     * @return request thread factory
+     */
+    static ThreadFactory requestThreadFactory() {
+        final AtomicInteger threadCounter = new AtomicInteger(1);
+        return runnable -> {
+            final Thread thread = new Thread(runnable,
+                    REQUEST_THREAD_NAME_PREFIX
+                            + threadCounter.getAndIncrement());
+            thread.setDaemon(false);
+            return thread;
+        };
     }
 
     /**

--- a/monitoring-rest-json/src/test/java/org/hestiastore/management/restjson/ManagementAgentServerTest.java
+++ b/monitoring-rest-json/src/test/java/org/hestiastore/management/restjson/ManagementAgentServerTest.java
@@ -109,6 +109,16 @@ class ManagementAgentServerTest {
     }
 
     @Test
+    void requestThreadFactoryUsesHestiaThreadNames() {
+        final Thread thread = ManagementAgentServer.requestThreadFactory()
+                .newThread(() -> {
+                });
+
+        assertTrue(thread.getName().startsWith("hestia-management-http-"));
+        assertFalse(thread.isDaemon());
+    }
+
+    @Test
     void reportEndpointReturnsJvmAndPerIndexSections() throws Exception {
         indexes.get(0).put(1, "A");
         indexes.get(1).put(2, "B");


### PR DESCRIPTION
## Summary
- add optional HestiaStoreRuntime support so indexes can share runtime-owned executor pools
- move segment-maintenance and split-maintenance to runtime-owned pools while keeping index-specific pools scoped by index
- add runtime lifecycle, tuning, naming, and two-index shared-runtime integration coverage

## Thread pool ownership
- Runtime/shared: segment-maintenance, split-maintenance
- Index-owned: index-maintenance, split-policy, registry-maintenance, wal-group-sync
- Process/service-owned: management-http

## Tests
- mvn clean verify
- mvn -pl engine -Dtest=WalRuntimeTest test