### PR TITLE
Add startup memory estimate report

### DIFF
--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -16,12 +16,14 @@ reliably in production-like environments.
 
 1. Start with [WAL](wal.md) if you need local crash recovery.
 2. Add [Monitoring](monitoring.md) before broad rollout.
-3. Use [Performance Tuning](tuning.md) only after you have workload evidence.
-4. Define [Backup & Restore](backup-restore.md) before calling the system
+3. Read [Startup Memory Estimate](memory-estimate.md) when checking heap
+   pressure during startup.
+4. Use [Performance Tuning](tuning.md) only after you have workload evidence.
+5. Define [Backup & Restore](backup-restore.md) before calling the system
    production-ready.
-5. Add [Export & Import](export-import.md) when you need portable logical
+6. Add [Export & Import](export-import.md) when you need portable logical
    backups or migration tooling.
-6. Use [WAL Canary Runbook](wal-canary-runbook.md) for staged WAL rollouts.
+7. Use [WAL Canary Runbook](wal-canary-runbook.md) for staged WAL rollouts.
 
 ## After an unexpected shutdown
 
@@ -37,6 +39,8 @@ Recommended recovery sequence:
 ## Related docs
 
 - [Configuration](../configuration/index.md) for builder-level settings
+- [Startup Memory Estimate](memory-estimate.md) for heap-pressure report
+  assumptions
 - [Monitoring Architecture](../architecture/monitoring/index.md) for internal
   monitoring design
 - [Performance Model & Sizing](../architecture/segmentindex/performance.md) for

--- a/docs/operations/memory-estimate.md
+++ b/docs/operations/memory-estimate.md
@@ -1,0 +1,64 @@
+---
+title: Startup Memory Estimate
+audience: operator
+doc_type: reference
+owner: engine
+---
+
+# Startup Memory Estimate
+
+HestiaStore logs a rough startup memory estimate after the effective
+`SegmentIndex` configuration is resolved. The report estimates active heap
+pressure from configuration values; it is not a JVM heap cap and it is not a
+measurement of allocated objects.
+
+The estimate is meant to explain why the configured index may need memory. Use
+it as a sizing hint, then verify real usage with JVM and application monitoring.
+
+## How to read the report
+
+The report puts the final estimate first:
+
+- `Estimated active heap`: steady-state memory plus the temporary margin.
+- `steady state`: memory expected after startup caches are loaded.
+- `temporary margin`: extra headroom for short-lived objects and snapshots.
+
+The `Largest steady-state areas` section shows the biggest calculated areas in
+descending order. The `Estimated memory by area` section keeps the detailed
+inputs for each area.
+
+Configuration values that are useful context but do not change the estimate are
+listed under `Reported but not included`. Conditional areas use `if loaded` in
+their labels because those structures are loaded lazily; the estimate shows
+their active-heap cost when loaded.
+
+## What the report uses
+
+The estimator combines resolved configuration, descriptor size estimates, and a
+small set of fixed assumptions:
+
+- `entry overhead`: applied per cached key/value entry.
+- `page overhead`: applied per chunk-store cache page.
+- `tree map entry`: applied per route-map tree entry.
+- `segment id`: applied when estimating route-map entries.
+- `scarce index position`: applied per scarce-index entry.
+- `fixed per loaded/cached segment`: applied once for each loaded or cached
+  segment.
+- `temporary margin`: extra space above steady state, calculated as the
+  larger of a percentage of steady state or one loaded segment cache.
+
+These assumptions are deliberately visible because they are not exact JVM
+object-layout measurements. They are stable estimator constants used to make
+the report understandable and repeatable.
+
+## Incomplete estimates
+
+If a key or value `TypeDescriptor` cannot provide
+`getEstimatedAverageSizeInBytes()`, HestiaStore still starts normally. The
+report marks dependent line items as unavailable and still shows independent
+items such as Bloom filters and fixed segment infrastructure.
+
+## Related docs
+
+- [Performance Tuning](tuning.md)
+- [Data Types](../configuration/data-types.md)

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptor.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptor.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 /**
  * Defines full binary behavior of a value type used by the storage engine.
@@ -48,6 +49,30 @@ public interface TypeDescriptor<T> {
      * @return type encoder
      */
     TypeEncoder<T> getTypeEncoder();
+
+    /**
+     * Returns an estimated average serialized size in bytes for this type.
+     *
+     * <p>
+     * Fixed-size descriptors should return their constant serialized size.
+     * Variable-size descriptors should return a conservative estimate only when
+     * the descriptor can make one safely. An empty value means that memory
+     * estimation cannot model this type without a custom descriptor or another
+     * explicit source of size information.
+     * </p>
+     * <p>
+     * Empty is different from zero. {@link OptionalInt#empty()} means that the
+     * descriptor does not know a defensible estimate. {@code OptionalInt.of(0)}
+     * is a real estimate for descriptors that serialize no bytes, such as a
+     * null-value marker. Estimation code should treat unknown estimates
+     * explicitly instead of silently guessing.
+     * </p>
+     *
+     * @return estimated average serialized size, or empty when unknown
+     */
+    default OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.empty();
+    }
 
     /**
      * Returns the sentinel value used as a tombstone for delete semantics.

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorByte.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorByte.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 
@@ -40,6 +41,16 @@ public class TypeDescriptorByte implements TypeDescriptor<Byte> {
     @Override
     public TypeEncoder<Byte> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns one byte as the fixed serialized size estimate.
+     *
+     * @return fixed byte size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(REQUIRED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorDouble.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorDouble.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.directory.FileReader;
@@ -44,6 +45,16 @@ public class TypeDescriptorDouble implements TypeDescriptor<Double> {
     @Override
     public TypeEncoder<Double> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns eight bytes as the fixed serialized size estimate.
+     *
+     * @return fixed double size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(REQUIRED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorFixedLengthString.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorFixedLengthString.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.datatype;
 
 import java.nio.charset.Charset;
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 
@@ -100,6 +101,16 @@ public final class TypeDescriptorFixedLengthString
                 }
             }
         };
+    }
+
+    /**
+     * Returns the configured fixed string length as the size estimate.
+     *
+     * @return fixed-length string size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(length);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorFloat.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorFloat.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.directory.FileReader;
@@ -44,6 +45,16 @@ public class TypeDescriptorFloat implements TypeDescriptor<Float> {
     @Override
     public TypeEncoder<Float> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns four bytes as the fixed serialized size estimate.
+     *
+     * @return fixed float size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(REQUIRED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorInteger.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorInteger.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.directory.FileReader;
@@ -54,6 +55,16 @@ public class TypeDescriptorInteger implements TypeDescriptor<Integer> {
     @Override
     public TypeEncoder<Integer> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns four bytes as the fixed serialized size estimate.
+     *
+     * @return fixed integer size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(REQUIRED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorLong.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorLong.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.datatype;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.directory.FileReader;
@@ -58,6 +59,16 @@ public class TypeDescriptorLong implements TypeDescriptor<Long> {
     @Override
     public TypeEncoder<Long> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns eight bytes as the fixed serialized size estimate.
+     *
+     * @return fixed long size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(REQUIRED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorNull.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorNull.java
@@ -4,6 +4,7 @@ import static org.hestiastore.index.datatype.NullValue.NULL;
 import static org.hestiastore.index.datatype.NullValue.TOMBSTONE;
 
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 import org.hestiastore.index.Vldtn;
 
@@ -68,6 +69,16 @@ public class TypeDescriptorNull implements TypeDescriptor<NullValue> {
                         0);
             }
         };
+    }
+
+    /**
+     * Returns zero bytes as the fixed serialized size estimate.
+     *
+     * @return fixed null-value size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(0);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorShortString.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorShortString.java
@@ -2,11 +2,14 @@ package org.hestiastore.index.datatype;
 
 import java.nio.charset.Charset;
 import java.util.Comparator;
+import java.util.OptionalInt;
 
 /**
  * Descriptor for short strings prefixed by one-byte payload length.
  */
 public class TypeDescriptorShortString implements TypeDescriptor<String> {
+
+    private static final int MAX_SERIALIZED_BYTES = 128;
 
     private static final String CHARSET_ENCODING_NAME = "ISO_8859_1";
 
@@ -38,6 +41,16 @@ public class TypeDescriptorShortString implements TypeDescriptor<String> {
     @Override
     public TypeEncoder<String> getTypeEncoder() {
         return CONVERTOR_TO_BYTES;
+    }
+
+    /**
+     * Returns the conservative maximum short-string serialized size estimate.
+     *
+     * @return conservative short-string size estimate
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(MAX_SERIALIZED_BYTES);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/MemoryEstimateReport.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/MemoryEstimateReport.java
@@ -1,0 +1,72 @@
+package org.hestiastore.index.segmentindex;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import org.hestiastore.index.Vldtn;
+
+/**
+ * Immutable startup memory-estimation report.
+ */
+public final class MemoryEstimateReport {
+
+    private final List<String> lines;
+    private final boolean complete;
+    private final OptionalLong totalEstimatedBytes;
+
+    /**
+     * Creates a memory-estimation report.
+     *
+     * @param lines user-facing report lines without log prefixes
+     * @param complete whether all line items and totals were calculated
+     * @param totalEstimatedBytes final estimate when complete
+     */
+    public MemoryEstimateReport(final List<String> lines,
+            final boolean complete, final OptionalLong totalEstimatedBytes) {
+        this.lines = List.copyOf(Vldtn.requireNonNull(lines, "lines"));
+        this.complete = complete;
+        this.totalEstimatedBytes = Vldtn.requireNonNull(totalEstimatedBytes,
+                "totalEstimatedBytes");
+    }
+
+    /**
+     * Returns whether all line items and totals were calculated.
+     *
+     * @return true when the estimate is complete
+     */
+    public boolean isComplete() {
+        return complete;
+    }
+
+    /**
+     * Returns final estimated bytes when available.
+     *
+     * @return final estimated bytes, or empty when the report is incomplete
+     */
+    public OptionalLong totalEstimatedBytes() {
+        return totalEstimatedBytes;
+    }
+
+    /**
+     * Returns user-facing report lines without log prefixes.
+     *
+     * @return immutable report lines
+     */
+    public List<String> lines() {
+        return lines;
+    }
+
+    /**
+     * Returns the report as one line-separator-delimited string.
+     *
+     * @return report text
+     */
+    public String text() {
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    @Override
+    public String toString() {
+        return text();
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
@@ -1,6 +1,8 @@
 package org.hestiastore.index.segmentindex;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import org.hestiastore.index.CloseableResource;
@@ -394,6 +396,21 @@ public interface SegmentIndex<K, V> extends CloseableResource {
      * @return runtime monitoring view
      */
     SegmentIndexRuntimeMonitoring runtimeMonitoring();
+
+    /**
+     * Returns memory-estimation diagnostics captured during successful startup.
+     * <p>
+     * Implementations that do not capture startup diagnostics return an incomplete
+     * report.
+     * </p>
+     *
+     * @return startup memory-estimation report
+     */
+    default MemoryEstimateReport startupMemoryEstimate() {
+        return new MemoryEstimateReport(
+                List.of("startup memory estimate unavailable for this implementation"),
+                false, OptionalLong.empty());
+    }
 
     /**
      * Returns runtime tuning API.

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
@@ -1,0 +1,504 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
+import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
+
+/**
+ * Builds a rough heap-pressure estimate from resolved startup configuration.
+ */
+final class IndexMemoryEstimator {
+
+    static final int ENTRY_OVERHEAD_BYTES = 96;
+    static final int PAGE_OVERHEAD_BYTES = 64;
+    static final int TREE_MAP_ENTRY_OVERHEAD_BYTES = 56;
+    static final int SEGMENT_ID_ESTIMATE_BYTES = 16;
+    static final int SCARCE_INDEX_POSITION_BYTES = 4;
+    static final int FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES = 16 * 1024;
+    static final int TEMPORARY_MEMORY_MARGIN_PERCENT = 25;
+
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String UNAVAILABLE = "unavailable";
+    private static final String NOTICE =
+            "Rough estimate only; not a JVM cap or measured allocation.";
+    private static final String RUNTIME_NOTE =
+            "Real usage depends on JVM layout, GC, workload, and temporary snapshots.";
+
+    private IndexMemoryEstimator() {
+    }
+
+    /**
+     * Estimates startup memory pressure for an index configuration.
+     *
+     * @param <K> key type
+     * @param <V> value type
+     * @param configuration resolved effective configuration
+     * @param keyTypeDescriptor resolved key descriptor
+     * @param valueTypeDescriptor resolved value descriptor
+     * @param routeCount current number of route-map entries
+     * @return memory estimate report
+     */
+    static <K, V> MemoryEstimateReport estimate(
+            final EffectiveIndexConfiguration<K, V> configuration,
+            final TypeDescriptor<K> keyTypeDescriptor,
+            final TypeDescriptor<V> valueTypeDescriptor,
+            final int routeCount) {
+        final EffectiveIndexConfiguration<K, V> resolved =
+                Vldtn.requireNonNull(configuration, "configuration");
+        final TypeDescriptor<K> keyDescriptor = Vldtn.requireNonNull(
+                keyTypeDescriptor, "keyTypeDescriptor");
+        final TypeDescriptor<V> valueDescriptor = Vldtn.requireNonNull(
+                valueTypeDescriptor, "valueTypeDescriptor");
+        final int resolvedRouteCount = Vldtn
+                .requireGreaterThanOrEqualToZero(routeCount, "routeCount");
+
+        final OptionalInt keyEstimate =
+                keyDescriptor.getEstimatedAverageSizeInBytes();
+        final OptionalInt valueEstimate =
+                valueDescriptor.getEstimatedAverageSizeInBytes();
+        final OptionalLong entryEstimate = entryEstimate(keyEstimate,
+                valueEstimate);
+        final OptionalLong scarceEntryEstimate =
+                scarceEntryEstimate(keyEstimate);
+        final OptionalLong oneLoadedSegmentCache =
+                estimateOneLoadedSegmentCache(resolved, entryEstimate);
+        final OptionalLong loadedSegmentCaches =
+                estimateLoadedSegmentCaches(resolved, entryEstimate);
+        final OptionalLong chunkStoreCache =
+                estimateChunkStoreCache(resolved, entryEstimate);
+        final OptionalLong routeMap =
+                estimateRouteMap(resolvedRouteCount, keyEstimate);
+        final OptionalLong bloomFilters = OptionalLong
+                .of(estimateBloomFilters(resolved));
+        final OptionalLong scarceIndexes =
+                estimateScarceIndexes(resolved, keyEstimate);
+        final OptionalLong segmentInfrastructure = OptionalLong
+                .of(estimateSegmentInfrastructure(resolved));
+
+        long steadyStateBytes = 0L;
+        steadyStateBytes = addIfPresent(steadyStateBytes,
+                loadedSegmentCaches);
+        steadyStateBytes = addIfPresent(steadyStateBytes, chunkStoreCache);
+        steadyStateBytes = addIfPresent(steadyStateBytes, routeMap);
+        steadyStateBytes = addIfPresent(steadyStateBytes, bloomFilters);
+        steadyStateBytes = addIfPresent(steadyStateBytes, scarceIndexes);
+        steadyStateBytes = addIfPresent(steadyStateBytes,
+                segmentInfrastructure);
+
+        final boolean complete = entryEstimate.isPresent()
+                && loadedSegmentCaches.isPresent()
+                && chunkStoreCache.isPresent()
+                && routeMap.isPresent()
+                && scarceIndexes.isPresent();
+        final OptionalLong steadyState =
+                complete ? OptionalLong.of(steadyStateBytes)
+                        : OptionalLong.empty();
+        final OptionalLong temporaryMemoryMargin = estimateTemporaryMemoryMargin(
+                steadyState, oneLoadedSegmentCache);
+        final OptionalLong total = total(steadyState, temporaryMemoryMargin);
+        final List<Map.Entry<String, OptionalLong>> steadyAreas = List.of(
+                Map.entry("loaded segment cache", loadedSegmentCaches),
+                Map.entry("chunk-store cache", chunkStoreCache),
+                Map.entry("route map", routeMap),
+                Map.entry("Bloom filters if loaded", bloomFilters),
+                Map.entry("scarce indexes if loaded", scarceIndexes),
+                Map.entry("loaded segment infrastructure",
+                        segmentInfrastructure));
+
+        final StringBuilder out = new StringBuilder();
+        appendTitle(out);
+        appendSummary(out, steadyState, temporaryMemoryMargin, total);
+        appendNotes(out);
+        appendLargestAreas(out, steadyAreas);
+        appendAssumptions(out, keyDescriptor, valueDescriptor, keyEstimate,
+                valueEstimate, entryEstimate);
+        appendConfiguration(out, resolved, resolvedRouteCount);
+        appendReportedButNotIncluded(out, resolved);
+        out.append("Estimated memory by area:").append(LINE_SEPARATOR);
+        appendLine(out, "loaded segment cache", loadedSegmentCaches,
+                "needs key and value descriptor estimates",
+                String.format(Locale.ROOT,
+                        "inputs: %d segments, %d read keys, %d maintenance keys, entry %s",
+                        resolved.segment().cachedSegmentLimit(),
+                        resolved.segment().cacheKeyLimit(),
+                        resolved.writePath()
+                                .segmentWriteCacheKeyLimitDuringMaintenance(),
+                        estimateText(entryEstimate)));
+
+        appendLine(out, "chunk-store cache", chunkStoreCache,
+                "needs key and value descriptor estimates",
+                String.format(Locale.ROOT,
+                        "inputs: %d pages, %d chunk keys, page overhead %s, entry %s",
+                        resolved.chunkStoreCache().pageLimit(),
+                        resolved.segment().chunkKeyLimit(),
+                        formatBytes(PAGE_OVERHEAD_BYTES),
+                        estimateText(entryEstimate)));
+
+        appendLine(out, "route map", routeMap,
+                "needs key descriptor estimate",
+                String.format(Locale.ROOT,
+                        "inputs: %d routes, key %s, segment id %s, tree entry %s",
+                        resolvedRouteCount, estimateText(keyEstimate),
+                        formatBytes(SEGMENT_ID_ESTIMATE_BYTES),
+                        formatBytes(TREE_MAP_ENTRY_OVERHEAD_BYTES)));
+
+        appendLine(out, "Bloom filters if loaded", bloomFilters, "",
+                String.format(Locale.ROOT, "inputs: %d segments, filter %s",
+                        resolved.segment().cachedSegmentLimit(),
+                        formatBytes(resolved.bloomFilter()
+                                .indexSizeBytes())));
+
+        appendLine(out, "scarce indexes if loaded", scarceIndexes,
+                "needs key descriptor estimate",
+                String.format(Locale.ROOT,
+                        "inputs: %d segments, %d scarce entries each, scarce entry %s",
+                        resolved.segment().cachedSegmentLimit(),
+                        ceilDiv(resolved.segment().maxKeys(),
+                                resolved.segment().chunkKeyLimit()),
+                        estimateText(scarceEntryEstimate)));
+
+        appendLine(out, "loaded segment infrastructure",
+                segmentInfrastructure, "",
+                String.format(Locale.ROOT, "inputs: %d segments, overhead %s",
+                        resolved.segment().cachedSegmentLimit(),
+                        formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES)));
+
+        appendLine(out, "temporary memory margin",
+                temporaryMemoryMargin,
+                "needs complete steady-state estimate and entry estimate",
+                String.format(Locale.ROOT,
+                        "inputs: max(%d%% of steady state = %s, one segment cache = %s)",
+                        TEMPORARY_MEMORY_MARGIN_PERCENT,
+                        memoryText(steadyState),
+                        memoryText(oneLoadedSegmentCache)));
+
+        out.append("End memory estimate").append(LINE_SEPARATOR);
+        return new MemoryEstimateReport(out.toString().lines().toList(),
+                total.isPresent(), total);
+    }
+
+    private static void appendTitle(final StringBuilder out) {
+        out.append("Estimated memory use at startup").append(LINE_SEPARATOR);
+    }
+
+    private static void appendSummary(final StringBuilder out,
+            final OptionalLong steadyState,
+            final OptionalLong temporaryMemoryMargin,
+            final OptionalLong total) {
+        out.append("Estimated active heap: ")
+                .append(memoryText(total)).append(LINE_SEPARATOR);
+        appendIndented(out, "steady state: " + memoryText(steadyState)
+                + " (memory expected after startup caches are loaded)");
+        appendIndented(out, "temporary margin: "
+                + memoryText(temporaryMemoryMargin)
+                + " (extra headroom for short-lived objects and snapshots)");
+    }
+
+    private static void appendNotes(final StringBuilder out) {
+        out.append("Notes:").append(LINE_SEPARATOR);
+        appendIndented(out, NOTICE);
+        appendIndented(out, RUNTIME_NOTE);
+        appendIndented(out, "details: docs/operations/memory-estimate.md");
+    }
+
+    private static void appendLargestAreas(final StringBuilder out,
+            final List<Map.Entry<String, OptionalLong>> steadyAreas) {
+        out.append("Largest steady-state areas:").append(LINE_SEPARATOR);
+        final List<Map.Entry<String, OptionalLong>> availableAreas = steadyAreas
+                .stream()
+                .filter(area -> area.getValue().isPresent()
+                        && area.getValue().getAsLong() > 0L)
+                .sorted(Comparator
+                        .comparingLong((Map.Entry<String, OptionalLong> area) ->
+                                area.getValue().getAsLong())
+                        .reversed())
+                .limit(3L)
+                .toList();
+        if (availableAreas.isEmpty()) {
+            appendIndented(out, UNAVAILABLE);
+            return;
+        }
+        availableAreas.forEach(area -> appendIndented(out,
+                area.getKey() + ": " + memoryText(area.getValue())));
+    }
+
+    private static <K, V> void appendAssumptions(final StringBuilder out,
+            final TypeDescriptor<K> keyDescriptor,
+            final TypeDescriptor<V> valueDescriptor,
+            final OptionalInt keyEstimate, final OptionalInt valueEstimate,
+            final OptionalLong entryEstimate) {
+        out.append("Per-entry size assumptions:").append(LINE_SEPARATOR);
+        appendIndented(out, "key: " + descriptorName(keyDescriptor) + ", "
+                + aboutText(keyEstimate));
+        appendIndented(out, "value: " + descriptorName(valueDescriptor) + ", "
+                + aboutText(valueEstimate));
+        appendIndented(out, "entry: " + aboutText(entryEstimate)
+                + " (key + value + overhead)");
+        out.append("Estimator assumptions:").append(LINE_SEPARATOR);
+        appendIndented(out, "fixed per loaded/cached segment: about "
+                + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES));
+        appendIndented(out, "temporary margin: max("
+                + TEMPORARY_MEMORY_MARGIN_PERCENT
+                + "% of steady state, one segment cache)");
+    }
+
+    private static void appendConfiguration(final StringBuilder out,
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final int routeCount) {
+        out.append("Configuration used for this estimate:")
+                .append(LINE_SEPARATOR);
+        appendIndented(out, "cached segments="
+                + resolved.segment().cachedSegmentLimit()
+                + ", segment cache keys="
+                + resolved.segment().cacheKeyLimit()
+                + ", maintenance keys="
+                + resolved.writePath()
+                        .segmentWriteCacheKeyLimitDuringMaintenance());
+        appendIndented(out, "max keys per segment="
+                + resolved.segment().maxKeys());
+        appendIndented(out, "chunk key limit="
+                + resolved.segment().chunkKeyLimit()
+                + ", chunk-store pages="
+                + resolved.chunkStoreCache().pageLimit()
+                + ", Bloom filter="
+                + formatBytes(resolved.bloomFilter().indexSizeBytes()));
+        appendIndented(out, "route map entries=" + routeCount);
+    }
+
+    private static void appendReportedButNotIncluded(final StringBuilder out,
+            final EffectiveIndexConfiguration<?, ?> resolved) {
+        out.append("Reported but not included:").append(LINE_SEPARATOR);
+        appendIndented(out, "index write-buffer keys: "
+                + resolved.writePath().indexBufferedWriteKeyLimit());
+    }
+
+    private static void appendLine(final StringBuilder out,
+            final String label, final OptionalLong estimateBytes,
+            final String unavailableReason, final String... details) {
+        out.append("  ").append(label).append(": ")
+                .append(memoryText(estimateBytes)).append(LINE_SEPARATOR);
+        if (estimateBytes.isEmpty() && !unavailableReason.isBlank()) {
+            appendDetail(out, "reason: " + unavailableReason);
+        }
+        for (final String detail : details) {
+            appendDetail(out, detail);
+        }
+    }
+
+    private static OptionalLong entryEstimate(final OptionalInt keyEstimate,
+            final OptionalInt valueEstimate) {
+        if (keyEstimate.isEmpty() || valueEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(add(add(keyEstimate.getAsInt(),
+                valueEstimate.getAsInt()), ENTRY_OVERHEAD_BYTES));
+    }
+
+    private static OptionalLong scarceEntryEstimate(
+            final OptionalInt keyEstimate) {
+        if (keyEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(add(
+                add(keyEstimate.getAsInt(), SCARCE_INDEX_POSITION_BYTES),
+                ENTRY_OVERHEAD_BYTES));
+    }
+
+    private static OptionalLong estimateLoadedSegmentCaches(
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final OptionalLong entryEstimate) {
+        if (entryEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long perSegmentKeys = add(resolved.segment().cacheKeyLimit(),
+                resolved.writePath()
+                        .segmentWriteCacheKeyLimitDuringMaintenance());
+        return OptionalLong.of(multiply(
+                multiply(resolved.segment().cachedSegmentLimit(),
+                        perSegmentKeys),
+                entryEstimate.getAsLong()));
+    }
+
+    private static OptionalLong estimateOneLoadedSegmentCache(
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final OptionalLong entryEstimate) {
+        if (entryEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long perSegmentKeys = add(resolved.segment().cacheKeyLimit(),
+                resolved.writePath()
+                        .segmentWriteCacheKeyLimitDuringMaintenance());
+        return OptionalLong.of(multiply(perSegmentKeys,
+                entryEstimate.getAsLong()));
+    }
+
+    private static OptionalLong estimateChunkStoreCache(
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final OptionalLong entryEstimate) {
+        if (entryEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long pageBytes = add(PAGE_OVERHEAD_BYTES,
+                multiply(resolved.segment().chunkKeyLimit(),
+                        entryEstimate.getAsLong()));
+        return OptionalLong.of(multiply(resolved.chunkStoreCache().pageLimit(),
+                pageBytes));
+    }
+
+    private static OptionalLong estimateRouteMap(final int routeCount,
+            final OptionalInt keyEstimate) {
+        if (keyEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long perEntryBytes = add(
+                add(keyEstimate.getAsInt(), SEGMENT_ID_ESTIMATE_BYTES),
+                TREE_MAP_ENTRY_OVERHEAD_BYTES);
+        return OptionalLong.of(multiply(multiply(routeCount, 2L),
+                perEntryBytes));
+    }
+
+    private static long estimateBloomFilters(
+            final EffectiveIndexConfiguration<?, ?> resolved) {
+        return multiply(resolved.segment().cachedSegmentLimit(),
+                resolved.bloomFilter().indexSizeBytes());
+    }
+
+    private static OptionalLong estimateScarceIndexes(
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final OptionalInt keyEstimate) {
+        if (keyEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long scarceKeysPerSegment = ceilDiv(resolved.segment().maxKeys(),
+                resolved.segment().chunkKeyLimit());
+        final long scarceEntryBytes = add(
+                add(keyEstimate.getAsInt(), SCARCE_INDEX_POSITION_BYTES),
+                ENTRY_OVERHEAD_BYTES);
+        return OptionalLong.of(multiply(
+                multiply(resolved.segment().cachedSegmentLimit(),
+                        scarceKeysPerSegment),
+                scarceEntryBytes));
+    }
+
+    private static long estimateSegmentInfrastructure(
+            final EffectiveIndexConfiguration<?, ?> resolved) {
+        return multiply(resolved.segment().cachedSegmentLimit(),
+                FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES);
+    }
+
+    private static OptionalLong estimateTemporaryMemoryMargin(
+            final OptionalLong steadyState,
+            final OptionalLong oneLoadedSegmentCache) {
+        if (steadyState.isEmpty() || oneLoadedSegmentCache.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        final long percentageHeadroom = multiply(steadyState.getAsLong(),
+                TEMPORARY_MEMORY_MARGIN_PERCENT) / 100L;
+        return OptionalLong.of(Math.max(percentageHeadroom,
+                oneLoadedSegmentCache.getAsLong()));
+    }
+
+    private static OptionalLong total(final OptionalLong steadyState,
+            final OptionalLong transientHeadroom) {
+        if (steadyState.isEmpty() || transientHeadroom.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(add(steadyState.getAsLong(),
+                transientHeadroom.getAsLong()));
+    }
+
+    private static long addIfPresent(final long total,
+            final OptionalLong value) {
+        return value.isPresent() ? add(total, value.getAsLong()) : total;
+    }
+
+    private static long ceilDiv(final long dividend, final long divisor) {
+        return (dividend + divisor - 1L) / divisor;
+    }
+
+    private static long add(final long left, final long right) {
+        if (Long.MAX_VALUE - left < right) {
+            return Long.MAX_VALUE;
+        }
+        return left + right;
+    }
+
+    private static long multiply(final long left, final long right) {
+        if (left == 0L || right == 0L) {
+            return 0L;
+        }
+        if (left > Long.MAX_VALUE / right) {
+            return Long.MAX_VALUE;
+        }
+        return left * right;
+    }
+
+    private static String estimateText(final OptionalInt estimate) {
+        return estimate.isPresent() ? formatBytes(estimate.getAsInt())
+                : "unknown";
+    }
+
+    private static String estimateText(final OptionalLong estimate) {
+        return estimate.isPresent() ? formatBytes(estimate.getAsLong())
+                : UNAVAILABLE;
+    }
+
+    private static String memoryText(final OptionalLong estimate) {
+        return estimate.isPresent() ? formatBytes(estimate.getAsLong())
+                : UNAVAILABLE;
+    }
+
+    private static String aboutText(final OptionalInt estimate) {
+        return estimate.isPresent()
+                ? "about " + formatBytes(estimate.getAsInt())
+                : "unknown";
+    }
+
+    private static String aboutText(final OptionalLong estimate) {
+        return estimate.isPresent()
+                ? "about " + formatBytes(estimate.getAsLong())
+                : "unknown";
+    }
+
+    private static void appendIndented(final StringBuilder out,
+            final String line) {
+        out.append("  ").append(line).append(LINE_SEPARATOR);
+    }
+
+    private static void appendDetail(final StringBuilder out,
+            final String line) {
+        out.append("    ").append(line).append(LINE_SEPARATOR);
+    }
+
+    private static String descriptorName(final TypeDescriptor<?> descriptor) {
+        final String simpleName = descriptor.getClass().getSimpleName();
+        if (simpleName.length() <= 48) {
+            return simpleName;
+        }
+        return simpleName.substring(0, 45) + "...";
+    }
+
+    private static String formatBytes(final long bytes) {
+        if (bytes < 1024L) {
+            return bytes + " B";
+        }
+        final String[] units = {"KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+        double value = bytes;
+        int unitIndex = -1;
+        while (value >= 1024D && unitIndex < units.length - 1) {
+            value = value / 1024D;
+            unitIndex++;
+        }
+        return String.format(Locale.ROOT, "%.2f %s", value,
+                units[unitIndex]);
+    }
+
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
@@ -10,6 +10,7 @@ import org.hestiastore.index.chunkstorecache.ChunkStoreCache;
 import org.hestiastore.index.chunkstorecache.LruChunkStoreCache;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.DataTypeDescriptorRegistry;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
@@ -56,6 +57,8 @@ public final class SegmentIndexBootstrapOperation<K, V> {
     private static final String ERROR_INDEX_NOT_FOUND = "Cannot open segment index because configuration does not exist.";
     private static final String STALE_LOCK_RECOVERY_MESSAGE = "Recovered stale index lock (.lock). Index is going to be checked "
             + "for consistency and unlocked.";
+    private static final String MEMORY_ESTIMATE_LOG_PREFIX =
+            "memory-estimate";
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(SegmentIndexBootstrapOperation.class);
@@ -134,8 +137,10 @@ public final class SegmentIndexBootstrapOperation<K, V> {
             resolveConfiguration(mode, state, configurationManager);
             resolveTypeDescriptors(state);
             writeConfiguration(state, configurationManager);
-            createExecutorRegistry(state);
             openKeyToSegmentMap(state);
+            createStartupMemoryEstimate(state);
+            logStartupMemoryEstimate(state);
+            createExecutorRegistry(state);
             createChunkStoreCache(state);
             openSegmentRegistry(state);
             openCoreStorage(state);
@@ -224,6 +229,23 @@ public final class SegmentIndexBootstrapOperation<K, V> {
             final BootstrapState<K, V> state) {
         state.setKeyToSegmentMap(new PersistentSegmentRouteMap<>(directory,
                 state.getKeyTypeDescriptor()));
+    }
+
+    private void createStartupMemoryEstimate(final BootstrapState<K, V> state) {
+        final EffectiveIndexConfiguration<K, V> configuration =
+                state.getConfiguration();
+        final int routeCount = state.getKeyToSegmentMap().getSegmentIds()
+                .size();
+        final MemoryEstimateReport memoryEstimate = IndexMemoryEstimator.estimate(
+                configuration, state.getKeyTypeDescriptor(),
+                state.getValueTypeDescriptor(), routeCount);
+        state.setStartupMemoryEstimate(memoryEstimate);
+    }
+
+    private void logStartupMemoryEstimate(final BootstrapState<K, V> state) {
+        state.getStartupMemoryEstimate().lines()
+                .forEach(line -> LOGGER.info("{} {}",
+                        MEMORY_ESTIMATE_LOG_PREFIX, line));
     }
 
     private void createChunkStoreCache(
@@ -436,6 +458,7 @@ public final class SegmentIndexBootstrapOperation<K, V> {
                 state.getRuntimeMaintenanceService(),
                 state.getRuntimeTuning(),
                 state.getRuntimeMonitoring(),
+                state.getStartupMemoryEstimate(),
                 state.getCoreStorageRuntime()));
     }
 
@@ -640,6 +663,7 @@ public final class SegmentIndexBootstrapOperation<K, V> {
         private PointOperationCoordinator<K, V> operationAccess;
         private RuntimeTuning runtimeTuning;
         private SegmentIndexRuntimeMonitoring runtimeMonitoring;
+        private MemoryEstimateReport startupMemoryEstimate;
         private SegmentIndex<K, V> index;
         private boolean closeOwnershipTransferred;
 
@@ -703,6 +727,17 @@ public final class SegmentIndexBootstrapOperation<K, V> {
 
         SegmentIndex<K, V> getIndex() {
             return requireInitialized(index, "index");
+        }
+
+        void setStartupMemoryEstimate(
+                final MemoryEstimateReport startupMemoryEstimate) {
+            this.startupMemoryEstimate = Vldtn.requireNonNull(
+                    startupMemoryEstimate, "startupMemoryEstimate");
+        }
+
+        MemoryEstimateReport getStartupMemoryEstimate() {
+            return requireInitialized(startupMemoryEstimate,
+                    "startupMemoryEstimate");
         }
 
         AtomicLong compactRequestHighWaterMark() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
@@ -6,6 +6,7 @@ import org.hestiastore.index.AbstractCloseableResource;
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentIndexMaintenance;
 import org.hestiastore.index.segmentindex.SegmentWindow;
@@ -111,6 +112,11 @@ final class SegmentIndexMdcLoggingAdapter<K, V>
     @Override
     public SegmentIndexRuntimeMonitoring runtimeMonitoring() {
         return runtimeMonitoring;
+    }
+
+    @Override
+    public MemoryEstimateReport startupMemoryEstimate() {
+        return delegate.startupMemoryEstimate();
     }
 
     @Override

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
@@ -13,6 +13,7 @@ import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
@@ -42,6 +43,7 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
     private final EffectiveIndexConfiguration<K, V> configuration;
     private final RuntimeTuning runtimeTuning;
     private final SegmentIndexRuntimeMonitoring runtimeMonitoring;
+    private final MemoryEstimateReport startupMemoryEstimate;
     private final SegmentIndexMaintenance maintenanceApi;
     private final SegmentIndexStateMachine stateMachine;
     private final SessionCloseCoordinator<K, V> closeCoordinator;
@@ -58,6 +60,7 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
      *            logging
      * @param runtimeTuning runtime tuning API view
      * @param runtimeMonitoring runtime monitoring API view
+     * @param startupMemoryEstimate startup memory estimate captured during bootstrap
      * @param maintenanceApi maintenance API view
      * @param stateMachine session lifecycle state machine
      * @param closeCoordinator ordered close sequence coordinator
@@ -69,6 +72,7 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
             final EffectiveIndexConfiguration<K, V> configuration,
             final RuntimeTuning runtimeTuning,
             final SegmentIndexRuntimeMonitoring runtimeMonitoring,
+            final MemoryEstimateReport startupMemoryEstimate,
             final SegmentIndexMaintenance maintenanceApi,
             final SegmentIndexStateMachine stateMachine,
             final SessionCloseCoordinator<K, V> closeCoordinator) {
@@ -86,6 +90,8 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
                 "runtimeTuning");
         this.runtimeMonitoring = Vldtn.requireNonNull(runtimeMonitoring,
                 "runtimeMonitoring");
+        this.startupMemoryEstimate = Vldtn.requireNonNull(startupMemoryEstimate,
+                "startupMemoryEstimate");
         this.maintenanceApi = Vldtn.requireNonNull(maintenanceApi,
                 "maintenanceApi");
         this.stateMachine = Vldtn.requireNonNull(stateMachine,
@@ -262,6 +268,12 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
     @Override
     public SegmentIndexRuntimeMonitoring runtimeMonitoring() {
         return runtimeMonitoring;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MemoryEstimateReport startupMemoryEstimate() {
+        return startupMemoryEstimate;
     }
 
     private SegmentId requireSegmentId(final SegmentId segmentId) {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssembler.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssembler.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentindex.core.session;
 
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
@@ -38,6 +39,7 @@ public final class SegmentIndexSessionAssembler {
      * @param maintenance maintenance service
      * @param runtimeTuning runtime tuning API view
      * @param runtimeMonitoring runtime monitoring API view
+     * @param startupMemoryEstimate startup memory estimate captured during bootstrap
      * @param coreStorageRuntime core storage lifecycle owner
      * @return created session index
      */
@@ -51,6 +53,7 @@ public final class SegmentIndexSessionAssembler {
             final MappedSegmentMaintenanceService<K, V> maintenance,
             final RuntimeTuning runtimeTuning,
             final SegmentIndexRuntimeMonitoring runtimeMonitoring,
+            final MemoryEstimateReport startupMemoryEstimate,
             final OpenedStorageRuntime<K, V> coreStorageRuntime) {
         final SegmentIndexRuntimeResources<K, V> initializedResources =
                 Vldtn.requireNonNull(resources, "resources");
@@ -84,6 +87,8 @@ public final class SegmentIndexSessionAssembler {
                 initializedConfiguration,
                 Vldtn.requireNonNull(runtimeTuning, "runtimeTuning"),
                 Vldtn.requireNonNull(runtimeMonitoring, "runtimeMonitoring"),
+                Vldtn.requireNonNull(startupMemoryEstimate,
+                        "startupMemoryEstimate"),
                 maintenanceApi,
                 initializedResources.stateMachine(),
                 closeCoordinator);

--- a/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorEstimatedAverageSizeTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorEstimatedAverageSizeTest.java
@@ -1,0 +1,49 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TypeDescriptorEstimatedAverageSizeTest {
+
+    @Test
+    void fixedSizeDescriptorsExposeConstantEstimates() {
+        assertEquals(1,
+                new TypeDescriptorByte().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+        assertEquals(4,
+                new TypeDescriptorInteger().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+        assertEquals(8,
+                new TypeDescriptorLong().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+        assertEquals(4,
+                new TypeDescriptorFloat().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+        assertEquals(8,
+                new TypeDescriptorDouble().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+        assertEquals(0,
+                new TypeDescriptorNull().getEstimatedAverageSizeInBytes()
+                        .orElseThrow());
+    }
+
+    @Test
+    void boundedStringDescriptorsExposeConservativeEstimates() {
+        assertEquals(128,
+                new TypeDescriptorShortString()
+                        .getEstimatedAverageSizeInBytes().orElseThrow());
+        assertEquals(12,
+                new TypeDescriptorFixedLengthString(12)
+                        .getEstimatedAverageSizeInBytes().orElseThrow());
+    }
+
+    @Test
+    void unboundedDescriptorsDoNotGuessAverageSize() {
+        assertTrue(new TypeDescriptorString()
+                .getEstimatedAverageSizeInBytes().isEmpty());
+        assertTrue(new TypeDescriptorByteArray()
+                .getEstimatedAverageSizeInBytes().isEmpty());
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/MemoryEstimateReportTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/MemoryEstimateReportTest.java
@@ -1,0 +1,68 @@
+package org.hestiastore.index.segmentindex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+
+import org.junit.jupiter.api.Test;
+
+class MemoryEstimateReportTest {
+
+    @Test
+    void linesAreDefensivelyCopiedAndImmutable() {
+        final List<String> source = new ArrayList<>();
+        source.add("first");
+        final MemoryEstimateReport report = new MemoryEstimateReport(source,
+                true, OptionalLong.of(7L));
+
+        source.add("second");
+
+        assertEquals(List.of("first"), report.lines());
+        assertThrows(UnsupportedOperationException.class,
+                () -> report.lines().add("third"));
+    }
+
+    @Test
+    void textJoinsExactLines() {
+        final MemoryEstimateReport report = new MemoryEstimateReport(
+                List.of("alpha", "beta"), true, OptionalLong.of(9L));
+
+        assertEquals("alpha" + System.lineSeparator() + "beta",
+                report.text());
+        assertEquals(report.text(), report.toString());
+    }
+
+    @Test
+    void preservesCompleteIncompleteAndZeroTotals() {
+        final MemoryEstimateReport complete = new MemoryEstimateReport(
+                List.of("complete"), true, OptionalLong.of(12L));
+        final MemoryEstimateReport incomplete = new MemoryEstimateReport(
+                List.of("incomplete"), false, OptionalLong.empty());
+        final MemoryEstimateReport zero = new MemoryEstimateReport(
+                List.of("zero"), true, OptionalLong.of(0L));
+
+        assertTrue(complete.isComplete());
+        assertEquals(12L, complete.totalEstimatedBytes().orElseThrow());
+        assertTrue(incomplete.totalEstimatedBytes().isEmpty());
+        assertTrue(zero.isComplete());
+        assertEquals(0L, zero.totalEstimatedBytes().orElseThrow());
+    }
+
+    @Test
+    void constructorRejectsNullLines() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MemoryEstimateReport(null, false,
+                        OptionalLong.empty()));
+    }
+
+    @Test
+    void constructorRejectsNullTotalEstimatedBytes() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MemoryEstimateReport(List.of("line"), false,
+                        null));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexStartupMemoryEstimateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexStartupMemoryEstimateTest.java
@@ -1,0 +1,24 @@
+package org.hestiastore.index.segmentindex;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class SegmentIndexStartupMemoryEstimateTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void defaultStartupMemoryEstimateIsIncomplete() {
+        final SegmentIndex<Integer, String> index =
+                mock(SegmentIndex.class, CALLS_REAL_METHODS);
+
+        final MemoryEstimateReport report = index.startupMemoryEstimate();
+
+        assertFalse(report.isComplete());
+        assertTrue(report.totalEstimatedBytes().isEmpty());
+        assertTrue(report.text().contains("unavailable"));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
@@ -1,0 +1,319 @@
+package org.hestiastore.index.segmentindex.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hestiastore.index.datatype.ByteArray;
+import org.hestiastore.index.datatype.NullValue;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.datatype.TypeDescriptorByteArray;
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.datatype.TypeDescriptorNull;
+import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
+import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationResolver;
+import org.junit.jupiter.api.Test;
+
+class IndexMemoryEstimatorTest {
+
+    @Test
+    void estimateCalculatesCompleteReportWithReadableInputs() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-complete",
+                        String.class, new TypeDescriptorShortString());
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("complete", estimate);
+
+        assertTrue(estimate.isComplete());
+        assertEquals(98_460L, estimate.totalEstimatedBytes().orElseThrow());
+        final String log = estimate.text();
+        assertTrue(log.contains("Estimated memory use at startup"));
+        assertTrue(log.contains("Estimated active heap: 96.15 KiB"));
+        assertTrue(log.contains(
+                "steady state: 76.92 KiB (memory expected after startup caches are loaded)"));
+        assertTrue(log.contains(
+                "temporary margin: 19.23 KiB (extra headroom for short-lived objects and snapshots)"));
+        assertLineAppearsBefore(log, "Estimated active heap: 96.15 KiB",
+                "Notes:");
+        assertLineAppearsBefore(log, "Estimated active heap: 96.15 KiB",
+                "Per-entry size assumptions:");
+        assertTrue(log.contains(
+                "Rough estimate only; not a JVM cap or measured allocation."));
+        assertTrue(log.contains("Per-entry size assumptions:"));
+        assertTrue(log.contains("entry: about 228 B (key + value + overhead)"));
+        assertTrue(log.contains(
+                "fixed per loaded/cached segment: about 16.00 KiB"));
+        assertTrue(log.contains(
+                "details: docs/operations/memory-estimate.md"));
+        assertTrue(log.contains("Largest steady-state areas:"));
+        assertTrue(log.contains(
+                "loaded segment infrastructure: 48.00 KiB"));
+        assertTrue(log.contains(
+                "scarce indexes if loaded: 15.23 KiB"));
+        assertTrue(log.contains("Configuration used for this estimate:"));
+        assertTrue(log.contains(
+                "cached segments=3, segment cache keys=10, maintenance keys=6"));
+        assertTrue(log.contains("max keys per segment=100"));
+        assertTrue(log.contains("Reported but not included:"));
+        assertTrue(log.contains(
+                "index write-buffer keys: 18"));
+        assertTrue(log.contains(
+                "chunk key limit=2, chunk-store pages=0, Bloom filter=1.00 KiB"));
+        assertTrue(log.contains(
+                "Estimated memory by area:"));
+        assertTrue(log.contains(
+                "inputs: 3 segments, 10 read keys, 6 maintenance keys, entry 228 B"));
+        assertTrue(log.contains("End memory estimate"));
+        assertFalse(log.contains("based on:"));
+        assertFalse(log.contains("reported only"));
+    }
+
+    @Test
+    void estimateIncludesChunkStoreCachePageLimit() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-chunk-cache",
+                        String.class, new TypeDescriptorShortString(), 10, 6,
+                        2, 3, 7);
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("chunk-store-cache", estimate);
+
+        assertEquals(103_010L, estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "chunk-store cache: 3.55 KiB"));
+        assertTrue(estimate.text().contains(
+                "inputs: 7 pages, 2 chunk keys, page overhead 64 B, entry 228 B"));
+    }
+
+    @Test
+    void estimateScalesCachedSegmentLimit() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-segment-limit",
+                        String.class, new TypeDescriptorShortString(), 10, 6,
+                        2, 5, 0);
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("cached-segment-limit", estimate);
+
+        assertEquals(164_100L, estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "loaded segment cache: 17.81 KiB"));
+        assertTrue(estimate.text().contains(
+                "Bloom filters if loaded: 5.00 KiB"));
+        assertTrue(estimate.text().contains(
+                "loaded segment infrastructure: 80.00 KiB"));
+    }
+
+    @Test
+    void estimateIncludesRouteCount() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-route-count",
+                        String.class, new TypeDescriptorShortString());
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 4);
+        printReport("route-count", estimate);
+
+        assertEquals(99_220L, estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "route map: 608 B"));
+        assertTrue(estimate.text().contains(
+                "inputs: 4 routes, key 4 B, segment id 16 B, tree entry 56 B"));
+    }
+
+    @Test
+    void estimateReflectsCacheKeyLimitsInSegmentCacheAndHeadroom() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-cache-limits",
+                        String.class, new TypeDescriptorShortString(), 20, 10,
+                        2, 3, 0);
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("cache-key-limits", estimate);
+
+        assertEquals(110_430L, estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "loaded segment cache: 20.04 KiB"));
+        assertTrue(estimate.text().contains(
+                "inputs: 3 segments, 20 read keys, 10 maintenance keys, entry 228 B"));
+        assertTrue(estimate.text().contains(
+                "temporary memory margin: 21.57 KiB"));
+        assertTrue(estimate.text().contains(
+                "inputs: max(25% of steady state = 86.27 KiB, one segment cache = 6.68 KiB)"));
+    }
+
+    @Test
+    void estimateFormatsGiBWhenSegmentCacheExceedsOneGiB() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-segment-cache-gib",
+                        String.class, new TypeDescriptorShortString(),
+                        500_000, 200_000, 2, 10, 0);
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("segment-cache-gib", estimate);
+
+        assertEquals(1_995_282_600L,
+                estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "Estimated active heap: 1.86 GiB"));
+        assertTrue(estimate.text().contains(
+                "steady state: 1.49 GiB (memory expected after startup caches are loaded)"));
+        assertTrue(estimate.text().contains(
+                "loaded segment cache: 1.49 GiB"));
+        assertTrue(estimate.text().contains(
+                "inputs: 10 segments, 500000 read keys, 200000 maintenance keys, entry 228 B"));
+    }
+
+    @Test
+    void estimateFormatsGiBWhenChunkStoreCacheExceedsOneGiB() {
+        final EffectiveIndexConfiguration<Integer, String> configuration =
+                effectiveConfiguration("memory-estimate-chunk-store-gib",
+                        String.class, new TypeDescriptorShortString(), 10, 6,
+                        100, 3, 50_000);
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorShortString(), 0);
+        printReport("chunk-store-gib", estimate);
+
+        assertEquals(1_429_079_350L,
+                estimate.totalEstimatedBytes().orElseThrow());
+        assertTrue(estimate.text().contains(
+                "Estimated active heap: 1.33 GiB"));
+        assertTrue(estimate.text().contains(
+                "chunk-store cache: 1.06 GiB"));
+        assertTrue(estimate.text().contains(
+                "inputs: 50000 pages, 100 chunk keys, page overhead 64 B, entry 228 B"));
+    }
+
+    @Test
+    void estimateReportsIncompleteWhenValueDescriptorSizeIsUnknown() {
+        final EffectiveIndexConfiguration<Integer, ByteArray> configuration =
+                effectiveConfiguration("memory-estimate-incomplete",
+                        ByteArray.class, new TypeDescriptorByteArray());
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorByteArray(), 3);
+        printReport("unknown-value-size", estimate);
+
+        assertFalse(estimate.isComplete());
+        assertTrue(estimate.totalEstimatedBytes().isEmpty());
+        final String log = estimate.text();
+        assertTrue(log.contains("value: TypeDescriptorByteArray, unknown"));
+        assertTrue(log.contains(
+                "loaded segment cache: unavailable"));
+        assertTrue(log.contains(
+                "reason: needs key and value descriptor estimates"));
+        assertTrue(log.contains("Bloom filters if loaded"));
+        assertTrue(log.contains("Estimated active heap: unavailable"));
+    }
+
+    @Test
+    void estimateTreatsZeroValueSizeAsRealEstimate() {
+        final EffectiveIndexConfiguration<Integer, NullValue> configuration =
+                effectiveConfiguration("memory-estimate-zero",
+                        NullValue.class, new TypeDescriptorNull());
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorInteger(),
+                new TypeDescriptorNull(), 1);
+        printReport("zero-value-size", estimate);
+
+        assertTrue(estimate.isComplete());
+        assertTrue(estimate.totalEstimatedBytes().isPresent());
+        assertTrue(estimate.text().contains(
+                "entry: about 100 B (key + value + overhead)"));
+    }
+
+    private static <V> EffectiveIndexConfiguration<Integer, V> effectiveConfiguration(
+            final String name, final Class<V> valueClass,
+            final TypeDescriptor<V> valueTypeDescriptor) {
+        return effectiveConfiguration(name, valueClass, valueTypeDescriptor,
+                10, 6, 2, 3, 0);
+    }
+
+    private static <V> EffectiveIndexConfiguration<Integer, V> effectiveConfiguration(
+            final String name, final Class<V> valueClass,
+            final TypeDescriptor<V> valueTypeDescriptor,
+            final int cacheKeyLimit,
+            final int maintenanceWriteCacheKeyLimit,
+            final int chunkKeyLimit,
+            final int cachedSegmentLimit,
+            final int chunkStorePageLimit) {
+        return EffectiveIndexConfigurationResolver.resolveForCreate(
+                IndexConfiguration.<Integer, V>builder()
+                        .identity(identity -> identity.keyClass(Integer.class))
+                        .identity(identity -> identity.valueClass(valueClass))
+                        .identity(identity -> identity.keyTypeDescriptor(
+                                new TypeDescriptorInteger()))
+                        .identity(identity -> identity
+                                .valueTypeDescriptor(valueTypeDescriptor))
+                        .identity(identity -> identity.name(name))
+                        .segment(segment -> segment
+                                .cacheKeyLimit(cacheKeyLimit))
+                        .writePath(writePath -> writePath
+                                .segmentWriteCacheKeyLimit(5))
+                        .writePath(writePath -> writePath
+                                .maintenanceWriteCacheKeyLimit(
+                                        maintenanceWriteCacheKeyLimit))
+                        .segment(segment -> segment.maxKeys(100))
+                        .segment(segment -> segment
+                                .chunkKeyLimit(chunkKeyLimit))
+                        .segment(segment -> segment
+                                .cachedSegmentLimit(cachedSegmentLimit))
+                        .bloomFilter(bloomFilter -> bloomFilter
+                                .hashFunctions(1))
+                        .bloomFilter(bloomFilter -> bloomFilter
+                                .indexSizeBytes(1024))
+                        .bloomFilter(bloomFilter -> bloomFilter
+                                .falsePositiveProbability(0.01D))
+                        .chunkStoreCache(cache -> cache
+                                .pageLimit(chunkStorePageLimit))
+                        .build());
+    }
+
+    private static void printReport(final String scenario,
+            final MemoryEstimateReport report) {
+        System.out.println();
+        System.out.println("==== memory estimate report: " + scenario
+                + " ====");
+        System.out.println(report.text());
+        System.out.println("==== end memory estimate report: " + scenario
+                + " ====");
+        assertReadableLineLengths(report);
+        assertFalse(report.text().contains(" bytes"));
+    }
+
+    private static void assertReadableLineLengths(
+            final MemoryEstimateReport report) {
+        report.lines().forEach(line -> assertTrue(line.length() <= 100,
+                () -> "Report line is too long: " + line));
+    }
+
+    private static void assertLineAppearsBefore(final String log,
+            final String earlier, final String later) {
+        final int earlierIndex = log.indexOf(earlier);
+        final int laterIndex = log.indexOf(later);
+
+        assertTrue(earlierIndex >= 0, () -> "Missing line: " + earlier);
+        assertTrue(laterIndex >= 0, () -> "Missing line: " + later);
+        assertTrue(earlierIndex < laterIndex,
+                () -> earlier + " should appear before " + later);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
@@ -7,11 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.chunkstore.ChunkData;
 import org.hestiastore.index.chunkstore.ChunkFilter;
@@ -20,10 +29,13 @@ import org.hestiastore.index.chunkstore.ChunkFilterProvider;
 import org.hestiastore.index.chunkstore.ChunkFilterProviderResolver;
 import org.hestiastore.index.chunkstore.ChunkFilterProviderResolverImpl;
 import org.hestiastore.index.chunkstore.ChunkFilterSpec;
+import org.hestiastore.index.datatype.ByteArray;
+import org.hestiastore.index.datatype.TypeDescriptorByteArray;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.properties.IndexPropertiesSchema;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.persistence.IndexConfigurationStore;
 import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
@@ -134,6 +146,9 @@ class SegmentIndexBootstrapOperationTest {
 
         try {
             assertInstanceOf(SegmentIndexMdcLoggingAdapter.class, index);
+            assertTrue(index.startupMemoryEstimate().isComplete());
+            assertTrue(index.startupMemoryEstimate().text().contains(
+                    "Estimated active heap:"));
         } finally {
             index.close();
         }
@@ -168,6 +183,9 @@ class SegmentIndexBootstrapOperationTest {
                     new IndexConfigurationStore<Integer, String>(directory)
                             .load()
                             .maintenance().registryLifecycleThreads());
+            assertTrue(index.startupMemoryEstimate().isComplete());
+            assertTrue(index.startupMemoryEstimate().text().contains(
+                    "Estimated active heap:"));
         } finally {
             index.close();
         }
@@ -233,18 +251,94 @@ class SegmentIndexBootstrapOperationTest {
     }
 
     @Test
+    void createLogsStartupMemoryEstimate() {
+        final TestLogAppender appender = TestLogAppender.attachToLogger(
+                SegmentIndexBootstrapOperation.class.getName(), Level.INFO);
+
+        try {
+            final SegmentIndex<Integer, String> index = operation(
+                    new MemDirectory(),
+                    buildConf("bootstrap-operation-memory-estimate", false))
+                    .create();
+            try {
+                final List<String> loggedReportLines = appender
+                        .messagesStartingWith("memory-estimate ")
+                        .stream()
+                        .map(message -> message
+                                .substring("memory-estimate ".length()))
+                        .toList();
+
+                assertEquals(index.startupMemoryEstimate().lines(),
+                        loggedReportLines);
+                printReport("bootstrap-complete",
+                        index.startupMemoryEstimate());
+                assertTrue(appender.countMessageStartingWith(
+                        "memory-estimate ") > 1);
+                assertTrue(index.startupMemoryEstimate().isComplete());
+            } finally {
+                index.close();
+            }
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
+    void createLogsIncompleteStartupMemoryEstimateForUnknownValueSize() {
+        final TestLogAppender appender = TestLogAppender.attachToLogger(
+                SegmentIndexBootstrapOperation.class.getName(), Level.INFO);
+
+        try {
+            final SegmentIndex<Integer, ByteArray> index =
+                    new SegmentIndexBootstrapOperation<Integer, ByteArray>(
+                            new MemDirectory(),
+                            buildUnknownValueSizeConf(
+                                    "bootstrap-operation-memory-incomplete"),
+                            null, runtimeHandle()).create();
+            printReport("bootstrap-incomplete",
+                    index.startupMemoryEstimate());
+            index.close();
+
+            final List<String> loggedReportLines = appender
+                    .messagesStartingWith("memory-estimate ")
+                    .stream()
+                    .map(message -> message
+                            .substring("memory-estimate ".length()))
+                    .toList();
+
+            assertEquals(index.startupMemoryEstimate().lines(),
+                    loggedReportLines);
+            assertTrue(appender.countMessageStartingWith("memory-estimate ")
+                    > 1);
+            assertFalse(index.startupMemoryEstimate().isComplete());
+            assertTrue(index.startupMemoryEstimate()
+                    .totalEstimatedBytes().isEmpty());
+        } finally {
+            appender.detach();
+        }
+    }
+
+    @Test
     void tryOpenReturnsEmptyWithoutConfigurationAndDoesNotAcquireLock() {
         final MemDirectory directory = new MemDirectory();
+        final TestLogAppender appender = TestLogAppender.attachToLogger(
+                SegmentIndexBootstrapOperation.class.getName(), Level.INFO);
 
-        final Optional<SegmentIndex<Integer, String>> index =
-                operation(directory,
-                        buildConf("bootstrap-operation-try-open-empty",
-                                false))
-                        .tryOpen();
+        try {
+            final Optional<SegmentIndex<Integer, String>> index =
+                    operation(directory,
+                            buildConf("bootstrap-operation-try-open-empty",
+                                    false))
+                            .tryOpen();
 
-        assertTrue(index.isEmpty());
-        assertFalse(directory.isFileExists(LOCK_FILE_NAME));
-        assertFalse(directory.isFileExists(CONFIGURATION_FILE_NAME));
+            assertTrue(index.isEmpty());
+            assertFalse(directory.isFileExists(LOCK_FILE_NAME));
+            assertFalse(directory.isFileExists(CONFIGURATION_FILE_NAME));
+            assertEquals(0,
+                    appender.countMessageStartingWith("memory-estimate "));
+        } finally {
+            appender.detach();
+        }
     }
 
     @Test
@@ -260,7 +354,12 @@ class SegmentIndexBootstrapOperationTest {
                         .tryOpen();
 
         assertTrue(index.isPresent());
-        index.get().close();
+        try {
+            assertTrue(index.get().startupMemoryEstimate()
+                    .isComplete());
+        } finally {
+            index.get().close();
+        }
     }
 
     private static SegmentIndexBootstrapOperation<Integer, String> operation(
@@ -435,6 +534,40 @@ class SegmentIndexBootstrapOperationTest {
                 .build();
     }
 
+    private static IndexConfiguration<Integer, ByteArray> buildUnknownValueSizeConf(
+            final String indexName) {
+        return IndexConfiguration.<Integer, ByteArray>builder()
+                .identity(identity -> identity.keyClass(Integer.class))
+                .identity(identity -> identity.valueClass(ByteArray.class))
+                .identity(identity -> identity
+                        .keyTypeDescriptor(new TypeDescriptorInteger()))
+                .identity(identity -> identity
+                        .valueTypeDescriptor(new TypeDescriptorByteArray()))
+                .identity(identity -> identity.name(indexName))
+                .logging(logging -> logging.contextEnabled(false))
+                .segment(segment -> segment.cacheKeyLimit(10))
+                .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(5))
+                .writePath(writePath -> writePath
+                        .maintenanceWriteCacheKeyLimit(6))
+                .segment(segment -> segment.chunkKeyLimit(2))
+                .segment(segment -> segment.maxKeys(100))
+                .segment(segment -> segment.cachedSegmentLimit(3))
+                .bloomFilter(bloomFilter -> bloomFilter.hashFunctions(1))
+                .bloomFilter(bloomFilter -> bloomFilter.indexSizeBytes(1024))
+                .bloomFilter(bloomFilter -> bloomFilter
+                        .falsePositiveProbability(0.01D))
+                .io(io -> io.diskBufferSizeBytes(1024))
+                .maintenance(maintenance -> maintenance
+                        .backgroundAutoEnabled(false))
+                .maintenance(maintenance -> maintenance
+                        .registryLifecycleThreads(1))
+                .filters(filters -> filters.encodingFilters(
+                        List.of(new ChunkFilterDoNothing())))
+                .filters(filters -> filters.decodingFilters(
+                        List.of(new ChunkFilterDoNothing())))
+                .build();
+    }
+
     private static final class BootstrapChunkFilterProvider
             implements ChunkFilterProvider {
 
@@ -471,5 +604,93 @@ class SegmentIndexBootstrapOperationTest {
         public Stream<String> getFileNames() {
             throw new IndexException("File names unavailable.");
         }
+    }
+
+    private static final class TestLogAppender extends AbstractAppender {
+
+        private final LoggerContext loggerContext;
+        private final String loggerConfigName;
+        private final List<String> messages = Collections
+                .synchronizedList(new ArrayList<>());
+
+        private TestLogAppender(final String name,
+                final LoggerContext loggerContext,
+                final String loggerConfigName) {
+            super(name, null, null, false, null);
+            this.loggerContext = loggerContext;
+            this.loggerConfigName = loggerConfigName;
+        }
+
+        static TestLogAppender attachToLogger(final String loggerName,
+                final Level level) {
+            final LoggerContext context = (LoggerContext) LogManager
+                    .getContext(false);
+            final Configuration configuration = context.getConfiguration();
+            final LoggerConfig loggerConfig = configuration
+                    .getLoggerConfig(loggerName);
+            final String appenderName = "test-appender-"
+                    + System.nanoTime();
+            final TestLogAppender appender = new TestLogAppender(appenderName,
+                    context, loggerConfig.getName());
+            appender.start();
+            loggerConfig.addAppender(appender, level, null);
+            context.updateLoggers();
+            return appender;
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+
+        String messages() {
+            synchronized (messages) {
+                return String.join("\n", messages);
+            }
+        }
+
+        long countMessageStartingWith(final String prefix) {
+            synchronized (messages) {
+                return messages.stream()
+                        .filter(message -> message.startsWith(prefix))
+                        .count();
+            }
+        }
+
+        List<String> messagesStartingWith(final String prefix) {
+            synchronized (messages) {
+                return messages.stream()
+                        .filter(message -> message.startsWith(prefix))
+                        .toList();
+            }
+        }
+
+        void detach() {
+            final Configuration configuration = loggerContext
+                    .getConfiguration();
+            final LoggerConfig loggerConfig = configuration
+                    .getLoggerConfig(loggerConfigName);
+            loggerConfig.removeAppender(getName());
+            stop();
+            loggerContext.updateLoggers();
+        }
+    }
+
+    private static void printReport(final String scenario,
+            final MemoryEstimateReport report) {
+        System.out.println();
+        System.out.println("==== memory estimate report: " + scenario
+                + " ====");
+        System.out.println(report.text());
+        System.out.println("==== end memory estimate report: " + scenario
+                + " ====");
+        assertReadableLineLengths(report);
+        assertFalse(report.text().contains(" bytes"));
+    }
+
+    private static void assertReadableLineLengths(
+            final MemoryEstimateReport report) {
+        report.lines().forEach(line -> assertTrue(line.length() <= 100,
+                () -> "Report line is too long: " + line));
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssemblerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionAssemblerTest.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.segmentindex.core.session;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -7,11 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
+import java.util.OptionalLong;
 
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
@@ -43,6 +46,7 @@ class SegmentIndexSessionAssemblerTest {
                         mockMaintenanceService(),
                         mock(RuntimeTuning.class),
                         mock(SegmentIndexRuntimeMonitoring.class),
+                        startupMemoryEstimate(),
                         newCoreStorageRuntime()));
     }
 
@@ -61,6 +65,7 @@ class SegmentIndexSessionAssemblerTest {
                         mockMaintenanceService(),
                         mock(RuntimeTuning.class),
                         mock(SegmentIndexRuntimeMonitoring.class),
+                        startupMemoryEstimate(),
                         newCoreStorageRuntime()));
     }
 
@@ -78,6 +83,7 @@ class SegmentIndexSessionAssemblerTest {
                         mockMaintenanceService(),
                         mock(RuntimeTuning.class),
                         mock(SegmentIndexRuntimeMonitoring.class),
+                        startupMemoryEstimate(),
                         newCoreStorageRuntime()));
     }
 
@@ -96,6 +102,27 @@ class SegmentIndexSessionAssemblerTest {
                         mockMaintenanceService(),
                         mock(RuntimeTuning.class),
                         mock(SegmentIndexRuntimeMonitoring.class),
+                        startupMemoryEstimate(),
+                        newCoreStorageRuntime()));
+    }
+
+    @Test
+    void createIndex_rejectsNullStartupMemoryEstimate() {
+        final TypeDescriptorInteger keyDescriptor = new TypeDescriptorInteger();
+        final SegmentIndexRuntimeResources<Integer, String> resources =
+                initializedResources();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> SegmentIndexSessionAssembler.createIndex(resources,
+                        effectiveConfiguration("factory-null-report"),
+                        keyDescriptor,
+                        mockOperationAccess(),
+                        mockSplitService(),
+                        mockStreamingService(),
+                        mockMaintenanceService(),
+                        mock(RuntimeTuning.class),
+                        mock(SegmentIndexRuntimeMonitoring.class),
+                        null,
                         newCoreStorageRuntime()));
     }
 
@@ -106,6 +133,7 @@ class SegmentIndexSessionAssemblerTest {
                 initializedResources();
         final RuntimeTuning runtimeTuning = mock(RuntimeTuning.class);
         final SegmentIndexRuntimeMonitoring runtimeMonitoring = mock(SegmentIndexRuntimeMonitoring.class);
+        final MemoryEstimateReport startupMemoryEstimate = startupMemoryEstimate();
 
         final SegmentIndex<Integer, String> index = SegmentIndexSessionAssembler.createIndex(resources,
                 effectiveConfiguration("factory-create-index"),
@@ -116,6 +144,7 @@ class SegmentIndexSessionAssemblerTest {
                 mockMaintenanceService(),
                 runtimeTuning,
                 runtimeMonitoring,
+                startupMemoryEstimate,
                 newCoreStorageRuntime());
 
         assertInstanceOf(SegmentIndexSession.class, index);
@@ -124,6 +153,10 @@ class SegmentIndexSessionAssemblerTest {
                 implementation.stateMachine());
         assertSame(runtimeTuning, implementation.runtimeTuning());
         assertSame(runtimeMonitoring, implementation.runtimeMonitoring());
+        assertSame(startupMemoryEstimate,
+                implementation.startupMemoryEstimate());
+        assertEquals("line",
+                implementation.startupMemoryEstimate().lines().get(0));
     }
 
     private SegmentIndexRuntimeResources<Integer, String> initializedResources() {
@@ -137,6 +170,11 @@ class SegmentIndexSessionAssemblerTest {
     private EffectiveIndexConfiguration<Integer, String> effectiveConfiguration(
             final String indexName) {
         return effective(configuration(indexName));
+    }
+
+    private MemoryEstimateReport startupMemoryEstimate() {
+        return new MemoryEstimateReport(List.of("line"), true,
+                OptionalLong.of(12L));
     }
 
     private IndexConfiguration<Integer, String> configuration(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -18,6 +19,7 @@ import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
 import org.hestiastore.index.segment.SegmentIteratorIsolation;
+import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.SegmentIndex;
 import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
@@ -99,6 +101,8 @@ class SegmentIndexSessionTest {
                 closeCalls);
 
         final RecordingIndex streamingIndex = new RecordingIndex(iterator);
+        assertEquals("test-startup-report",
+                streamingIndex.startupMemoryEstimate().text());
         try (Stream<Entry<Integer, String>> stream = streamingIndex.getStream(
                 SegmentWindow.unbounded(),
                 SegmentIteratorIsolation.FULL_ISOLATION)) {
@@ -221,6 +225,7 @@ class SegmentIndexSessionTest {
                     mockOperationAccess(), mockStreamingService(),
                     recordingConfiguration(), mock(RuntimeTuning.class),
                     mock(SegmentIndexRuntimeMonitoring.class),
+                    SegmentIndexSessionTest.startupMemoryEstimate(),
                     mock(SegmentIndexMaintenance.class),
                     stateMachine, mockCloseCoordinator());
             this.iterator = iterator;
@@ -243,6 +248,11 @@ class SegmentIndexSessionTest {
             // no-op test index
         }
 
+    }
+
+    private static MemoryEstimateReport startupMemoryEstimate() {
+        return new MemoryEstimateReport(List.of("test-startup-report"), true,
+                OptionalLong.of(1L));
     }
 
     private static final class CountingIterator<K, V>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
         - Overview: operations/index.md
         - WAL: operations/wal.md
         - Monitoring: operations/monitoring.md
+        - Startup Memory Estimate: operations/memory-estimate.md
         - Performance Tuning: operations/tuning.md
         - Backup & Restore: operations/backup-restore.md
         - Export & Import: operations/export-import.md


### PR DESCRIPTION
## Summary
- add descriptor average-size estimates for built-in type descriptors
- log a startup memory-estimate report and expose it through SegmentIndex.startupMemoryEstimate()
- document the memory estimate report and cover complete/incomplete report cases

## Tests
- mvn clean verify