### PR TITLE
Avoid segment cache capacity lock on hot writes

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
+++ b/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
@@ -67,13 +67,25 @@ public class UniqueCache<K, V> {
      * When there is old value than old value is rewritten.
      */
     public void put(final Entry<K, V> entry) {
+        putAndReportNewKey(entry);
+    }
+
+    /**
+     * Stores an entry and reports whether it added a previously absent key.
+     *
+     * @param entry entry to store
+     * @return true when the key was not present before this write
+     */
+    public boolean putAndReportNewKey(final Entry<K, V> entry) {
         Vldtn.requireNonNull(entry, "entry");
         final K key = Vldtn.requireNonNull(entry.getKey(), "entry.key");
         final V value = Vldtn.requireNonNull(entry.getValue(), "entry.value");
         final V previous = map.put(key, value);
         if (previous == null) {
             size.incrementAndGet();
+            return true;
         }
+        return false;
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
@@ -30,6 +30,7 @@ final class SegmentCache<K, V> {
     private final TypeDescriptor<V> valueTypeDescriptor;
     private final AtomicInteger maxNumberOfKeysInSegmentWriteCache;
     private final AtomicInteger maxNumberOfKeysInSegmentWriteCacheDuringMaintenance;
+    private final AtomicInteger bufferedWriteKeys = new AtomicInteger();
     private static final int MAX_INITIAL_CAPACITY = 1_000_000;
     private final ReentrantLock capacityLock = new ReentrantLock();
     private final Condition capacityAvailable = capacityLock.newCondition();
@@ -84,8 +85,12 @@ final class SegmentCache<K, V> {
      * @param entry entry to cache
      */
     public void putToWriteCache(final Entry<K, V> entry) {
-        awaitCapacity();
-        writeCache.put(Vldtn.requireNonNull(entry, ENTRY_ARG));
+        final Entry<K, V> nonNullEntry = validateEntry(entry);
+        if (tryPutExistingWriteKey(nonNullEntry)) {
+            return;
+        }
+        reserveWriteSlot();
+        putReservedEntry(nonNullEntry);
     }
 
     /**
@@ -95,16 +100,15 @@ final class SegmentCache<K, V> {
      * @return true when the entry was accepted
      */
     boolean tryPutToWriteCacheWithoutWaiting(final Entry<K, V> entry) {
-        capacityLock.lock();
-        try {
-            if (currentBufferedKeys() >= effectiveWriteCacheLimit()) {
-                return false;
-            }
-            writeCache.put(Vldtn.requireNonNull(entry, ENTRY_ARG));
+        final Entry<K, V> nonNullEntry = validateEntry(entry);
+        if (tryPutExistingWriteKey(nonNullEntry)) {
             return true;
-        } finally {
-            capacityLock.unlock();
         }
+        if (!tryReserveWriteSlot()) {
+            return false;
+        }
+        putReservedEntry(nonNullEntry);
+        return true;
     }
 
     /**
@@ -189,6 +193,7 @@ final class SegmentCache<K, V> {
             frozen.clear();
             frozenWriteCache = null;
         }
+        bufferedWriteKeys.set(0);
         signalCapacityAvailable();
     }
 
@@ -199,10 +204,11 @@ final class SegmentCache<K, V> {
         deltaCache.clear();
         final UniqueCache<K, V> frozen = frozenWriteCache;
         if (frozen != null) {
+            final int frozenSize = frozen.size();
             frozen.clear();
             frozenWriteCache = null;
+            releaseWriteSlots(frozenSize);
         }
-        signalCapacityAvailable();
     }
 
     /**
@@ -308,10 +314,11 @@ final class SegmentCache<K, V> {
             signalCapacityAvailable();
             return;
         }
+        final int frozenSize = frozen.size();
         frozen.forEachEntry((key, value) -> deltaCache.put(Entry.of(key, value)));
         frozen.clear();
         frozenWriteCache = null;
-        signalCapacityAvailable();
+        releaseWriteSlots(frozenSize);
     }
 
     /**
@@ -339,17 +346,56 @@ final class SegmentCache<K, V> {
      * @return total buffered write keys
      */
     private int currentBufferedKeys() {
-        final UniqueCache<K, V> frozen = frozenWriteCache;
-        return writeCache.size() + sizeOf(frozen);
+        return bufferedWriteKeys.get();
     }
 
     /**
-     * Blocks until there is capacity for another write-cache entry.
+     * Reserves capacity for another write-cache entry.
+     */
+    private void reserveWriteSlot() {
+        while (!tryReserveWriteSlot()) {
+            awaitCapacity();
+        }
+    }
+
+    private boolean tryReserveWriteSlot() {
+        while (true) {
+            final int current = currentBufferedKeys();
+            if (current >= effectiveWriteCacheLimit()) {
+                return false;
+            }
+            if (bufferedWriteKeys.compareAndSet(current, current + 1)) {
+                return true;
+            }
+        }
+    }
+
+    private void putReservedEntry(final Entry<K, V> entry) {
+        final boolean added;
+        try {
+            added = writeCache.putAndReportNewKey(entry);
+        } catch (final RuntimeException e) {
+            releaseWriteSlots(1);
+            throw e;
+        }
+        if (!added) {
+            releaseWriteSlots(1);
+        }
+    }
+
+    private boolean tryPutExistingWriteKey(final Entry<K, V> entry) {
+        final UniqueCache<K, V> write = writeCache;
+        if (write.get(entry.getKey()) == null) {
+            return false;
+        }
+        write.putAndReportNewKey(entry);
+        return true;
+    }
+
+    /**
+     * Blocks until there may be capacity for another write-cache entry.
      */
     private void awaitCapacity() {
-        if (maxNumberOfKeysInSegmentWriteCache.get() <= 0) {
-            return;
-        }
         capacityLock.lock();
         try {
             while (currentBufferedKeys() >= effectiveWriteCacheLimit()) {
@@ -361,6 +407,16 @@ final class SegmentCache<K, V> {
                     "Interrupted while waiting for write cache capacity", ex);
         } finally {
             capacityLock.unlock();
+        }
+    }
+
+    private void releaseWriteSlots(final int slots) {
+        if (slots <= 0) {
+            return;
+        }
+        final int previous = bufferedWriteKeys.getAndAdd(-slots);
+        if (previous >= effectiveWriteCacheLimit()) {
+            signalCapacityAvailable();
         }
     }
 
@@ -540,6 +596,10 @@ final class SegmentCache<K, V> {
                 .withInitialCapacity(capacityHint)//
                 .withThreadSafe(true)//
                 .buildEmpty();
+    }
+
+    private Entry<K, V> validateEntry(final Entry<K, V> entry) {
+        return Vldtn.requireNonNull(entry, ENTRY_ARG);
     }
 
     /**

--- a/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
@@ -97,6 +97,15 @@ class UniqueCacheTest {
     }
 
     @Test
+    void putAndReportNewKey_reports_when_key_is_new() {
+        assertTrue(cache.putAndReportNewKey(Entry.of(10, "hello")));
+        assertFalse(cache.putAndReportNewKey(Entry.of(10, "dear")));
+
+        assertEquals(1, cache.size());
+        assertEquals("dear", cache.get(10));
+    }
+
+    @Test
     void test_constructor_null_comparator_throws() {
         final Exception e = assertThrows(IllegalArgumentException.class,
                 this::buildWithNullComparator);

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentCacheTest.java
@@ -9,7 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.hestiastore.index.Entry;
@@ -331,6 +334,110 @@ class SegmentCacheTest {
 
         assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(4, "D")));
         assertFalse(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(5, "E")));
+    }
+
+    @Test
+    void tryPut_overwrite_does_not_consume_capacity() {
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), 2, 3, 1024);
+
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(1, "A")));
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(2, "C")));
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(1, "B")));
+        assertFalse(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(3, "D")));
+
+        assertEquals(2, cache.getNumberOfKeysInWriteCache());
+        assertEquals("B", cache.get(1));
+    }
+
+    @Test
+    void put_overwrite_does_not_block_at_capacity() throws Exception {
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), 1, 2, 1024);
+        cache.putToWriteCache(Entry.of(1, "A"));
+
+        CompletableFuture.runAsync(() -> cache.putToWriteCache(Entry.of(1, "B")))
+                .get(1, TimeUnit.SECONDS);
+
+        assertEquals(1, cache.getNumberOfKeysInWriteCache());
+        assertEquals("B", cache.get(1));
+    }
+
+    @Test
+    void mergeFrozenWriteCacheToDeltaCache_releases_reserved_capacity() {
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), 2, 3, 1024);
+        cache.putToWriteCache(Entry.of(1, "A"));
+        cache.putToWriteCache(Entry.of(2, "B"));
+        cache.freezeWriteCache();
+
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(3, "C")));
+        assertFalse(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(4, "D")));
+
+        cache.mergeFrozenWriteCacheToDeltaCache();
+
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(4, "D")));
+        assertFalse(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(5, "E")));
+        assertEquals(2, cache.getNumberOfKeysInWriteCache());
+        assertEquals(4, cache.size());
+    }
+
+    @Test
+    void evictAll_releases_reserved_capacity() {
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), 2, 3, 1024);
+        cache.putToWriteCache(Entry.of(1, "A"));
+        cache.putToWriteCache(Entry.of(2, "B"));
+        assertFalse(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(3, "C")));
+
+        cache.evictAll();
+
+        assertTrue(cache.tryPutToWriteCacheWithoutWaiting(Entry.of(3, "C")));
+        assertEquals(1, cache.getNumberOfKeysInWriteCache());
+        assertEquals("C", cache.get(3));
+    }
+
+    @Test
+    void tryPut_concurrent_unique_writes_stop_at_limit() throws Exception {
+        final int limit = 32;
+        final int threads = 16;
+        final int writesPerThread = 8;
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), limit, limit + 1,
+                1024);
+        final CountDownLatch ready = new CountDownLatch(threads);
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final AtomicInteger accepted = new AtomicInteger();
+        final ExecutorService executor = Executors.newFixedThreadPool(threads);
+        final CompletableFuture<?>[] tasks = new CompletableFuture<?>[threads];
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                final int workerId = i;
+                tasks[i] = CompletableFuture.runAsync(() -> {
+                    ready.countDown();
+                    awaitStart(startGate);
+                    final int baseKey = workerId * writesPerThread;
+                    for (int key = baseKey; key < baseKey
+                            + writesPerThread; key++) {
+                        if (cache.tryPutToWriteCacheWithoutWaiting(
+                                Entry.of(key, "V" + key))) {
+                            accepted.incrementAndGet();
+                        }
+                    }
+                }, executor);
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            startGate.countDown();
+            CompletableFuture.allOf(tasks).get(10, TimeUnit.SECONDS);
+        } finally {
+            startGate.countDown();
+            executor.shutdownNow();
+        }
+
+        assertEquals(limit, accepted.get());
+        assertEquals(limit, cache.getNumberOfKeysInWriteCache());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace the per-write SegmentCache capacity lock path with atomic buffered-key reservation
- allow active write-cache overwrites without consuming reservation capacity
- add focused tests for overwrite, eviction, frozen-cache merge, and concurrent admission behavior

## Benchmark
Command used before and after:

```bash
java -jar benchmarks/target/benchmarks-0.0.7-SNAPSHOT.jar 'SegmentIndexHotRoutePutBenchmark.*' -wi 3 -i 5 -f 2 -w 1s -r 1s
```

Results:
- `putHotRoute`: `750,910 ± 200,247 ops/s` -> `808,455 ± 274,524 ops/s` (`+7.7%`, noisy)
- `putThenGetHotRoute`: `483,756 ± 133,752 ops/s` -> `466,333 ± 103,973 ops/s` (`-3.6%`, noisy)

The confidence intervals overlap heavily, so this is not a proven benchmark win from this run alone.

## Tests
- `mvn -pl engine -Dtest=UniqueCacheTest,SegmentCacheTest,SegmentImplConcurrencyContractTest test`
- `mvn clean verify`

Note: this PR intentionally excludes unrelated split/WAL work that was already staged in the worktree.