### PR TITLE
Refine index memory estimate report

### DIFF
--- a/docs/operations/memory-estimate.md
+++ b/docs/operations/memory-estimate.md
@@ -8,44 +8,60 @@ owner: engine
 # Startup Memory Estimate
 
 HestiaStore logs a rough startup memory estimate after the effective
-`SegmentIndex` configuration is resolved. The report estimates active heap
-pressure from configuration values; it is not a JVM heap cap and it is not a
-measurement of allocated objects.
+`SegmentIndex` configuration is resolved. The report estimates memory pressure
+from configuration values; it is not a memory cap and it is not a measurement
+of allocated objects.
 
 The estimate is meant to explain why the configured index may need memory. Use
 it as a sizing hint, then verify real usage with JVM and application monitoring.
 
 ## How to read the report
 
-The report puts the final estimate first:
+The report puts the final estimate first and then expands the calculated areas:
 
-- `Estimated active heap`: steady-state memory plus the temporary margin.
-- `steady state`: memory expected after startup caches are loaded.
-- `temporary margin`: extra headroom for short-lived objects and snapshots.
+- `Total index memory`: all segments, chunk-store page cache, and maintenance
+  overhead.
+- `All segments`: cached segment memory plus the segment routing map.
+- `One cached segment`: per-segment memory blocks that are multiplied by the
+  configured segment cache slots.
+- `Delta cache`: configured maximum number of keys in the cache multiplied by
+  the estimated key/value entry.
+- `Chunk-store page cache`: cached chunk-store pages and their key/value
+  entries.
+- `Maintenance overhead`: temporary headroom for short-lived objects,
+  maintenance work, and snapshots.
+- `Key/value entry`: key size, value size, and fixed per-entry overhead
+  used by key/value cache estimates.
+- `Key/position entry`: key size, integer position size, and fixed per-entry
+  overhead used by scarce-index estimates.
+- `Formula constants`: fixed constants used by the estimator. This section is
+  shown for transparency and is not added separately to the total.
+- `Other requirements`: related settings reported for context but not included
+  in the total.
 
-The `Largest steady-state areas` section shows the biggest calculated areas in
-descending order. The `Estimated memory by area` section keeps the detailed
-inputs for each area.
-
-Configuration values that are useful context but do not change the estimate are
-listed under `Reported but not included`. Conditional areas use `if loaded` in
-their labels because those structures are loaded lazily; the estimate shows
-their active-heap cost when loaded.
+The tree keeps each detail line aligned under the value it explains. Area
+branches such as `All segments`, `One cached segment`, `Segment routing map`,
+and `Chunk-store page cache` show their configuration inputs below the memory
+area they affect. `Bloom filter` and `Scarce index` are shown as per-segment
+areas when they can contribute to loaded segment memory. `Scarce index` groups
+the maximum sparse-entry count calculation and the reused `Key/position entry`.
 
 ## What the report uses
 
 The estimator combines resolved configuration, descriptor size estimates, and a
 small set of fixed assumptions:
 
-- `entry overhead`: applied per cached key/value entry.
-- `page overhead`: applied per chunk-store cache page.
-- `tree map entry`: applied per route-map tree entry.
-- `segment id`: applied when estimating route-map entries.
-- `scarce index position`: applied per scarce-index entry.
+- `fixed per-entry overhead`: applied when estimating key/value entries and
+  key/position entries.
+- `page overhead`: applied per chunk-store page-cache page.
+- `segment id`: applied with key size when estimating key/segment-id route-map
+  entries.
+- `scarce index position`: integer position stored with each scarce-index key.
 - `fixed per loaded/cached segment`: applied once for each loaded or cached
   segment.
-- `temporary margin`: extra space above steady state, calculated as the
-  larger of a percentage of steady state or one loaded segment cache.
+- `maintenance overhead`: extra space above memory before maintenance,
+  calculated as the larger of a percentage of memory before maintenance or one
+  delta cache.
 
 These assumptions are deliberately visible because they are not exact JVM
 object-layout measurements. They are stable estimator constants used to make
@@ -55,7 +71,7 @@ the report understandable and repeatable.
 
 If a key or value `TypeDescriptor` cannot provide
 `getEstimatedAverageSizeInBytes()`, HestiaStore still starts normally. The
-report marks dependent line items as unavailable and still shows independent
+report marks dependent line items as `unknown` and still shows independent
 items such as Bloom filters and fixed segment infrastructure.
 
 ## Related docs

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
@@ -1,9 +1,6 @@
 package org.hestiastore.index.segmentindex.core.session;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
@@ -13,25 +10,19 @@ import org.hestiastore.index.segmentindex.MemoryEstimateReport;
 import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
 
 /**
- * Builds a rough heap-pressure estimate from resolved startup configuration.
+ * Builds a rough memory-pressure estimate from resolved startup configuration.
  */
 final class IndexMemoryEstimator {
 
     static final int ENTRY_OVERHEAD_BYTES = 96;
     static final int PAGE_OVERHEAD_BYTES = 64;
-    static final int TREE_MAP_ENTRY_OVERHEAD_BYTES = 56;
-    static final int SEGMENT_ID_ESTIMATE_BYTES = 16;
+    static final int SEGMENT_ID_ESTIMATE_BYTES = 4;
     static final int SCARCE_INDEX_POSITION_BYTES = 4;
     static final int FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES = 16 * 1024;
     static final int TEMPORARY_MEMORY_MARGIN_PERCENT = 25;
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
-    private static final String UNAVAILABLE = "unavailable";
     private static final String UNKNOWN = "unknown";
-    private static final String NOTICE =
-            "Rough estimate only; not a JVM cap or measured allocation.";
-    private static final String RUNTIME_NOTE =
-            "Real usage depends on JVM layout, GC, workload, and temporary snapshots.";
 
     private IndexMemoryEstimator() {
     }
@@ -39,12 +30,12 @@ final class IndexMemoryEstimator {
     /**
      * Estimates startup memory pressure for an index configuration.
      *
-     * @param <K> key type
-     * @param <V> value type
-     * @param configuration resolved effective configuration
-     * @param keyTypeDescriptor resolved key descriptor
+     * @param <K>                 key type
+     * @param <V>                 value type
+     * @param configuration       resolved effective configuration
+     * @param keyTypeDescriptor   resolved key descriptor
      * @param valueTypeDescriptor resolved value descriptor
-     * @param routeCount current number of route-map entries
+     * @param routeCount          current number of route-map entries
      * @return memory estimate report
      */
     static <K, V> MemoryEstimateReport estimate(
@@ -52,8 +43,7 @@ final class IndexMemoryEstimator {
             final TypeDescriptor<K> keyTypeDescriptor,
             final TypeDescriptor<V> valueTypeDescriptor,
             final int routeCount) {
-        final EffectiveIndexConfiguration<K, V> resolved =
-                Vldtn.requireNonNull(configuration, "configuration");
+        final EffectiveIndexConfiguration<K, V> resolved = Vldtn.requireNonNull(configuration, "configuration");
         final TypeDescriptor<K> keyDescriptor = Vldtn.requireNonNull(
                 keyTypeDescriptor, "keyTypeDescriptor");
         final TypeDescriptor<V> valueDescriptor = Vldtn.requireNonNull(
@@ -61,126 +51,151 @@ final class IndexMemoryEstimator {
         final int resolvedRouteCount = Vldtn
                 .requireGreaterThanOrEqualToZero(routeCount, "routeCount");
 
-        final OptionalInt keyEstimate =
-                keyDescriptor.getEstimatedAverageSizeInBytes();
-        final OptionalInt valueEstimate =
-                valueDescriptor.getEstimatedAverageSizeInBytes();
+        final OptionalInt keyEstimate = keyDescriptor.getEstimatedAverageSizeInBytes();
+        final OptionalInt valueEstimate = valueDescriptor.getEstimatedAverageSizeInBytes();
+        final long maxScarceIndexKeys = maxScarceIndexKeys(resolved);
         final OptionalLong entryEstimate = entryEstimate(keyEstimate,
                 valueEstimate);
-        final OptionalLong scarceEntryEstimate =
-                scarceEntryEstimate(keyEstimate);
-        final OptionalLong oneLoadedSegmentCache =
-                estimateOneLoadedSegmentCache(resolved, entryEstimate);
-        final OptionalLong loadedSegmentCaches =
-                estimateLoadedSegmentCaches(resolved, entryEstimate);
-        final OptionalLong chunkStoreCache =
-                estimateChunkStoreCache(resolved, entryEstimate);
-        final OptionalLong routeMap =
-                estimateRouteMap(resolvedRouteCount, keyEstimate);
+        final OptionalLong scarceEntryEstimate = scarceEntryEstimate(keyEstimate);
+        final OptionalLong routeEntryEstimate = routeMapEntryEstimate(keyEstimate);
+        final OptionalLong oneDeltaCache = estimateOneDeltaCache(resolved, entryEstimate);
+        final OptionalLong deltaCaches = estimateDeltaCaches(resolved, entryEstimate);
+        final OptionalLong chunkStoreCache = estimateChunkStoreCache(resolved, entryEstimate);
+        final OptionalLong routeMap = estimateRouteMap(resolvedRouteCount,
+                routeEntryEstimate);
+        final OptionalLong oneBloomFilter = OptionalLong.of(resolved.bloomFilter().indexSizeBytes());
         final OptionalLong bloomFilters = OptionalLong
                 .of(estimateBloomFilters(resolved));
-        final OptionalLong scarceIndexes =
-                estimateScarceIndexes(resolved, keyEstimate);
+        final OptionalLong oneScarceIndex = estimateOneScarceIndex(resolved, keyEstimate);
+        final OptionalLong scarceIndexes = estimateScarceIndexes(resolved, keyEstimate);
+        final OptionalLong oneSegmentInfrastructure = OptionalLong.of(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES);
         final OptionalLong segmentInfrastructure = OptionalLong
                 .of(estimateSegmentInfrastructure(resolved));
+        final OptionalLong oneCachedSegment = sumEstimates(
+                oneDeltaCache, oneBloomFilter, oneScarceIndex,
+                oneSegmentInfrastructure);
+        final OptionalLong loadedSegments = sumEstimates(deltaCaches,
+                bloomFilters, scarceIndexes, segmentInfrastructure);
+        final OptionalLong allSegments = sumEstimates(loadedSegments,
+                routeMap);
 
         long steadyStateBytes = 0L;
-        steadyStateBytes = addIfPresent(steadyStateBytes,
-                loadedSegmentCaches);
+        steadyStateBytes = addIfPresent(steadyStateBytes, allSegments);
         steadyStateBytes = addIfPresent(steadyStateBytes, chunkStoreCache);
-        steadyStateBytes = addIfPresent(steadyStateBytes, routeMap);
-        steadyStateBytes = addIfPresent(steadyStateBytes, bloomFilters);
-        steadyStateBytes = addIfPresent(steadyStateBytes, scarceIndexes);
-        steadyStateBytes = addIfPresent(steadyStateBytes,
-                segmentInfrastructure);
 
         final boolean complete = entryEstimate.isPresent()
-                && loadedSegmentCaches.isPresent()
+                && allSegments.isPresent()
                 && chunkStoreCache.isPresent()
                 && routeMap.isPresent()
                 && scarceIndexes.isPresent();
-        final OptionalLong steadyState =
-                complete ? OptionalLong.of(steadyStateBytes)
-                        : OptionalLong.empty();
+        final OptionalLong steadyState = complete ? OptionalLong.of(steadyStateBytes)
+                : OptionalLong.empty();
         final OptionalLong temporaryMemoryMargin = estimateTemporaryMemoryMargin(
-                steadyState, oneLoadedSegmentCache);
+                steadyState, oneDeltaCache);
         final OptionalLong total = total(steadyState, temporaryMemoryMargin);
-        final List<Map.Entry<String, OptionalLong>> steadyAreas = List.of(
-                Map.entry("loaded segment cache", loadedSegmentCaches),
-                Map.entry("chunk-store cache", chunkStoreCache),
-                Map.entry("route map", routeMap),
-                Map.entry("Bloom filters if loaded", bloomFilters),
-                Map.entry("scarce indexes if loaded", scarceIndexes),
-                Map.entry("loaded segment infrastructure",
-                        segmentInfrastructure));
 
         final StringBuilder out = new StringBuilder();
         appendTitle(out);
-        appendSummary(out, steadyState, temporaryMemoryMargin, total);
-        appendNotes(out);
-        appendLargestAreas(out, steadyAreas);
-        appendAssumptions(out, keyDescriptor, valueDescriptor, keyEstimate,
-                valueEstimate, entryEstimate);
-        appendConfiguration(out, resolved, resolvedRouteCount);
-        appendReportedButNotIncluded(out, resolved);
-        out.append("Estimated memory by area:").append(LINE_SEPARATOR);
-        appendLine(out, "loaded segment cache", loadedSegmentCaches,
+        appendParentEstimateTreeLine(out, "", "├─ ", "Total index memory",
+                total,
+                "needs segment, page-cache, and maintenance estimates");
+        appendParentEstimateTreeLine(out, "│  ", "├─ ", "All segments",
+                allSegments, "needs complete segment and routing estimates",
+                formatCount(resolved.segment().cachedSegmentLimit())
+                        + " segment cache slots");
+        appendParentEstimateTreeLine(out, "│  │  ", "├─ ",
+                "One cached segment", oneCachedSegment,
                 "needs key and value descriptor estimates",
-                String.format(Locale.ROOT,
-                        "inputs: %d segments, %d read keys, %d maintenance keys, entry %s",
-                        resolved.segment().cachedSegmentLimit(),
-                        resolved.segment().cacheKeyLimit(),
-                        resolved.writePath()
-                                .segmentWriteCacheKeyLimitDuringMaintenance(),
-                        estimateText(entryEstimate)));
-
-        appendLine(out, "chunk-store cache", chunkStoreCache,
+                "multiplied by "
+                        + formatCount(resolved.segment().cachedSegmentLimit())
+                        + " segment cache slots");
+        appendEstimateTreeLine(out, "│  │  │  ", "├─ ", "Delta cache",
+                oneDeltaCache,
                 "needs key and value descriptor estimates",
-                String.format(Locale.ROOT,
-                        "inputs: %d pages, %d chunk keys, page overhead %s, entry %s",
-                        resolved.chunkStoreCache().pageLimit(),
-                        resolved.segment().chunkKeyLimit(),
-                        formatBytes(PAGE_OVERHEAD_BYTES),
-                        estimateText(entryEstimate)));
-
-        appendLine(out, "route map", routeMap,
-                "needs key descriptor estimate",
-                String.format(Locale.ROOT,
-                        "inputs: %d routes, key %s, segment id %s, tree entry %s",
-                        resolvedRouteCount, estimateText(keyEstimate),
-                        formatBytes(SEGMENT_ID_ESTIMATE_BYTES),
-                        formatBytes(TREE_MAP_ENTRY_OVERHEAD_BYTES)));
-
-        appendLine(out, "Bloom filters if loaded", bloomFilters, "",
-                String.format(Locale.ROOT, "inputs: %d segments, filter %s",
-                        resolved.segment().cachedSegmentLimit(),
-                        formatBytes(resolved.bloomFilter()
-                                .indexSizeBytes())));
-
-        appendLine(out, "scarce indexes if loaded", scarceIndexes,
-                "needs key descriptor estimate",
-                String.format(Locale.ROOT,
-                        "inputs: %d segments, %d scarce entries each, scarce entry %s",
-                        resolved.segment().cachedSegmentLimit(),
-                        ceilDiv(resolved.segment().maxKeys(),
-                                resolved.segment().chunkKeyLimit()),
-                        estimateText(scarceEntryEstimate)));
-
-        appendLine(out, "loaded segment infrastructure",
-                segmentInfrastructure, "",
-                String.format(Locale.ROOT, "inputs: %d segments, overhead %s",
-                        resolved.segment().cachedSegmentLimit(),
-                        formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES)));
-
-        appendLine(out, "temporary memory margin",
+                "configured max number of keys in cache: "
+                        + formatCount(resolved.segment().cacheKeyLimit()),
+                "key/value entry: " + estimateText(entryEstimate));
+        appendEstimateTreeLine(out, "│  │  │  ", "├─ ",
+                "Bloom filter", oneBloomFilter, "",
+                "configured bloom filter size: " + formatBytes(
+                        resolved.bloomFilter().indexSizeBytes()));
+        appendParentEstimateTreeLine(out, "│  │  │  ", "├─ ",
+                "Scarce index", oneScarceIndex,
+                "needs key descriptor estimate");
+        appendTreeLine(out, "│  │  │  │  ", "├─ ",
+                "Max number of keys in scarce index",
+                formatCount(maxScarceIndexKeys),
+                "max number of keys in segment: "
+                        + formatCount(resolved.segment().maxKeys()),
+                "number of keys per page: "
+                        + formatCount(resolved.segment().chunkKeyLimit()));
+        appendTreeLine(out, "│  │  │  │  ", "└─ ",
+                "Key/position entry", estimateText(scarceEntryEstimate));
+        appendEstimateTreeLine(out, "│  │  │  ", "└─ ", "Segment runtime",
+                oneSegmentInfrastructure, "",
+                "overhead: "
+                        + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES));
+        appendParentEstimateTreeLine(out, "│  │  ", "└─ ", "Segment routing map",
+                routeMap, "needs key descriptor estimate");
+        appendTreeLine(out, "│  │     ", "├─ ",
+                "Number of segment routes", formatCount(resolvedRouteCount));
+        appendTreeLine(out, "│  │     ", "└─ ",
+                "Key/segment-id entry", estimateText(routeEntryEstimate),
+                "key: " + estimateText(keyEstimate),
+                "segment id: " + formatBytes(SEGMENT_ID_ESTIMATE_BYTES));
+        appendEstimateTreeLine(out, "│  ", "├─ ",
+                "Chunk-store page cache", chunkStoreCache,
+                "needs key and value descriptor estimates",
+                formatCount(resolved.chunkStoreCache().pageLimit())
+                        + " pages",
+                "chunk keys per page: "
+                        + formatCount(resolved.segment().chunkKeyLimit()),
+                "page overhead: " + formatBytes(PAGE_OVERHEAD_BYTES),
+                "key/value entry: " + estimateText(entryEstimate));
+        appendEstimateTreeLine(out, "│  ", "└─ ", "Maintenance overhead",
                 temporaryMemoryMargin,
-                "needs complete steady-state estimate and entry estimate",
-                String.format(Locale.ROOT,
-                        "inputs: max(%d%% of steady state = %s, one segment cache = %s)",
-                        TEMPORARY_MEMORY_MARGIN_PERCENT,
-                        memoryText(steadyState),
-                        memoryText(oneLoadedSegmentCache)));
-
+                "needs memory before maintenance and key/value entry estimates",
+                "maintenance threads: "
+                        + formatCount(resolved.maintenance().indexThreads()),
+                "max(" + TEMPORARY_MEMORY_MARGIN_PERCENT
+                        + "% of memory before maintenance = "
+                        + memoryText(steadyState) + ",",
+                "one delta cache = "
+                        + memoryText(oneDeltaCache) + ")");
+        appendTreeLine(out, "", "├─ ", "Key/value entry",
+                estimateText(entryEstimate),
+                "key: " + descriptorName(keyDescriptor) + ", "
+                        + aboutText(keyEstimate),
+                "value: " + descriptorName(valueDescriptor) + ", "
+                        + aboutText(valueEstimate),
+                "overhead: " + formatBytes(ENTRY_OVERHEAD_BYTES));
+        appendTreeLine(out, "", "├─ ", "Key/position entry",
+                estimateText(scarceEntryEstimate),
+                "key: " + descriptorName(keyDescriptor) + ", "
+                        + aboutText(keyEstimate),
+                "integer position: TypeDescriptorInteger, "
+                        + "about " + formatBytes(SCARCE_INDEX_POSITION_BYTES),
+                "overhead: " + formatBytes(ENTRY_OVERHEAD_BYTES));
+        appendTreeLine(out, "", "├─ ", "Formula constants",
+                "shown for transparency, not added separately",
+                "fixed per loaded/cached segment: about "
+                        + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES),
+                "chunk-store page overhead: "
+                        + formatBytes(PAGE_OVERHEAD_BYTES),
+                "route-map segment id: "
+                        + formatBytes(SEGMENT_ID_ESTIMATE_BYTES),
+                "maintenance overhead: max("
+                        + TEMPORARY_MEMORY_MARGIN_PERCENT
+                        + "% of memory before maintenance,",
+                "one delta cache)");
+        appendTreeLine(out, "", "├─ ", "Other requirements",
+                "reported but not included",
+                "index write-buffer keys: " + formatCount(
+                        resolved.writePath().indexBufferedWriteKeyLimit()));
+        appendTreeLine(out, "", "└─ ", "Notes", "rough estimate only",
+                "not a JVM cap or measured allocation",
+                "usage depends on JVM layout, GC, workload, and snapshots",
+                "details: docs/operations/memory-estimate.md");
         out.append("End memory estimate").append(LINE_SEPARATOR);
         return new MemoryEstimateReport(out.toString().lines().toList(),
                 total.isPresent(), total);
@@ -188,110 +203,6 @@ final class IndexMemoryEstimator {
 
     private static void appendTitle(final StringBuilder out) {
         out.append("Estimated memory use at startup").append(LINE_SEPARATOR);
-    }
-
-    private static void appendSummary(final StringBuilder out,
-            final OptionalLong steadyState,
-            final OptionalLong temporaryMemoryMargin,
-            final OptionalLong total) {
-        out.append("Estimated active heap: ")
-                .append(memoryText(total)).append(LINE_SEPARATOR);
-        appendIndented(out, "steady state: " + memoryText(steadyState)
-                + " (memory expected after startup caches are loaded)");
-        appendIndented(out, "temporary margin: "
-                + memoryText(temporaryMemoryMargin)
-                + " (extra headroom for short-lived objects and snapshots)");
-    }
-
-    private static void appendNotes(final StringBuilder out) {
-        out.append("Notes:").append(LINE_SEPARATOR);
-        appendIndented(out, NOTICE);
-        appendIndented(out, RUNTIME_NOTE);
-        appendIndented(out, "details: docs/operations/memory-estimate.md");
-    }
-
-    private static void appendLargestAreas(final StringBuilder out,
-            final List<Map.Entry<String, OptionalLong>> steadyAreas) {
-        out.append("Largest steady-state areas:").append(LINE_SEPARATOR);
-        final List<Map.Entry<String, OptionalLong>> availableAreas = steadyAreas
-                .stream()
-                .filter(area -> area.getValue().isPresent()
-                        && area.getValue().getAsLong() > 0L)
-                .sorted(Comparator
-                        .comparingLong((Map.Entry<String, OptionalLong> area) ->
-                                area.getValue().getAsLong())
-                        .reversed())
-                .limit(3L)
-                .toList();
-        if (availableAreas.isEmpty()) {
-            appendIndented(out, UNAVAILABLE);
-            return;
-        }
-        availableAreas.forEach(area -> appendIndented(out,
-                area.getKey() + ": " + memoryText(area.getValue())));
-    }
-
-    private static <K, V> void appendAssumptions(final StringBuilder out,
-            final TypeDescriptor<K> keyDescriptor,
-            final TypeDescriptor<V> valueDescriptor,
-            final OptionalInt keyEstimate, final OptionalInt valueEstimate,
-            final OptionalLong entryEstimate) {
-        out.append("Per-entry size assumptions:").append(LINE_SEPARATOR);
-        appendIndented(out, "key: " + descriptorName(keyDescriptor) + ", "
-                + aboutText(keyEstimate));
-        appendIndented(out, "value: " + descriptorName(valueDescriptor) + ", "
-                + aboutText(valueEstimate));
-        appendIndented(out, "entry: " + aboutText(entryEstimate)
-                + " (key + value + overhead)");
-        out.append("Estimator assumptions:").append(LINE_SEPARATOR);
-        appendIndented(out, "fixed per loaded/cached segment: about "
-                + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES));
-        appendIndented(out, "temporary margin: max("
-                + TEMPORARY_MEMORY_MARGIN_PERCENT
-                + "% of steady state, one segment cache)");
-    }
-
-    private static void appendConfiguration(final StringBuilder out,
-            final EffectiveIndexConfiguration<?, ?> resolved,
-            final int routeCount) {
-        out.append("Configuration used for this estimate:")
-                .append(LINE_SEPARATOR);
-        appendIndented(out, "cached segments="
-                + resolved.segment().cachedSegmentLimit()
-                + ", segment cache keys="
-                + resolved.segment().cacheKeyLimit()
-                + ", maintenance keys="
-                + resolved.writePath()
-                        .segmentWriteCacheKeyLimitDuringMaintenance());
-        appendIndented(out, "max keys per segment="
-                + resolved.segment().maxKeys());
-        appendIndented(out, "chunk key limit="
-                + resolved.segment().chunkKeyLimit()
-                + ", chunk-store pages="
-                + resolved.chunkStoreCache().pageLimit()
-                + ", Bloom filter="
-                + formatBytes(resolved.bloomFilter().indexSizeBytes()));
-        appendIndented(out, "route map entries=" + routeCount);
-    }
-
-    private static void appendReportedButNotIncluded(final StringBuilder out,
-            final EffectiveIndexConfiguration<?, ?> resolved) {
-        out.append("Reported but not included:").append(LINE_SEPARATOR);
-        appendIndented(out, "index write-buffer keys: "
-                + resolved.writePath().indexBufferedWriteKeyLimit());
-    }
-
-    private static void appendLine(final StringBuilder out,
-            final String label, final OptionalLong estimateBytes,
-            final String unavailableReason, final String... details) {
-        out.append("  ").append(label).append(": ")
-                .append(memoryText(estimateBytes)).append(LINE_SEPARATOR);
-        if (estimateBytes.isEmpty() && !unavailableReason.isBlank()) {
-            appendDetail(out, "reason: " + unavailableReason);
-        }
-        for (final String detail : details) {
-            appendDetail(out, detail);
-        }
     }
 
     private static OptionalLong entryEstimate(final OptionalInt keyEstimate,
@@ -313,31 +224,34 @@ final class IndexMemoryEstimator {
                 ENTRY_OVERHEAD_BYTES));
     }
 
-    private static OptionalLong estimateLoadedSegmentCaches(
+    private static OptionalLong routeMapEntryEstimate(
+            final OptionalInt keyEstimate) {
+        if (keyEstimate.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(add(keyEstimate.getAsInt(),
+                SEGMENT_ID_ESTIMATE_BYTES));
+    }
+
+    private static OptionalLong estimateDeltaCaches(
             final EffectiveIndexConfiguration<?, ?> resolved,
             final OptionalLong entryEstimate) {
         if (entryEstimate.isEmpty()) {
             return OptionalLong.empty();
         }
-        final long perSegmentKeys = add(resolved.segment().cacheKeyLimit(),
-                resolved.writePath()
-                        .segmentWriteCacheKeyLimitDuringMaintenance());
         return OptionalLong.of(multiply(
                 multiply(resolved.segment().cachedSegmentLimit(),
-                        perSegmentKeys),
+                        resolved.segment().cacheKeyLimit()),
                 entryEstimate.getAsLong()));
     }
 
-    private static OptionalLong estimateOneLoadedSegmentCache(
+    private static OptionalLong estimateOneDeltaCache(
             final EffectiveIndexConfiguration<?, ?> resolved,
             final OptionalLong entryEstimate) {
         if (entryEstimate.isEmpty()) {
             return OptionalLong.empty();
         }
-        final long perSegmentKeys = add(resolved.segment().cacheKeyLimit(),
-                resolved.writePath()
-                        .segmentWriteCacheKeyLimitDuringMaintenance());
-        return OptionalLong.of(multiply(perSegmentKeys,
+        return OptionalLong.of(multiply(resolved.segment().cacheKeyLimit(),
                 entryEstimate.getAsLong()));
     }
 
@@ -355,15 +269,12 @@ final class IndexMemoryEstimator {
     }
 
     private static OptionalLong estimateRouteMap(final int routeCount,
-            final OptionalInt keyEstimate) {
-        if (keyEstimate.isEmpty()) {
+            final OptionalLong routeEntryEstimate) {
+        if (routeEntryEstimate.isEmpty()) {
             return OptionalLong.empty();
         }
-        final long perEntryBytes = add(
-                add(keyEstimate.getAsInt(), SEGMENT_ID_ESTIMATE_BYTES),
-                TREE_MAP_ENTRY_OVERHEAD_BYTES);
-        return OptionalLong.of(multiply(multiply(routeCount, 2L),
-                perEntryBytes));
+        return OptionalLong.of(multiply(routeCount,
+                routeEntryEstimate.getAsLong()));
     }
 
     private static long estimateBloomFilters(
@@ -372,21 +283,36 @@ final class IndexMemoryEstimator {
                 resolved.bloomFilter().indexSizeBytes());
     }
 
-    private static OptionalLong estimateScarceIndexes(
+    private static OptionalLong estimateOneScarceIndex(
             final EffectiveIndexConfiguration<?, ?> resolved,
             final OptionalInt keyEstimate) {
         if (keyEstimate.isEmpty()) {
             return OptionalLong.empty();
         }
-        final long scarceKeysPerSegment = ceilDiv(resolved.segment().maxKeys(),
-                resolved.segment().chunkKeyLimit());
+        final long scarceKeysPerSegment = maxScarceIndexKeys(resolved);
         final long scarceEntryBytes = add(
                 add(keyEstimate.getAsInt(), SCARCE_INDEX_POSITION_BYTES),
                 ENTRY_OVERHEAD_BYTES);
-        return OptionalLong.of(multiply(
-                multiply(resolved.segment().cachedSegmentLimit(),
-                        scarceKeysPerSegment),
+        return OptionalLong.of(multiply(scarceKeysPerSegment,
                 scarceEntryBytes));
+    }
+
+    private static OptionalLong estimateScarceIndexes(
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final OptionalInt keyEstimate) {
+        final OptionalLong oneScarceIndex = estimateOneScarceIndex(resolved, keyEstimate);
+        if (oneScarceIndex.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(multiply(
+                resolved.segment().cachedSegmentLimit(),
+                oneScarceIndex.getAsLong()));
+    }
+
+    private static long maxScarceIndexKeys(
+            final EffectiveIndexConfiguration<?, ?> resolved) {
+        return ceilDiv(resolved.segment().maxKeys(),
+                resolved.segment().chunkKeyLimit());
     }
 
     private static long estimateSegmentInfrastructure(
@@ -414,6 +340,17 @@ final class IndexMemoryEstimator {
         }
         return OptionalLong.of(add(steadyState.getAsLong(),
                 transientHeadroom.getAsLong()));
+    }
+
+    private static OptionalLong sumEstimates(final OptionalLong... estimates) {
+        long sum = 0L;
+        for (final OptionalLong estimate : estimates) {
+            if (estimate.isEmpty()) {
+                return OptionalLong.empty();
+            }
+            sum = add(sum, estimate.getAsLong());
+        }
+        return OptionalLong.of(sum);
     }
 
     private static long addIfPresent(final long total,
@@ -449,12 +386,12 @@ final class IndexMemoryEstimator {
 
     private static String estimateText(final OptionalLong estimate) {
         return estimate.isPresent() ? formatBytes(estimate.getAsLong())
-                : UNAVAILABLE;
+                : UNKNOWN;
     }
 
     private static String memoryText(final OptionalLong estimate) {
         return estimate.isPresent() ? formatBytes(estimate.getAsLong())
-                : UNAVAILABLE;
+                : UNKNOWN;
     }
 
     private static String aboutText(final OptionalInt estimate) {
@@ -469,14 +406,63 @@ final class IndexMemoryEstimator {
                 : UNKNOWN;
     }
 
-    private static void appendIndented(final StringBuilder out,
-            final String line) {
-        out.append("  ").append(line).append(LINE_SEPARATOR);
+    private static void appendEstimateTreeLine(final StringBuilder out,
+            final String prefix, final String connector, final String label,
+            final OptionalLong estimateBytes, final String unknownReason,
+            final String... details) {
+        appendEstimateTreeLine(out, prefix, connector, label, estimateBytes,
+                unknownReason, false, details);
     }
 
-    private static void appendDetail(final StringBuilder out,
-            final String line) {
-        out.append("    ").append(line).append(LINE_SEPARATOR);
+    private static void appendParentEstimateTreeLine(final StringBuilder out,
+            final String prefix, final String connector, final String label,
+            final OptionalLong estimateBytes, final String unknownReason,
+            final String... details) {
+        appendEstimateTreeLine(out, prefix, connector, label, estimateBytes,
+                unknownReason, true, details);
+    }
+
+    private static void appendEstimateTreeLine(final StringBuilder out,
+            final String prefix, final String connector, final String label,
+            final OptionalLong estimateBytes, final String unknownReason,
+            final boolean childBranch, final String... details) {
+        final String[] resolvedDetails;
+        if (estimateBytes.isEmpty() && !unknownReason.isBlank()) {
+            resolvedDetails = new String[details.length + 1];
+            resolvedDetails[0] = "reason: " + unknownReason;
+            System.arraycopy(details, 0, resolvedDetails, 1,
+                    details.length);
+        } else {
+            resolvedDetails = details;
+        }
+        appendTreeLine(out, prefix, connector, label,
+                memoryText(estimateBytes), childBranch, resolvedDetails);
+    }
+
+    private static void appendTreeLine(final StringBuilder out,
+            final String prefix, final String connector, final String label,
+            final String value, final String... details) {
+        appendTreeLine(out, prefix, connector, label, value, false, details);
+    }
+
+    private static void appendTreeLine(final StringBuilder out,
+            final String prefix, final String connector, final String label,
+            final String value, final boolean childBranch,
+            final String... details) {
+        final String lead = prefix + connector + label + " - ";
+        out.append(lead).append(value).append(LINE_SEPARATOR);
+        final String childMarker = childBranch ? "│" : "";
+        final String detailPrefix = prefix + continuation(connector)
+                + childMarker
+                + " ".repeat(label.length() + " - ".length()
+                        - childMarker.length());
+        for (final String detail : details) {
+            out.append(detailPrefix).append(detail).append(LINE_SEPARATOR);
+        }
+    }
+
+    private static String continuation(final String connector) {
+        return connector.startsWith("├") ? "│  " : "   ";
     }
 
     private static String descriptorName(final TypeDescriptor<?> descriptor) {
@@ -491,7 +477,7 @@ final class IndexMemoryEstimator {
         if (bytes < 1024L) {
             return bytes + " B";
         }
-        final String[] units = {"KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+        final String[] units = { "KiB", "MiB", "GiB", "TiB", "PiB", "EiB" };
         double value = bytes;
         int unitIndex = -1;
         while (value >= 1024D && unitIndex < units.length - 1) {
@@ -500,6 +486,10 @@ final class IndexMemoryEstimator {
         }
         return String.format(Locale.ROOT, "%.2f %s", value,
                 units[unitIndex]);
+    }
+
+    private static String formatCount(final long count) {
+        return String.format(Locale.ROOT, "%,d", count);
     }
 
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/IntegrationSegmentIndexConcurrencyTest.java
@@ -276,15 +276,14 @@ class IntegrationSegmentIndexConcurrencyTest {
 
     private static Stream<ParallelPutsScenario> parallelPutsScenarios() {
         return Stream.of(
-                new ParallelPutsScenario("small-cache-50-keys", 50, 3, 3, 2,
+                new ParallelPutsScenario("small-cache-50-keys", 50, 3, 50, 2,
                         4, 5, 4, 40),
                 new ParallelPutsScenario("active-partition-64-200-keys", 200,
-                        128,
-                        64, 16, 128, 10, 8, 64),
+                        128, 200, 16, 128, 10, 8, 64),
                 new ParallelPutsScenario(
-                        "active-partition-128-small-segment-budget", 300, 128,
-                        128, 16, 32, 5, 8, 64),
-                new ParallelPutsScenario("large-segment-512", 300, 256, 64,
+                        "active-partition-300-small-segment-budget", 300, 128,
+                        300, 16, 32, 5, 8, 64),
+                new ParallelPutsScenario("large-segment-512", 300, 256, 300,
                         32, 512, 10, 8, 40));
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.hestiastore.index.datatype.ByteArray;
 import org.hestiastore.index.datatype.NullValue;
 import org.hestiastore.index.datatype.TypeDescriptor;
@@ -21,9 +23,9 @@ class IndexMemoryEstimatorTest {
 
     @Test
     void estimateCalculatesCompleteReportWithReadableInputs() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-complete",
-                        String.class, new TypeDescriptorShortString());
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-complete",
+                String.class, new TypeDescriptorShortString());
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
@@ -31,44 +33,68 @@ class IndexMemoryEstimatorTest {
         printReport("complete", estimate);
 
         assertTrue(estimate.isComplete());
-        assertEquals(98_460L, estimate.totalEstimatedBytes().orElseThrow());
+        assertEquals(93_330L, estimate.totalEstimatedBytes().orElseThrow());
         final String log = estimate.text();
         assertTrue(log.contains("Estimated memory use at startup"));
-        assertTrue(log.contains("Estimated active heap: 96.15 KiB"));
+        assertTrue(log.contains("├─ Total index memory - 91.14 KiB"));
+        assertTrue(log.contains("│  ├─ All segments - 72.91 KiB"));
         assertTrue(log.contains(
-                "steady state: 76.92 KiB (memory expected after startup caches are loaded)"));
+                "│  │  │              3 segment cache slots"));
         assertTrue(log.contains(
-                "temporary margin: 19.23 KiB (extra headroom for short-lived objects and snapshots)"));
-        assertLineAppearsBefore(log, "Estimated active heap: 96.15 KiB",
-                "Notes:");
-        assertLineAppearsBefore(log, "Estimated active heap: 96.15 KiB",
-                "Per-entry size assumptions:");
+                "│  │  ├─ One cached segment - 24.30 KiB"));
         assertTrue(log.contains(
-                "Rough estimate only; not a JVM cap or measured allocation."));
-        assertTrue(log.contains("Per-entry size assumptions:"));
-        assertTrue(log.contains("entry: about 228 B (key + value + overhead)"));
+                "│  └─ Maintenance overhead - 18.23 KiB"));
+        assertLineAppearsBefore(log, "├─ Total index memory - 91.14 KiB",
+                "├─ Key/value entry - 228 B");
+        assertTrue(log.contains(
+                "not a JVM cap or measured allocation"));
+        assertTrue(log.contains("├─ Key/value entry - 228 B"));
+        assertLineAppearsBefore(log, "├─ Key/value entry - 228 B",
+                "├─ Key/position entry - 104 B");
+        assertTrue(log.contains("├─ Key/position entry - 104 B"));
+        assertTrue(log.contains("overhead: 96 B"));
+        assertTrue(log.contains(
+                "├─ Formula constants - shown for transparency, not added separately"));
         assertTrue(log.contains(
                 "fixed per loaded/cached segment: about 16.00 KiB"));
         assertTrue(log.contains(
                 "details: docs/operations/memory-estimate.md"));
-        assertTrue(log.contains("Largest steady-state areas:"));
         assertTrue(log.contains(
-                "loaded segment infrastructure: 48.00 KiB"));
+                "│  │  │  └─ Segment runtime - 16.00 KiB"));
         assertTrue(log.contains(
-                "scarce indexes if loaded: 15.23 KiB"));
-        assertTrue(log.contains("Configuration used for this estimate:"));
+                "│  │  │  ├─ Scarce index - 5.08 KiB"));
         assertTrue(log.contains(
-                "cached segments=3, segment cache keys=10, maintenance keys=6"));
-        assertTrue(log.contains("max keys per segment=100"));
-        assertTrue(log.contains("Reported but not included:"));
+                "│  │  │  │  ├─ Max number of keys in scarce index - 50"));
+        assertDetailAlignsWithValue(estimate,
+                "│  │  │  │  ├─ Max number of keys in scarce index - 50",
+                "max number of keys in segment: 100");
         assertTrue(log.contains(
-                "index write-buffer keys: 18"));
+                "number of keys per page: 2"));
+        assertFalse(log.contains(
+                "│  │  │  │  │        max number of keys in segment: 100"));
+        assertFalse(log.contains(
+                "│  │  │  │  │  │                                    max number of keys in segment: 100"));
         assertTrue(log.contains(
-                "chunk key limit=2, chunk-store pages=0, Bloom filter=1.00 KiB"));
+                "│  │  │  │  └─ Key/position entry - 104 B"));
         assertTrue(log.contains(
-                "Estimated memory by area:"));
+                "key: TypeDescriptorInteger, about 4 B"));
         assertTrue(log.contains(
-                "inputs: 3 segments, 10 read keys, 6 maintenance keys, entry 228 B"));
+                "integer position: TypeDescriptorInteger, about 4 B"));
+        assertTrue(log.contains(
+                "├─ Other requirements - reported but not included"));
+        assertTrue(log.contains("index write-buffer keys: 18"));
+        assertTrue(log.contains("chunk keys per page: 2"));
+        assertTrue(log.contains("configured bloom filter size: 1.00 KiB"));
+        assertTrue(log.contains(
+                "│  │  │  ├─ Delta cache - 2.23 KiB"));
+        assertTrue(log.contains(
+                "configured max number of keys in cache: 10"));
+        assertTrue(log.contains("key/value entry: 228 B"));
+        assertFalse(log.contains(
+                "entry overhead: 96 B inside key/value entry"));
+        assertDetailAlignsWithValue(estimate,
+                "│  │  ├─ One cached segment - 24.30 KiB",
+                "multiplied by 3 segment cache slots");
         assertTrue(log.contains("End memory estimate"));
         assertFalse(log.contains("based on:"));
         assertFalse(log.contains("reported only"));
@@ -76,136 +102,152 @@ class IndexMemoryEstimatorTest {
 
     @Test
     void estimateIncludesChunkStoreCachePageLimit() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-chunk-cache",
-                        String.class, new TypeDescriptorShortString(), 10, 6,
-                        2, 3, 7);
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-chunk-cache",
+                String.class, new TypeDescriptorShortString(), 10, 6,
+                2, 3, 7);
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
                 new TypeDescriptorShortString(), 0);
         printReport("chunk-store-cache", estimate);
 
-        assertEquals(103_010L, estimate.totalEstimatedBytes().orElseThrow());
+        assertEquals(97_880L, estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "chunk-store cache: 3.55 KiB"));
-        assertTrue(estimate.text().contains(
-                "inputs: 7 pages, 2 chunk keys, page overhead 64 B, entry 228 B"));
+                "│  ├─ Chunk-store page cache - 3.55 KiB"));
+        assertTrue(estimate.text().contains("7 pages"));
+        assertTrue(estimate.text().contains("chunk keys per page: 2"));
+        assertTrue(estimate.text().contains("page overhead: 64 B"));
+        assertTrue(estimate.text().contains("key/value entry: 228 B"));
     }
 
     @Test
     void estimateScalesCachedSegmentLimit() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-segment-limit",
-                        String.class, new TypeDescriptorShortString(), 10, 6,
-                        2, 5, 0);
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-segment-limit",
+                String.class, new TypeDescriptorShortString(), 10, 6,
+                2, 5, 0);
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
                 new TypeDescriptorShortString(), 0);
         printReport("cached-segment-limit", estimate);
 
-        assertEquals(164_100L, estimate.totalEstimatedBytes().orElseThrow());
+        assertEquals(155_550L, estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "loaded segment cache: 17.81 KiB"));
+                "│  ├─ All segments - 121.52 KiB"));
         assertTrue(estimate.text().contains(
-                "Bloom filters if loaded: 5.00 KiB"));
+                "│  │  ├─ One cached segment - 24.30 KiB"));
         assertTrue(estimate.text().contains(
-                "loaded segment infrastructure: 80.00 KiB"));
+                "5 segment cache slots"));
     }
 
     @Test
     void estimateIncludesRouteCount() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-route-count",
-                        String.class, new TypeDescriptorShortString());
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-route-count",
+                String.class, new TypeDescriptorShortString());
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
-                new TypeDescriptorShortString(), 4);
+                new TypeDescriptorShortString(), 10);
         printReport("route-count", estimate);
 
-        assertEquals(99_220L, estimate.totalEstimatedBytes().orElseThrow());
+        assertEquals(93_430L, estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "route map: 608 B"));
+                "│  │  └─ Segment routing map - 80 B"));
         assertTrue(estimate.text().contains(
-                "inputs: 4 routes, key 4 B, segment id 16 B, tree entry 56 B"));
+                "│  │     ├─ Number of segment routes - 10"));
+        assertTrue(estimate.text().contains(
+                "│  │     └─ Key/segment-id entry - 8 B"));
+        assertDetailAlignsWithValue(estimate,
+                "│  │     └─ Key/segment-id entry - 8 B",
+                "key: 4 B");
+        assertTrue(estimate.text().contains("segment id: 4 B"));
+        assertFalse(estimate.text().contains("segment id: 16 B"));
+        assertFalse(estimate.text().contains("route-map tree entry"));
     }
 
     @Test
-    void estimateReflectsCacheKeyLimitsInSegmentCacheAndHeadroom() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-cache-limits",
-                        String.class, new TypeDescriptorShortString(), 20, 10,
-                        2, 3, 0);
+    void estimateReflectsDeltaCacheKeyLimitAndHeadroom() {
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-cache-limits",
+                String.class, new TypeDescriptorShortString(), 20, 10,
+                2, 3, 0);
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
                 new TypeDescriptorShortString(), 0);
         printReport("cache-key-limits", estimate);
 
-        assertEquals(110_430L, estimate.totalEstimatedBytes().orElseThrow());
+        assertEquals(101_880L, estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "loaded segment cache: 20.04 KiB"));
+                "│  │  │  ├─ Delta cache - 4.45 KiB"));
         assertTrue(estimate.text().contains(
-                "inputs: 3 segments, 20 read keys, 10 maintenance keys, entry 228 B"));
+                "configured max number of keys in cache: 20"));
+        assertTrue(estimate.text().contains("key/value entry: 228 B"));
         assertTrue(estimate.text().contains(
-                "temporary memory margin: 21.57 KiB"));
+                "│  └─ Maintenance overhead - 19.90 KiB"));
         assertTrue(estimate.text().contains(
-                "inputs: max(25% of steady state = 86.27 KiB, one segment cache = 6.68 KiB)"));
+                "max(25% of memory before maintenance = 79.59 KiB,"));
+        assertTrue(estimate.text().contains(
+                "one delta cache = 4.45 KiB)"));
     }
 
     @Test
     void estimateFormatsGiBWhenSegmentCacheExceedsOneGiB() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-segment-cache-gib",
-                        String.class, new TypeDescriptorShortString(),
-                        500_000, 200_000, 2, 10, 0);
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-segment-cache-gib",
+                String.class, new TypeDescriptorShortString(),
+                500_000, 200_000, 2, 10, 0);
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
                 new TypeDescriptorShortString(), 0);
         printReport("segment-cache-gib", estimate);
 
-        assertEquals(1_995_282_600L,
+        assertEquals(1_425_282_600L,
                 estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "Estimated active heap: 1.86 GiB"));
+                "├─ Total index memory - 1.33 GiB"));
         assertTrue(estimate.text().contains(
-                "steady state: 1.49 GiB (memory expected after startup caches are loaded)"));
+                "│  ├─ All segments - 1.06 GiB"));
         assertTrue(estimate.text().contains(
-                "loaded segment cache: 1.49 GiB"));
+                "│  │  │  ├─ Delta cache - 108.72 MiB"));
         assertTrue(estimate.text().contains(
-                "inputs: 10 segments, 500000 read keys, 200000 maintenance keys, entry 228 B"));
+                "configured max number of keys in cache: 500,000"));
+        assertTrue(estimate.text().contains("key/value entry: 228 B"));
     }
 
     @Test
     void estimateFormatsGiBWhenChunkStoreCacheExceedsOneGiB() {
-        final EffectiveIndexConfiguration<Integer, String> configuration =
-                effectiveConfiguration("memory-estimate-chunk-store-gib",
-                        String.class, new TypeDescriptorShortString(), 10, 6,
-                        100, 3, 50_000);
+        final EffectiveIndexConfiguration<Integer, String> configuration = effectiveConfiguration(
+                "memory-estimate-chunk-store-gib",
+                String.class, new TypeDescriptorShortString(), 10, 6,
+                100, 3, 50_000);
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
                 new TypeDescriptorShortString(), 0);
         printReport("chunk-store-gib", estimate);
 
-        assertEquals(1_429_079_350L,
+        assertEquals(1_429_074_220L,
                 estimate.totalEstimatedBytes().orElseThrow());
         assertTrue(estimate.text().contains(
-                "Estimated active heap: 1.33 GiB"));
+                "├─ Total index memory - 1.33 GiB"));
         assertTrue(estimate.text().contains(
-                "chunk-store cache: 1.06 GiB"));
-        assertTrue(estimate.text().contains(
-                "inputs: 50000 pages, 100 chunk keys, page overhead 64 B, entry 228 B"));
+                "│  ├─ Chunk-store page cache - 1.06 GiB"));
+        assertTrue(estimate.text().contains("50,000 pages"));
+        assertTrue(estimate.text().contains("chunk keys per page: 100"));
+        assertTrue(estimate.text().contains("page overhead: 64 B"));
+        assertTrue(estimate.text().contains("key/value entry: 228 B"));
     }
 
     @Test
     void estimateReportsIncompleteWhenValueDescriptorSizeIsUnknown() {
-        final EffectiveIndexConfiguration<Integer, ByteArray> configuration =
-                effectiveConfiguration("memory-estimate-incomplete",
-                        ByteArray.class, new TypeDescriptorByteArray());
+        final EffectiveIndexConfiguration<Integer, ByteArray> configuration = effectiveConfiguration(
+                "memory-estimate-incomplete",
+                ByteArray.class, new TypeDescriptorByteArray());
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
@@ -217,18 +259,18 @@ class IndexMemoryEstimatorTest {
         final String log = estimate.text();
         assertTrue(log.contains("value: TypeDescriptorByteArray, unknown"));
         assertTrue(log.contains(
-                "loaded segment cache: unavailable"));
+                "│  │  │  ├─ Delta cache - unknown"));
         assertTrue(log.contains(
                 "reason: needs key and value descriptor estimates"));
-        assertTrue(log.contains("Bloom filters if loaded"));
-        assertTrue(log.contains("Estimated active heap: unavailable"));
+        assertTrue(log.contains("Bloom filter"));
+        assertTrue(log.contains("├─ Total index memory - unknown"));
     }
 
     @Test
     void estimateTreatsZeroValueSizeAsRealEstimate() {
-        final EffectiveIndexConfiguration<Integer, NullValue> configuration =
-                effectiveConfiguration("memory-estimate-zero",
-                        NullValue.class, new TypeDescriptorNull());
+        final EffectiveIndexConfiguration<Integer, NullValue> configuration = effectiveConfiguration(
+                "memory-estimate-zero",
+                NullValue.class, new TypeDescriptorNull());
 
         final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
                 configuration, new TypeDescriptorInteger(),
@@ -238,7 +280,34 @@ class IndexMemoryEstimatorTest {
         assertTrue(estimate.isComplete());
         assertTrue(estimate.totalEstimatedBytes().isPresent());
         assertTrue(estimate.text().contains(
-                "entry: about 100 B (key + value + overhead)"));
+                "├─ Key/value entry - 100 B"));
+        assertTrue(estimate.text().contains("overhead: 96 B"));
+    }
+
+    @Test
+    void estimateUsesKeyDescriptorForKeyPositionEntry() {
+        final EffectiveIndexConfiguration<String, Integer> configuration = effectiveConfiguration(
+                "memory-estimate-string-key",
+                String.class, new TypeDescriptorShortString(),
+                Integer.class, new TypeDescriptorInteger());
+
+        final MemoryEstimateReport estimate = IndexMemoryEstimator.estimate(
+                configuration, new TypeDescriptorShortString(),
+                new TypeDescriptorInteger(), 0);
+        printReport("string-key", estimate);
+
+        final String log = estimate.text();
+        assertTrue(estimate.isComplete());
+        assertTrue(log.contains("│  │  │  ├─ Scarce index - 11.13 KiB"));
+        assertTrue(log.contains(
+                "│  │  │  │  └─ Key/position entry - 228 B"));
+        assertLineAppearsBefore(log, "├─ Key/value entry - 228 B",
+                "├─ Key/position entry - 228 B");
+        assertDetailAlignsWithValue(estimate,
+                "├─ Key/position entry - 228 B",
+                "key: TypeDescriptorShortString, about 128 B");
+        assertTrue(log.contains(
+                "integer position: TypeDescriptorInteger, about 4 B"));
     }
 
     private static <V> EffectiveIndexConfiguration<Integer, V> effectiveConfiguration(
@@ -256,12 +325,37 @@ class IndexMemoryEstimatorTest {
             final int chunkKeyLimit,
             final int cachedSegmentLimit,
             final int chunkStorePageLimit) {
+        return effectiveConfiguration(name, Integer.class,
+                new TypeDescriptorInteger(), valueClass, valueTypeDescriptor,
+                cacheKeyLimit, maintenanceWriteCacheKeyLimit, chunkKeyLimit,
+                cachedSegmentLimit, chunkStorePageLimit);
+    }
+
+    private static <K, V> EffectiveIndexConfiguration<K, V> effectiveConfiguration(
+            final String name, final Class<K> keyClass,
+            final TypeDescriptor<K> keyTypeDescriptor,
+            final Class<V> valueClass,
+            final TypeDescriptor<V> valueTypeDescriptor) {
+        return effectiveConfiguration(name, keyClass, keyTypeDescriptor,
+                valueClass, valueTypeDescriptor, 10, 6, 2, 3, 0);
+    }
+
+    private static <K, V> EffectiveIndexConfiguration<K, V> effectiveConfiguration(
+            final String name, final Class<K> keyClass,
+            final TypeDescriptor<K> keyTypeDescriptor,
+            final Class<V> valueClass,
+            final TypeDescriptor<V> valueTypeDescriptor,
+            final int cacheKeyLimit,
+            final int maintenanceWriteCacheKeyLimit,
+            final int chunkKeyLimit,
+            final int cachedSegmentLimit,
+            final int chunkStorePageLimit) {
         return EffectiveIndexConfigurationResolver.resolveForCreate(
-                IndexConfiguration.<Integer, V>builder()
-                        .identity(identity -> identity.keyClass(Integer.class))
+                IndexConfiguration.<K, V>builder()
+                        .identity(identity -> identity.keyClass(keyClass))
                         .identity(identity -> identity.valueClass(valueClass))
-                        .identity(identity -> identity.keyTypeDescriptor(
-                                new TypeDescriptorInteger()))
+                        .identity(identity -> identity
+                                .keyTypeDescriptor(keyTypeDescriptor))
                         .identity(identity -> identity
                                 .valueTypeDescriptor(valueTypeDescriptor))
                         .identity(identity -> identity.name(name))
@@ -304,6 +398,21 @@ class IndexMemoryEstimatorTest {
             final MemoryEstimateReport report) {
         report.lines().forEach(line -> assertTrue(line.length() <= 100,
                 () -> "Report line is too long: " + line));
+    }
+
+    private static void assertDetailAlignsWithValue(
+            final MemoryEstimateReport report, final String treeLine,
+            final String detail) {
+        final List<String> lines = report.lines();
+        final int lineIndex = lines.indexOf(treeLine);
+
+        assertTrue(lineIndex >= 0, () -> "Missing line: " + treeLine);
+        final String detailLine = lines.get(lineIndex + 1);
+        final int valueColumn = treeLine.indexOf(" - ") + " - ".length();
+
+        assertEquals(valueColumn, detailLine.indexOf(detail));
+        assertTrue(detailLine.substring(0, valueColumn).contains("│"),
+                () -> "Missing tree connection before detail: " + detailLine);
     }
 
     private static void assertLineAppearsBefore(final String log,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
@@ -146,7 +146,7 @@ class SegmentIndexBootstrapOperationTest {
             assertInstanceOf(SegmentIndexMdcLoggingAdapter.class, index);
             assertTrue(index.startupMemoryEstimate().isComplete());
             assertTrue(index.startupMemoryEstimate().text().contains(
-                    "Estimated active heap:"));
+                    "├─ Total index memory - "));
         } finally {
             index.close();
         }
@@ -183,7 +183,7 @@ class SegmentIndexBootstrapOperationTest {
                             .maintenance().registryLifecycleThreads());
             assertTrue(index.startupMemoryEstimate().isComplete());
             assertTrue(index.startupMemoryEstimate().text().contains(
-                    "Estimated active heap:"));
+                    "├─ Total index memory - "));
         } finally {
             index.close();
         }


### PR DESCRIPTION
## Summary
- reorganize the startup memory estimate report into clearer tree sections
- rename and clarify cache, scarce-index, route-map, and formula wording
- estimate the segment routing map as number of routes multiplied by key/segment-id entry size

## Tests
- mvn -pl engine -Dtest=IndexMemoryEstimatorTest test
- mvn -pl engine -Dtest=SegmentIndexBootstrapOperationTest test
- mvn -pl engine -Dtest=IntegrationSegmentIndexConcurrencyTest test
- python3 scripts/check_docs_nav.py
- mkdocs build --strict
- git diff --check

## Known verification issue
- mvn clean verify failed twice in IntegrationSegmentIndexConcurrencyTest.parallel_puts_and_gets_on_different_keys with: Write cache is full for segment segment-00000 and automatic maintenance is disabled. The exact test class passed when rerun directly.