### PR TITLE
Fix segment cache memory retention

### DIFF
--- a/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/SegmentIndexConcurrentIT.java
@@ -191,6 +191,7 @@ class SegmentIndexConcurrentIT {
         final Map<Integer, Integer>[] expectedByThread = new Map[threads];
 
         final AtomicBoolean stop = new AtomicBoolean(false);
+        final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
         final AtomicReference<Throwable> maintenanceError = new AtomicReference<>();
         final Thread maintenance = new Thread(() -> {
             try {
@@ -198,9 +199,9 @@ class SegmentIndexConcurrentIT {
                 int iteration = 0;
                 while (!stop.get()) {
                     try {
-                        index.maintenance().flush();
+                        index.maintenance().flushAndWait();
                         if ((iteration++ % 3) == 0) {
-                            index.maintenance().compact();
+                            index.maintenance().compactAndWait();
                         }
                     } catch (final IndexException ex) {
                         if (!isTransientIndexFailure(ex)) {
@@ -222,30 +223,36 @@ class SegmentIndexConcurrentIT {
         for (int t = 0; t < threads; t++) {
             final int threadId = t;
             executor.submit(() -> {
-                final Random rnd = new Random(112233L + threadId);
-                final int keySpaceOffset = threadId * 1_000;
-                final Map<Integer, Integer> expectedLocal = new HashMap<>();
-                startGate.await();
-                for (int i = 0; i < operationsPerThread; i++) {
-                    final int key = keySpaceOffset + rnd.nextInt(80);
-                    if (rnd.nextDouble() < 0.7) {
-                        final int value = rnd.nextInt(10_000);
-                        expectedLocal.put(key, value);
-                        index.put(key, value);
-                    } else {
-                        expectedLocal.remove(key);
-                        index.delete(key);
+                try {
+                    final Random rnd = new Random(112233L + threadId);
+                    final int keySpaceOffset = threadId * 1_000;
+                    final Map<Integer, Integer> expectedLocal = new HashMap<>();
+                    startGate.await();
+                    for (int i = 0; i < operationsPerThread; i++) {
+                        final int key = keySpaceOffset + rnd.nextInt(80);
+                        if (rnd.nextDouble() < 0.7) {
+                            final int value = rnd.nextInt(10_000);
+                            expectedLocal.put(key, value);
+                            index.put(key, value);
+                        } else {
+                            expectedLocal.remove(key);
+                            index.delete(key);
+                        }
                     }
+                    expectedByThread[threadId] = expectedLocal;
+                } catch (final Throwable t1) {
+                    writerFailure.compareAndSet(null, t1);
+                } finally {
+                    doneGate.countDown();
                 }
-                expectedByThread[threadId] = expectedLocal;
-                doneGate.countDown();
                 return null;
             });
         }
 
         startGate.countDown();
-        assertTrue(doneGate.await(60, TimeUnit.SECONDS),
+        assertTrue(doneGate.await(WORKER_AWAIT_SECONDS, TimeUnit.SECONDS),
                 "Writer threads did not finish in time");
+        assertNoWorkerFailure(writerFailure, "Writer thread failed");
 
         stop.set(true);
         // Stop cooperatively so maintenance retries are not interrupted and
@@ -860,7 +867,7 @@ class SegmentIndexConcurrentIT {
                         .name(name))//
                 .maintenance(maintenance -> maintenance
                         .backgroundAutoEnabled(false))//
-                .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(256)
+                .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(512)
                         .maintenanceWriteCacheKeyLimit(1_024)
                         .indexBufferedWriteKeyLimit(4_096)
                         .segmentSplitKeyThreshold(10_000_000))//

--- a/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
+++ b/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
@@ -2,12 +2,10 @@ package org.hestiastore.index.cache;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 import org.hestiastore.index.Entry;
@@ -25,12 +23,10 @@ public class UniqueCache<K, V> {
     private final Map<K, V> map;
 
     private final Comparator<K> keyComparator;
-    private final AtomicInteger size = new AtomicInteger();
-    private final boolean threadSafe;
 
     /**
      * Create builder for unique cache.
-     * 
+     *
      * @param <M> key type
      * @param <N> value type
      * @return builder
@@ -41,22 +37,17 @@ public class UniqueCache<K, V> {
 
     /**
      * Create unique cache with given key comparator.
-     * 
-     * @param keyComparator required comparator for keys
+     *
+     * @param keyComparator   required comparator for keys
+     * @param initialCapacity retained capacity hint; must not be negative
      */
     protected UniqueCache(final Comparator<K> keyComparator,
-            int initialCapacity) {
-        this(keyComparator, initialCapacity, false);
-    }
-
-    protected UniqueCache(final Comparator<K> keyComparator,
-            final int initialCapacity, final boolean threadSafe) {
+            final int initialCapacity) {
         this.keyComparator = Vldtn.requireNonNull(keyComparator,
                 "keyComparator");
-        this.map = threadSafe
-                ? new ConcurrentHashMap<>(initialCapacity)
-                : new HashMap<>(initialCapacity, 0.75F);
-        this.threadSafe = threadSafe;
+        Vldtn.requireGreaterThanOrEqualToZero(initialCapacity,
+                "initialCapacity");
+        this.map = new ConcurrentHashMap<>(initialCapacity, 0.75f, 1);
     }
 
     Comparator<K> getKeyComparator() {
@@ -81,11 +72,7 @@ public class UniqueCache<K, V> {
         final K key = Vldtn.requireNonNull(entry.getKey(), "entry.key");
         final V value = Vldtn.requireNonNull(entry.getValue(), "entry.value");
         final V previous = map.put(key, value);
-        if (previous == null) {
-            size.incrementAndGet();
-            return true;
-        }
-        return false;
+        return previous == null;
     }
 
     /**
@@ -104,7 +91,6 @@ public class UniqueCache<K, V> {
      */
     public void clear() {
         map.clear();
-        size.set(0);
     }
 
     /**
@@ -113,7 +99,7 @@ public class UniqueCache<K, V> {
      * @return number of key value entries in cache
      */
     public int size() {
-        return size.get();
+        return map.size();
     }
 
     /**
@@ -122,7 +108,7 @@ public class UniqueCache<K, V> {
      * @return true when cache is empty
      */
     public boolean isEmpty() {
-        return size.get() == 0;
+        return map.isEmpty();
     }
 
     /**
@@ -168,7 +154,8 @@ public class UniqueCache<K, V> {
     }
 
     /**
-     * Iterates over a snapshot of the cache entries as key/value pairs.
+     * Iterates over cache entries as key/value pairs. Concurrent updates may or
+     * may not be visible during traversal.
      *
      * @param consumer consumer for each key/value pair
      */
@@ -190,15 +177,10 @@ public class UniqueCache<K, V> {
     public List<Entry<K, V>> snapshotAndClear() {
         final List<Entry<K, V>> snapshot = snapshotEntries();
         map.clear();
-        size.set(0);
         return snapshot;
     }
 
     private List<Entry<K, V>> snapshotEntries() {
-        return snapshotEntriesLocked();
-    }
-
-    private List<Entry<K, V>> snapshotEntriesLocked() {
         if (map.isEmpty()) {
             return List.of();
         }
@@ -207,9 +189,5 @@ public class UniqueCache<K, V> {
             out.add(new Entry<>(entry.getKey(), entry.getValue()));
         }
         return out;
-    }
-
-    boolean isThreadSafe() {
-        return threadSafe;
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/cache/UniqueCacheBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/cache/UniqueCacheBuilder.java
@@ -20,11 +20,9 @@ public class UniqueCacheBuilder<K, V> {
     private SortedDataFile<K, V> sdf;
 
     /**
-     * Optional initial capacity hint for the underlying map. If not provided or
-     * set to a non-positive value, the default UniqueCache constructor is used.
+     * Optional initial capacity for the backing map.
      */
     private int initialCapacity = 0;
-    private boolean threadSafe = false;
 
     protected UniqueCacheBuilder() {
 
@@ -58,21 +56,10 @@ public class UniqueCacheBuilder<K, V> {
         return this;
     }
 
-    /**
-     * Configure whether the built cache should be thread-safe.
-     *
-     * @param threadSafe true to build a thread-safe cache
-     * @return this builder
-     */
-    public UniqueCacheBuilder<K, V> withThreadSafe(final boolean threadSafe) {
-        this.threadSafe = threadSafe;
-        return this;
-    }
-
     public UniqueCache<K, V> build() {
         Vldtn.requireNonNull(sdf, "sdf");
         UniqueCache<K, V> out = new UniqueCache<>(keyComparator,
-                initialCapacity, threadSafe);
+                initialCapacity);
         try (EntryIterator<K, V> iterator = sdf.openIterator()) {
             if (!iterator.hasNext()) {
                 throw new IllegalArgumentException(
@@ -87,7 +74,7 @@ public class UniqueCacheBuilder<K, V> {
     }
 
     public UniqueCache<K, V> buildEmpty() {
-        return new UniqueCache<>(keyComparator, initialCapacity, threadSafe);
+        return new UniqueCache<>(keyComparator, initialCapacity);
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
@@ -31,6 +31,7 @@ final class SegmentCache<K, V> {
     private final AtomicInteger maxNumberOfKeysInSegmentWriteCache;
     private final AtomicInteger maxNumberOfKeysInSegmentWriteCacheDuringMaintenance;
     private final AtomicInteger bufferedWriteKeys = new AtomicInteger();
+    private static final double INITIAL_CAPACITY_RATIO = 0.75D;
     private static final int MAX_INITIAL_CAPACITY = 1_000_000;
     private final ReentrantLock capacityLock = new ReentrantLock();
     private final Condition capacityAvailable = capacityLock.newCondition();
@@ -63,13 +64,11 @@ final class SegmentCache<K, V> {
                 Vldtn.requireGreaterThanZero(
                         maxNumberOfKeysInSegmentWriteCacheDuringMaintenance,
                         "maxNumberOfKeysInSegmentWriteCacheDuringMaintenance"));
-        final int deltaCapacityHint = Math.min(
-                Vldtn.requireGreaterThanZero(maxNumberOfKeysInSegmentCache,
-                        "maxNumberOfKeysInSegmentCache"),
-                MAX_INITIAL_CAPACITY);
+        final int deltaCapacityHint = initialCapacityHint(
+                maxNumberOfKeysInSegmentCache, "maxNumberOfKeysInSegmentCache");
         this.deltaCache = UniqueCache.<K, V>builder()
                 .withKeyComparator(keyComparator)
-                .withInitialCapacity(deltaCapacityHint).withThreadSafe(true)
+                .withInitialCapacity(deltaCapacityHint)
                 .buildEmpty();
         this.writeCache = buildWriteCache();
         if (deltaEntries != null) {
@@ -587,15 +586,23 @@ final class SegmentCache<K, V> {
      * @return empty write cache
      */
     private UniqueCache<K, V> buildWriteCache() {
-        final int capacityHint = Math.min(
-                Math.max(1,
-                        maxNumberOfKeysInSegmentWriteCacheDuringMaintenance.get()),
-                MAX_INITIAL_CAPACITY);
+        final int capacityHint = initialCapacityHint(
+                maxNumberOfKeysInSegmentWriteCacheDuringMaintenance.get(),
+                "maxNumberOfKeysInSegmentWriteCacheDuringMaintenance");
         return UniqueCache.<K, V>builder()//
                 .withKeyComparator(keyComparator)//
                 .withInitialCapacity(capacityHint)//
-                .withThreadSafe(true)//
                 .buildEmpty();
+    }
+
+    private static int initialCapacityHint(final int keyLimit,
+            final String argumentName) {
+        final int validLimit = Vldtn.requireGreaterThanZero(keyLimit,
+                argumentName);
+        return Math.min(
+                Math.max(1,
+                        (int) Math.ceil(validLimit * INITIAL_CAPACITY_RATIO)),
+                MAX_INITIAL_CAPACITY);
     }
 
     private Entry<K, V> validateEntry(final Entry<K, V> entry) {

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -29,23 +29,14 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
     private final Supplier<Segment<K, V>> segmentLoader;
     private final BusyRetryPolicy retryPolicy;
     private final Runtime runtime;
-    private volatile Segment<K, V> segment;
 
     DefaultBlockingSegment(final SegmentId segmentId,
             final Supplier<Segment<K, V>> segmentLoader,
             final BusyRetryPolicy retryPolicy) {
-        this(segmentId, segmentLoader, retryPolicy, null);
-    }
-
-    DefaultBlockingSegment(final SegmentId segmentId,
-            final Supplier<Segment<K, V>> segmentLoader,
-            final BusyRetryPolicy retryPolicy,
-            final Segment<K, V> initialSegment) {
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");
         this.segmentLoader = Vldtn.requireNonNull(segmentLoader,
                 "segmentLoader");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
-        this.segment = initialSegment;
         this.runtime = new RuntimeView();
     }
 
@@ -56,7 +47,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public Segment<K, V> getSegment() {
-        return loadSegment();
+        return segmentLoader.get();
     }
 
     @Override
@@ -66,7 +57,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<V> tryGet(final K key) {
-        return loadSegment().get(key);
+        return segmentLoader.get().get(key);
     }
 
     @Override
@@ -76,7 +67,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryPut(final K key, final V value) {
-        return loadSegment().put(key, value);
+        return segmentLoader.get().put(key, value);
     }
 
     @Override
@@ -93,7 +84,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
     public OperationResult<EntryIterator<K, V>> tryOpenIterator(
             final SegmentIteratorIsolation isolation) {
         Vldtn.requireNonNull(isolation, "isolation");
-        return loadSegment().openIterator(isolation);
+        return segmentLoader.get().openIterator(isolation);
     }
 
     @Override
@@ -111,7 +102,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryFlush() {
-        return loadSegment().flush();
+        return segmentLoader.get().flush();
     }
 
     @Override
@@ -121,47 +112,28 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryCompact() {
-        return loadSegment().compact();
+        return segmentLoader.get().compact();
     }
 
     @Override
     public K checkAndRepairConsistency() {
-        return loadSegment().checkAndRepairConsistency();
+        return segmentLoader.get().checkAndRepairConsistency();
     }
 
     @Override
     public void invalidateIterators() {
-        loadSegment().invalidateIterators();
-    }
-
-    private Segment<K, V> loadSegment() {
-        final Segment<K, V> loaded = segmentLoader.get();
-        segment = loaded;
-        return loaded;
+        segmentLoader.get().invalidateIterators();
     }
 
     private <T> T runBlocking(final String operation,
             final Function<Segment<K, V>, OperationResult<T>> action) {
         final long startNanos = retryPolicy.startNanos();
         while (true) {
-            /**
-             * Problems:
-             * 
-             * - executton could be here waiting for stopping BUSY, but it have about 5 ms
-             * to move it to CLOSED state. Status CLOSED mean closing segment and unloading
-             * of segment from memory.
-             * 
-             */
-            final Segment<K, V> currentSegment = loadSegment();
-            final OperationResult<T> result = action.apply(currentSegment);
+            final OperationResult<T> result = action.apply(segmentLoader.get());
             if (result.getStatus() == OperationStatus.OK) {
                 return result.getValue();
             }
             if (isRetryable(result.getStatus())) {
-                if (result.getStatus() == OperationStatus.CLOSED
-                        && segment == currentSegment) {
-                    segment = null;
-                }
                 retryPolicy.backoffOrThrow(startNanos, operation, segmentId);
                 continue;
             }
@@ -189,47 +161,47 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
         @Override
         public SegmentState getState() {
-            return loadSegment().getState();
+            return segmentLoader.get().getState();
         }
 
         @Override
         public SegmentStats getStats() {
-            return loadSegment().getStats();
+            return segmentLoader.get().getStats();
         }
 
         @Override
         public SegmentRuntimeSnapshot getRuntimeSnapshot() {
-            return loadSegment().getRuntimeSnapshot();
+            return segmentLoader.get().getRuntimeSnapshot();
         }
 
         @Override
         public long getNumberOfKeys() {
-            return loadSegment().getNumberOfKeys();
+            return segmentLoader.get().getNumberOfKeys();
         }
 
         @Override
         public int getNumberOfKeysInWriteCache() {
-            return loadSegment().getNumberOfKeysInWriteCache();
+            return segmentLoader.get().getNumberOfKeysInWriteCache();
         }
 
         @Override
         public long getNumberOfKeysInCache() {
-            return loadSegment().getNumberOfKeysInCache();
+            return segmentLoader.get().getNumberOfKeysInCache();
         }
 
         @Override
         public long getNumberOfKeysInSegmentCache() {
-            return loadSegment().getNumberOfKeysInSegmentCache();
+            return segmentLoader.get().getNumberOfKeysInSegmentCache();
         }
 
         @Override
         public int getNumberOfDeltaCacheFiles() {
-            return loadSegment().getNumberOfDeltaCacheFiles();
+            return segmentLoader.get().getNumberOfDeltaCacheFiles();
         }
 
         @Override
         public void updateRuntimeLimits(final SegmentRuntimeLimits limits) {
-            loadSegment().applyRuntimeLimits(
+            segmentLoader.get().applyRuntimeLimits(
                     Vldtn.requireNonNull(limits, "limits"));
         }
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
@@ -189,12 +189,7 @@ final class SegmentRegistryCache<K, V> {
 
     boolean updateLimit(final int newLimit) {
         limit.set(Vldtn.requireGreaterThanZero(newLimit, "newLimit"));
-        while (size.get() > limit.get()) {
-            if (!removeLastRecentUsedSegment(null)) {
-                return false;
-            }
-        }
-        return true;
+        return evictSynchronouslyAboveLimit(null);
     }
 
     List<Segment<K, V>> readyValuesSnapshot() {
@@ -230,22 +225,37 @@ final class SegmentRegistryCache<K, V> {
         if (size.get() <= limit.get()) {
             return;
         }
-        removeLastRecentUsedSegment(exceptKey);
+        evictSynchronouslyAboveLimit(exceptKey);
     }
 
     boolean removeLastRecentUsedSegment(final SegmentId exceptKey) {
-        final EvictionCandidate<K, V> candidate;
-        evictionLock.lock();
-        try {
-            candidate = selectLeastRecentlyUsedCandidate(exceptKey);
-            if (candidate == null) {
+        final EvictionCandidate<K, V> candidate = selectEvictionCandidate(
+                exceptKey);
+        if (candidate == null) {
+            return false;
+        }
+        return startUnloadAsync(candidate);
+    }
+
+    private boolean evictSynchronouslyAboveLimit(final SegmentId exceptKey) {
+        while (size.get() > limit.get()) {
+            final EvictionCandidate<K, V> candidate = selectEvictionCandidate(
+                    exceptKey);
+            if (candidate == null || !unloadAndFinalize(candidate, true)) {
                 return false;
             }
+        }
+        return true;
+    }
+
+    private EvictionCandidate<K, V> selectEvictionCandidate(
+            final SegmentId exceptKey) {
+        evictionLock.lock();
+        try {
+            return selectLeastRecentlyUsedCandidate(exceptKey);
         } finally {
             evictionLock.unlock();
         }
-        startUnloadAsync(candidate);
-        return true;
     }
 
     private EvictionCandidate<K, V> selectLeastRecentlyUsedCandidate(
@@ -295,18 +305,23 @@ final class SegmentRegistryCache<K, V> {
         }
     }
 
-    private void startUnloadAsync(final EvictionCandidate<K, V> candidate) {
+    private boolean startUnloadAsync(final EvictionCandidate<K, V> candidate) {
         try {
-            unloadExecutor.execute(() -> {
-                if (!unloadValue(candidate.value)) {
-                    candidate.entry.cancelUnload();
-                    return;
-                }
-                finalizeRemoval(candidate.key, candidate.entry, true);
-            });
+            unloadExecutor.execute(() -> unloadAndFinalize(candidate, true));
+            return true;
         } catch (final RejectedExecutionException ex) {
             candidate.entry.cancelUnload();
+            return false;
         }
+    }
+
+    private boolean unloadAndFinalize(final EvictionCandidate<K, V> candidate,
+            final boolean eviction) {
+        if (!unloadValue(candidate.value)) {
+            candidate.entry.cancelUnload();
+            return false;
+        }
+        return finalizeRemoval(candidate.key, candidate.entry, eviction);
     }
 
     private boolean finalizeRemoval(final SegmentId key,

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -94,9 +94,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
     public BlockingSegment<K, V> loadSegment(final SegmentId segmentId) {
         final SegmentId validatedSegmentId = Vldtn.requireNonNull(segmentId,
                 SEGMENT_ID_PARAMETER);
-        final Segment<K, V> loaded = blockingFacade.loadSegment(
-                validatedSegmentId);
-        return toBlockingSegment(validatedSegmentId, loaded);
+        blockingFacade.loadSegment(validatedSegmentId);
+        return toBlockingSegment(validatedSegmentId);
     }
 
     @Override
@@ -105,7 +104,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         final SegmentId validatedSegmentId = Vldtn.requireNonNull(segmentId,
                 SEGMENT_ID_PARAMETER);
         return blockingFacade.tryGetSegment(validatedSegmentId)
-                .map(segment -> toBlockingSegment(validatedSegmentId, segment));
+                .map(ignored -> toBlockingSegment(validatedSegmentId));
     }
 
     @Override
@@ -117,13 +116,13 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
             return Optional.empty();
         }
         return cache.getIfReady(validatedSegmentId)
-                .map(segment -> toBlockingSegment(validatedSegmentId, segment));
+                .map(ignored -> toBlockingSegment(validatedSegmentId));
     }
 
     @Override
     public BlockingSegment<K, V> createSegment() {
         final Segment<K, V> created = blockingFacade.createSegment();
-        return toBlockingSegment(created.getId(), created);
+        return toBlockingSegment(created.getId());
     }
 
     @Override
@@ -316,8 +315,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
     }
 
     private List<BlockingSegment<K, V>> loadedBlockingSegmentsSnapshot() {
-        return loadedSegmentsSnapshot().stream().map(this::toBlockingSegment)
-                .toList();
+        return loadedSegmentsSnapshot().stream()
+                .map(segment -> toBlockingSegment(segment.getId())).toList();
     }
 
     /** {@inheritDoc} */
@@ -332,17 +331,11 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         return runtime;
     }
 
-    private BlockingSegment<K, V> toBlockingSegment(
-            final Segment<K, V> segment) {
-        return toBlockingSegment(segment.getId(), segment);
-    }
-
-    private BlockingSegment<K, V> toBlockingSegment(final SegmentId segmentId,
-            final Segment<K, V> segment) {
+    private BlockingSegment<K, V> toBlockingSegment(final SegmentId segmentId) {
         return blockingSegments.computeIfAbsent(segmentId,
                 id -> new DefaultBlockingSegment<>(id,
                         () -> blockingFacade.loadSegment(id),
-                        blockingRetryPolicy, segment));
+                        blockingRetryPolicy));
     }
 
     private static OperationStatus resultForState(

--- a/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheBuilderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheBuilderTest.java
@@ -1,7 +1,6 @@
 package org.hestiastore.index.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,41 +139,6 @@ class UniqueCacheBuilderTest {
     }
 
     @Test
-    void test_build_with_threadSafe_true_returns_thread_safe_cache() {
-        final List<Entry<Integer, String>> data = List.of(
-                Entry.of(1, "a"), Entry.of(2, "b"));
-        final EntryIteratorWithCurrent<Integer, String> iterator = new EntryIteratorList<>(
-                data);
-        when(sdf.openIterator()).thenReturn(iterator);
-
-        final UniqueCache<Integer, String> cache = UniqueCache
-                .<Integer, String>builder()
-                .withKeyComparator(Integer::compareTo)
-                .withDataFile(sdf)
-                .withThreadSafe(true)
-                .build();
-
-        assertTrue(cache.isThreadSafe());
-    }
-
-    @Test
-    void test_build_with_threadSafe_false_returns_plain_cache() {
-        final List<Entry<Integer, String>> data = List.of(Entry.of(1, "a"));
-        final EntryIteratorWithCurrent<Integer, String> iterator = new EntryIteratorList<>(
-                data);
-        when(sdf.openIterator()).thenReturn(iterator);
-
-        final UniqueCache<Integer, String> cache = UniqueCache
-                .<Integer, String>builder()
-                .withKeyComparator(Integer::compareTo)
-                .withDataFile(sdf)
-                .withThreadSafe(false)
-                .build();
-
-        assertFalse(cache.isThreadSafe());
-    }
-
-    @Test
     void test_buildEmpty_without_dataFile_returns_empty_cache() {
         final UniqueCache<Integer, String> cache = UniqueCache
                 .<Integer, String>builder()
@@ -185,25 +149,4 @@ class UniqueCacheBuilderTest {
         assertEquals(0, cache.size());
     }
 
-    @Test
-    void test_buildEmpty_threadSafe_false_returns_plain_cache() {
-        final UniqueCache<Integer, String> cache = UniqueCache
-                .<Integer, String>builder()
-                .withKeyComparator(Integer::compareTo)
-                .withThreadSafe(false)
-                .buildEmpty();
-
-        assertFalse(cache.isThreadSafe());
-    }
-
-    @Test
-    void test_buildEmpty_threadSafe_true_returns_thread_safe_cache() {
-        final UniqueCache<Integer, String> cache = UniqueCache
-                .<Integer, String>builder()
-                .withKeyComparator(Integer::compareTo)
-                .withThreadSafe(true)
-                .buildEmpty();
-
-        assertTrue(cache.isThreadSafe());
-    }
 }

--- a/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
@@ -180,12 +180,11 @@ class UniqueCacheTest {
     }
 
     @Test
-    void test_threadSafe_cache_handles_concurrent_updates() throws Exception {
+    void test_cache_handles_concurrent_updates_by_default() throws Exception {
         final UniqueCache<Integer, String> threadSafe = UniqueCache
                 .<Integer, String>builder()
                 .withKeyComparator(Integer::compareTo)
                 .withInitialCapacity(16)
-                .withThreadSafe(true)
                 .buildEmpty();
         final int threads = 6;
         final int perThread = 200;

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -283,10 +284,10 @@ class SegmentRegistryCacheTest {
 
     @Test
     void evictsLeastRecentlyUsedWhenLimitExceeded() {
-        final List<Integer> evicted = new CopyOnWriteArrayList<>();
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
         final SegmentRegistryCache<Integer, String> cache = newCache(
                 2, key -> segment(key.getId()),
-                value -> evicted.add(value.getId().getId()));
+                value -> closedIds.add(value.getId().getId()));
 
         cache.get(id(1));
         cache.get(id(2));
@@ -294,8 +295,8 @@ class SegmentRegistryCacheTest {
         cache.get(id(3));
 
         assertTrue(cache.getSize() <= 2);
-        assertEquals(1, evicted.size());
-        assertEquals(2, evicted.get(0));
+        assertEquals(1, closedIds.size());
+        assertEquals(2, closedIds.get(0));
     }
 
     @Test
@@ -321,10 +322,10 @@ class SegmentRegistryCacheTest {
 
     @Test
     void removeLastRecentUsedSegmentSkipsExceptKey() {
-        final List<Integer> evicted = new CopyOnWriteArrayList<>();
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
         final SegmentRegistryCache<Integer, String> cache = newCache(
                 10, key -> segment(key.getId()),
-                value -> evicted.add(value.getId().getId()));
+                value -> closedIds.add(value.getId().getId()));
 
         cache.get(id(1));
         cache.get(id(2));
@@ -334,21 +335,21 @@ class SegmentRegistryCacheTest {
 
         assertTrue(cache.removeLastRecentUsedSegment(id(1)));
 
-        assertEquals(1, evicted.size());
-        assertEquals(2, evicted.get(0));
+        assertEquals(1, closedIds.size());
+        assertEquals(2, closedIds.get(0));
         assertEquals(id(1), cache.get(id(1)).getId());
     }
 
     @Test
     void removeLastRecentUsedSegmentSkipsBusyCandidateWithoutStall()
             throws Exception {
-        final List<Integer> evicted = new CopyOnWriteArrayList<>();
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
         final AtomicBoolean segmentTwoUnloadAllowed = new AtomicBoolean(true);
         final ExecutorService unloadExecutor = Executors.newSingleThreadExecutor();
         try {
             final SegmentRegistryCache<Integer, String> cache = newCache(
                     10, key -> segment(key.getId()),
-                    value -> evicted.add(value.getId().getId()), unloadExecutor,
+                    value -> closedIds.add(value.getId().getId()), unloadExecutor,
                     value -> value.getId().getId() != 2
                             || segmentTwoUnloadAllowed.get());
 
@@ -360,10 +361,10 @@ class SegmentRegistryCacheTest {
             segmentTwoUnloadAllowed.set(false);
 
             assertTrue(cache.removeLastRecentUsedSegment(id(1)));
-            waitUntil(() -> evicted.size() == 1, 1000);
+            waitUntil(() -> closedIds.size() == 1, 1000);
 
-            assertEquals(1, evicted.size());
-            assertEquals(3, evicted.get(0));
+            assertEquals(1, closedIds.size());
+            assertEquals(3, closedIds.get(0));
             assertEquals(id(2), cache.get(id(2)).getId());
         } finally {
             unloadExecutor.shutdownNow();
@@ -371,7 +372,7 @@ class SegmentRegistryCacheTest {
     }
 
     @Test
-    void evictionCloseRunsAsyncAndRemovalHappensAfterCloseSuccess()
+    void loadWaitsForSynchronousEvictionWhenLimitExceeded()
             throws Exception {
         final CountDownLatch closeStarted = new CountDownLatch(1);
         final CountDownLatch allowClose = new CountDownLatch(1);
@@ -387,16 +388,54 @@ class SegmentRegistryCacheTest {
 
             final Future<Segment<Integer, String>> loadSecond = executor
                     .submit(() -> cache.get(id(2)));
-            assertEquals(id(2),
-                    loadSecond.get(300, TimeUnit.MILLISECONDS).getId());
             assertTrue(closeStarted.await(1, TimeUnit.SECONDS));
             assertEquals(2, cache.getSize());
+            assertFalse(loadSecond.isDone());
 
             allowClose.countDown();
-            waitUntil(() -> cache.getSize() == 1, 1000);
+            assertEquals(id(2),
+                    loadSecond.get(1, TimeUnit.SECONDS).getId());
+            assertEquals(1, cache.getSize());
         } finally {
             unloadExecutor.shutdownNow();
         }
+    }
+
+    @Test
+    void getEvictsSynchronouslyToConfiguredLimit() {
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
+        final List<Runnable> queuedUnloads = new CopyOnWriteArrayList<>();
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                1, key -> segment(key.getId()),
+                value -> closedIds.add(value.getId().getId()),
+                queuedUnloads::add);
+
+        cache.get(id(1));
+        cache.get(id(2));
+        cache.get(id(3));
+
+        assertTrue(queuedUnloads.isEmpty());
+        assertEquals(List.of(1, 2), closedIds);
+        assertEquals(1, cache.getSize());
+    }
+
+    @Test
+    void removeLastRecentUsedSegmentReturnsFalseWhenAsyncUnloadIsRejected() {
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
+        final Executor rejectingExecutor = task -> {
+            throw new RejectedExecutionException("rejected");
+        };
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                10, key -> segment(key.getId()),
+                value -> closedIds.add(value.getId().getId()),
+                rejectingExecutor);
+
+        cache.get(id(1));
+        cache.get(id(2));
+
+        assertFalse(cache.removeLastRecentUsedSegment(null));
+        assertTrue(closedIds.isEmpty());
+        assertEquals(2, cache.getSize());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make UniqueCache always use the concurrent backing map and remove the obsolete withThreadSafe builder option
- keep initial capacity preallocation, but size SegmentCache hints at 75% of configured limits
- enforce SegmentRegistryCache limits synchronously during load/limit changes and surface async eviction rejection
- remove retained segment references from blocking wrappers and update regression tests

## Tests
- mvn -pl engine -Dtest=UniqueCacheBuilderTest,UniqueCacheTest,SegmentRegistryCacheTest,SegmentRegistryImplTest,DefaultBlockingSegmentTest,SegmentCacheTest test
- mvn clean verify