### PR TITLE
Retry write-cache-full with maintenance enabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@
 - Changes in persistence, configuration, or codec layers must include direct tests for round-trip behavior, backward compatibility, and invalid-input handling.
 - Changes in factory, lifecycle, or transaction layers must include direct tests for open/close/commit ordering, repeated calls, and rollback or cleanup on failure paths.
 - Changes in registry, provider, supplier, or spec-mapping layers must include direct tests for unknown IDs, duplicate registration, canonicalization, and negative-path resolution failures.
+- When an operation status is interpreted differently by configuration, test both the status producer and the caller/config interpretation path for enabled and disabled modes.
 - New public classes, public overloads, and new persistence/runtime adaptation paths must have direct tests for the main happy path and at least one representative failure path.
 - If a JUnit test class uses mocks, annotate it with `@ExtendWith(MockitoExtension.class)`.
 - Create one private field per mocked dependency.

--- a/engine/src/main/java/org/hestiastore/index/OperationStatus.java
+++ b/engine/src/main/java/org/hestiastore/index/OperationStatus.java
@@ -2,6 +2,11 @@ package org.hestiastore.index;
 
 /**
  * Public operation status used by legacy segment and registry APIs.
+ * <p>
+ * {@link #WRITE_CACHE_FULL} means the raw segment could not accept the
+ * operation because write-cache capacity is currently exhausted. Registry
+ * blocking calls interpret it according to automatic-maintenance configuration:
+ * retryable when maintenance is enabled, terminal when maintenance is disabled.
  */
 public enum OperationStatus {
     OK,

--- a/engine/src/main/java/org/hestiastore/index/segment/Segment.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/Segment.java
@@ -153,8 +153,9 @@ public interface Segment<K, V> {
      * @param key   key to write (non-null)
      * @param value value to write (non-null)
      * @return write result, including {@link OperationStatus#WRITE_CACHE_FULL}
-     *         when capacity is exhausted and no automatic maintenance path can
-     *         make progress
+     *         when the segment write cache has no immediate capacity. Blocking
+     *         registry callers may treat that status as retryable when
+     *         automatic maintenance is enabled.
      */
     OperationResult<Void> put(K key, V value);
 

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
@@ -16,6 +16,12 @@ import org.hestiastore.index.segment.SegmentStats;
  * The blocking segment keeps the registry as the source of truth for
  * loading/reloading a segment and converts retryable operation statuses into
  * bounded blocking calls.
+ * <p>
+ * Blocking calls treat {@code WRITE_CACHE_FULL} as retryable when automatic
+ * maintenance is enabled. In that mode, flush or compact work can free segment
+ * write-cache capacity, so the status has the same blocking meaning as
+ * {@code BUSY}. When automatic maintenance is disabled, the same status is a
+ * terminal failure because no background path can free capacity.
  *
  * @param <K> key type
  * @param <V> value type

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -16,6 +16,8 @@ import org.hestiastore.index.segment.SegmentRuntimeLimits;
 import org.hestiastore.index.segment.SegmentRuntimeSnapshot;
 import org.hestiastore.index.segment.SegmentState;
 import org.hestiastore.index.segment.SegmentStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Registry-backed implementation of retry-aware blocking segment operations.
@@ -25,18 +27,24 @@ import org.hestiastore.index.segment.SegmentStats;
  */
 final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
+    private static final Logger logger = LoggerFactory
+            .getLogger(DefaultBlockingSegment.class);
+
     private final SegmentId segmentId;
     private final Supplier<Segment<K, V>> segmentLoader;
     private final BusyRetryPolicy retryPolicy;
+    private final boolean automaticMaintenanceEnabled;
     private final Runtime runtime;
 
     DefaultBlockingSegment(final SegmentId segmentId,
             final Supplier<Segment<K, V>> segmentLoader,
-            final BusyRetryPolicy retryPolicy) {
+            final BusyRetryPolicy retryPolicy,
+            final boolean automaticMaintenanceEnabled) {
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");
         this.segmentLoader = Vldtn.requireNonNull(segmentLoader,
                 "segmentLoader");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
+        this.automaticMaintenanceEnabled = automaticMaintenanceEnabled;
         this.runtime = new RuntimeView();
     }
 
@@ -129,11 +137,14 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
             final Function<Segment<K, V>, OperationResult<T>> action) {
         final long startNanos = retryPolicy.startNanos();
         while (true) {
-            final OperationResult<T> result = action.apply(segmentLoader.get());
+            final Segment<K, V> segment = segmentLoader.get();
+            final OperationResult<T> result = action.apply(segment);
             if (result.getStatus() == OperationStatus.OK) {
                 return result.getValue();
             }
             if (isRetryable(result.getStatus())) {
+                logRetryableWriteCacheFull(operation, result.getStatus(),
+                        segment);
                 retryPolicy.backoffOrThrow(startNanos, operation, segmentId);
                 continue;
             }
@@ -141,9 +152,23 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
         }
     }
 
-    private static boolean isRetryable(final OperationStatus status) {
+    private boolean isRetryable(final OperationStatus status) {
         return status == OperationStatus.BUSY
-                || status == OperationStatus.CLOSED;
+                || status == OperationStatus.CLOSED
+                || (status == OperationStatus.WRITE_CACHE_FULL
+                        && automaticMaintenanceEnabled);
+    }
+
+    private void logRetryableWriteCacheFull(final String operation,
+            final OperationStatus status, final Segment<K, V> segment) {
+        if (status != OperationStatus.WRITE_CACHE_FULL
+                || !logger.isDebugEnabled()) {
+            return;
+        }
+        logger.debug(
+                "Write cache full treated as busy: segment='{}' operation='{}' automaticMaintenanceEnabled='{}' state='{}' writeCacheKeys='{}'",
+                segmentId, operation, automaticMaintenanceEnabled,
+                segment.getState(), segment.getNumberOfKeysInWriteCache());
     }
 
     private IndexException operationFailure(final String operation,

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryBuilder.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryBuilder.java
@@ -170,6 +170,8 @@ public final class SegmentRegistryBuilder<K, V> {
                 .busyBackoffMillis();
         final int busyTimeoutMillis = resolvedConf.maintenance()
                 .busyTimeoutMillis();
+        final boolean automaticMaintenanceEnabled = resolvedConf.maintenance()
+                .backgroundAutoEnabled();
         final SegmentFactory<K, V> resolvedFactory = new SegmentFactory<>(
                 resolvedDirectory, resolvedKeyDescriptor,
                 resolvedValueDescriptor, resolvedConf,
@@ -203,7 +205,8 @@ public final class SegmentRegistryBuilder<K, V> {
                 resolvedRegistryMaintenanceExecutor);
         return new SegmentRegistryImpl<>(resolvedAllocator, resolvedFileSystem,
                 cache, resolvedRegistryCloseRetryPolicy, gate, resolvedFactory,
-                resolvedFactory, resolvedBlockingRetryPolicy);
+                resolvedFactory, resolvedBlockingRetryPolicy,
+                automaticMaintenanceEnabled);
     }
 
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -46,6 +46,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
     private final SegmentRegistry.Materialization<K, V> materialization;
     private final SegmentRegistry.Runtime<K, V> runtime;
     private final ConcurrentMap<SegmentId, BlockingSegment<K, V>> blockingSegments;
+    private final boolean automaticMaintenanceEnabled;
 
     /**
      * Creates a registry using prebuilt dependencies from the builder.
@@ -63,7 +64,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
             final SegmentRegistryStateMachine gate,
             final PreparedSegmentWriterFactory<K, V> preparedSegmentWriterFactory,
             final SegmentRuntimeTuner runtimeTuner,
-            final BusyRetryPolicy blockingRetryPolicy) {
+            final BusyRetryPolicy blockingRetryPolicy,
+            final boolean automaticMaintenanceEnabled) {
         this.segmentIdAllocator = Vldtn.requireNonNull(segmentIdAllocator,
                 "segmentIdAllocator");
         this.fileSystem = Vldtn.requireNonNull(fileSystem, "fileSystem");
@@ -77,6 +79,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
                 .requireNonNull(preparedSegmentWriterFactory,
                         "preparedSegmentWriterFactory");
         this.runtimeTuner = Vldtn.requireNonNull(runtimeTuner, "runtimeTuner");
+        this.automaticMaintenanceEnabled = automaticMaintenanceEnabled;
         this.blockingFacade = new BlockingSegmentRegistryAdapter<>(this,
                 this.blockingRetryPolicy);
         this.blockingSegments = new ConcurrentHashMap<>();
@@ -335,7 +338,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         return blockingSegments.computeIfAbsent(segmentId,
                 id -> new DefaultBlockingSegment<>(id,
                         () -> blockingFacade.loadSegment(id),
-                        blockingRetryPolicy));
+                        blockingRetryPolicy, automaticMaintenanceEnabled));
     }
 
     private static OperationStatus resultForState(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
@@ -2,6 +2,8 @@ package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
@@ -108,22 +111,72 @@ class SegmentIndexSessionRetryTest {
         }
     }
 
+    @Test
+    void putPastWriteCacheLimitSucceedsWhenAutomaticMaintenanceEnabled() {
+        closeCurrentIndex();
+        index = newIndex("write-cache-full-auto-enabled", true);
+
+        for (int key = 0; key < 8; key++) {
+            index.put(key, "value-" + key);
+        }
+        index.maintenance().flushAndWait();
+
+        for (int key = 0; key < 8; key++) {
+            assertEquals("value-" + key, index.get(key));
+        }
+    }
+
+    @Test
+    void putPastWriteCacheLimitFailsWhenAutomaticMaintenanceDisabled() {
+        closeCurrentIndex();
+        index = newIndex("write-cache-full-auto-disabled", false);
+
+        index.put(1, "one");
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> index.put(2, "two"));
+
+        assertTrue(exception.getMessage().contains(
+                "Write cache is full for segment"));
+        assertTrue(exception.getMessage().contains(
+                "automatic maintenance is disabled"));
+    }
+
     private SegmentIndex<Integer, String> newIndex() {
-        final IndexConfiguration<Integer, String> conf = buildConf();
+        return newIndex("segment-index-retry-test", true);
+    }
+
+    private SegmentIndex<Integer, String> newIndex(final String indexName,
+            final boolean automaticMaintenanceEnabled) {
+        return newIndex(indexName, automaticMaintenanceEnabled, 5_000);
+    }
+
+    private SegmentIndex<Integer, String> newIndex(final String indexName,
+            final boolean automaticMaintenanceEnabled,
+            final int busyTimeoutMillis) {
+        final IndexConfiguration<Integer, String> conf = buildConf(indexName,
+                automaticMaintenanceEnabled, busyTimeoutMillis);
         return SegmentIndexSessionTestSupport.createStarted(
                 new MemDirectory(), tdi, tds, effective(conf));
     }
 
-    private IndexConfiguration<Integer, String> buildConf() {
+    private IndexConfiguration<Integer, String> buildConf(final String indexName,
+            final boolean automaticMaintenanceEnabled,
+            final int busyTimeoutMillis) {
         return IndexConfiguration.<Integer, String>builder()
                 .identity(identity -> identity.keyClass(Integer.class)).identity(identity -> identity.valueClass(String.class))
                 .identity(identity -> identity.keyTypeDescriptor(tdi)).identity(identity -> identity.valueTypeDescriptor(tds))
-                .identity(identity -> identity.name("segment-index-retry-test"))
+                .identity(identity -> identity.name(indexName))
                 .logging(logging -> logging.contextEnabled(false))
                 .segment(segmentConfig -> segmentConfig.cacheKeyLimit(10))
                 .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(1))
                 .writePath(writePath -> writePath.maintenanceWriteCacheKeyLimit(2))
                 .writePath(writePath -> writePath.indexBufferedWriteKeyLimit(2))
+                .maintenance(maintenance -> maintenance.busyBackoffMillis(1))
+                .maintenance(maintenance -> maintenance.busyTimeoutMillis(
+                        busyTimeoutMillis))
+                .maintenance(maintenance -> maintenance.backgroundAutoEnabled(
+                        automaticMaintenanceEnabled))
                 .segment(segmentConfig -> segmentConfig.chunkKeyLimit(2))
                 .segment(segmentConfig -> segmentConfig.maxKeys(100))
                 .segment(segmentConfig -> segmentConfig.cachedSegmentLimit(3))
@@ -134,6 +187,12 @@ class SegmentIndexSessionRetryTest {
                 .filters(filters -> filters.encodingFilters(List.of(new ChunkFilterDoNothing())))
                 .filters(filters -> filters.decodingFilters(List.of(new ChunkFilterDoNothing())))
                 .build();
+    }
+
+    private void closeCurrentIndex() {
+        if (index != null && !index.wasClosed()) {
+            index.close();
+        }
     }
 
     private static <K, V> void replaceSegment(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentCleanerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/storage/OrphanedSegmentCleanerTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.storage;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,12 +23,11 @@ class OrphanedSegmentCleanerTest {
                 .thenReturn(false, true);
         final OrphanedSegmentCleaner<Integer, String> remover =
                 new OrphanedSegmentCleaner<>(segmentRegistry,
-                        new BusyRetryPolicy(2, 1));
+                        new BusyRetryPolicy(1, 100));
 
         remover.remove(segmentId);
 
-        verify(segmentRegistry).deleteSegmentIfAvailable(segmentId);
-        verify(segmentRegistry).deleteSegmentIfAvailable(segmentId);
+        verify(segmentRegistry, times(2)).deleteSegmentIfAvailable(segmentId);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
@@ -1,15 +1,17 @@
 package org.hestiastore.index.segmentregistry;
 
 import org.hestiastore.index.BusyRetryPolicy;
-import org.hestiastore.index.OperationResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hestiastore.index.IndexException;
+import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentRuntimeLimits;
@@ -37,9 +39,7 @@ class DefaultBlockingSegmentTest {
 
     @BeforeEach
     void setUp() {
-        handle = new DefaultBlockingSegment<>(SEGMENT_ID,
-                () -> segmentRegistry.loadSegment(SEGMENT_ID).getSegment(),
-                new BusyRetryPolicy(1, 25));
+        handle = newHandle(false);
     }
 
     @Test
@@ -74,7 +74,23 @@ class DefaultBlockingSegmentTest {
     }
 
     @Test
-    void putThrowsImmediatelyWhenWriteCacheFullStatusReturned() {
+    void putRetriesWriteCacheFullStatusWhenMaintenanceEnabled() {
+        handle = newHandle(true);
+        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
+        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
+        when(segmentHandle.getSegment()).thenReturn(segment);
+        when(segment.put(1, "one"))
+                .thenReturn(OperationResult.writeCacheFull())
+                .thenReturn(OperationResult.ok());
+
+        handle.put(1, "one");
+
+        verify(segmentRegistry, times(2)).loadSegment(SEGMENT_ID);
+        verify(segment, times(2)).put(1, "one");
+    }
+
+    @Test
+    void putThrowsImmediatelyWhenWriteCacheFullStatusReturnedAndMaintenanceDisabled() {
         final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
         when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
         when(segmentHandle.getSegment()).thenReturn(segment);
@@ -88,6 +104,23 @@ class DefaultBlockingSegmentTest {
                 exception.getMessage());
         verify(segmentRegistry).loadSegment(SEGMENT_ID);
         verify(segment).put(1, "one");
+    }
+
+    @Test
+    void putTimesOutWhenWriteCacheFullStatusPersistsAndMaintenanceEnabled() {
+        handle = newHandle(new BusyRetryPolicy(1, 5), true);
+        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
+        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
+        when(segmentHandle.getSegment()).thenReturn(segment);
+        when(segment.put(1, "one"))
+                .thenReturn(OperationResult.writeCacheFull());
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> handle.put(1, "one"));
+
+        assertTrue(exception.getMessage().contains("timed out"));
+        assertFalse(exception.getMessage().contains(
+                "automatic maintenance is disabled"));
     }
 
     @Test
@@ -109,6 +142,20 @@ class DefaultBlockingSegmentTest {
         handle.getRuntime().updateRuntimeLimits(runtimeLimits);
 
         verify(segment).applyRuntimeLimits(runtimeLimits);
+    }
+
+    private BlockingSegment<Integer, String> newHandle(
+            final boolean automaticMaintenanceEnabled) {
+        return newHandle(new BusyRetryPolicy(1, 25),
+                automaticMaintenanceEnabled);
+    }
+
+    private BlockingSegment<Integer, String> newHandle(
+            final BusyRetryPolicy retryPolicy,
+            final boolean automaticMaintenanceEnabled) {
+        return new DefaultBlockingSegment<>(SEGMENT_ID,
+                () -> segmentRegistry.loadSegment(SEGMENT_ID).getSegment(),
+                retryPolicy, automaticMaintenanceEnabled);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplCloseTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplCloseTest.java
@@ -106,7 +106,7 @@ class SegmentRegistryImplCloseTest {
         final BusyRetryPolicy blockingRetryPolicy = new BusyRetryPolicy(
                 backoffMillis, timeoutMillis);
         return new SegmentRegistryImpl<>(allocator, fs, cache, closeRetryPolicy,
-                gate, writerFactory, runtimeTuner, blockingRetryPolicy);
+                gate, writerFactory, runtimeTuner, blockingRetryPolicy, false);
     }
 
     private static SegmentRegistryCache<Integer, String> newCache(


### PR DESCRIPTION
## Summary
- Treat WRITE_CACHE_FULL as retryable in the blocking segment path when automatic maintenance is enabled.
- Keep immediate write-cache-full failure when automatic maintenance is disabled.
- Document the config-dependent interpretation and add regression coverage for both enabled and disabled modes.

## Tests
- mvn -pl engine -Dtest=DefaultBlockingSegmentTest,SegmentIndexSessionRetryTest test
- mvn -pl engine verify
- mvn clean verify
- git diff --check