### PR TITLE
Bound segment registry cache loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,12 @@
 - Be honest.
 - When it makes sense, structure responses as numbered lists.
 
-# Hestia Store Repository Rules
+## Hestia Store Repository Rules
 
 - This repository is a Maven-based Java library project with a multi-module parent build.
 - Prefer focused changes that stay within the requested scope.
 - Avoid unnecessary API-breaking changes.
+- Project-specific thrown exceptions should extend `org.hestiastore.index.IndexException` so upper application layers can handle store failures consistently.
 - Run `mvn clean verify` after non-trivial changes.
 - Use the `fix-ci-failure` skill for failing CI jobs and broken local verification runs.
 - Use the `update-dependencies` skill for Maven dependency and plugin refresh work.

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
@@ -400,12 +400,6 @@ final class IndexMemoryEstimator {
                 : UNKNOWN;
     }
 
-    private static String aboutText(final OptionalLong estimate) {
-        return estimate.isPresent()
-                ? "about " + formatBytes(estimate.getAsLong())
-                : UNKNOWN;
-    }
-
     private static void appendEstimateTreeLine(final StringBuilder out,
             final String prefix, final String connector, final String label,
             final OptionalLong estimateBytes, final String unknownReason,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitPolicyScheduler.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitPolicyScheduler.java
@@ -111,15 +111,26 @@ final class SplitPolicyScheduler<K, V> {
         final int workersToSchedule = policyState
                 .reserveWorkers(workerParallelism());
         for (int i = 0; i < workersToSchedule; i++) {
+            boolean submitted = false;
             try {
                 workerExecutor.execute(this::runWorkerLoop);
+                submitted = true;
             } catch (final RuntimeException e) {
-                policyState.markWorkerFinished();
                 if (!isClosedOrClosingState()) {
                     throw e;
                 }
                 return;
+            } finally {
+                if (!submitted) {
+                    releaseReservedWorkers(workersToSchedule - i);
+                }
             }
+        }
+    }
+
+    private void releaseReservedWorkers(final int workerCount) {
+        for (int i = 0; i < workerCount; i++) {
+            policyState.markWorkerFinished();
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitTaskCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/split/SplitTaskCoordinator.java
@@ -1,13 +1,13 @@
 package org.hestiastore.index.segmentindex.core.split;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
-import java.util.Set;
 
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
@@ -168,14 +168,17 @@ final class SplitTaskCoordinator<K, V> {
             return false;
         }
         final long scheduledAtNanos = nanoTimeSupplier.getAsLong();
+        boolean submitted = false;
         try {
             splitExecutor.execute(
                     () -> executeScheduledSplit(segmentId, splitThreshold,
                             observedKeyCount, scheduledAtNanos));
-        } catch (final RuntimeException e) {
-            scheduledSplits.remove(segmentId);
-            markSplitFinished();
-            throw e;
+            submitted = true;
+        } finally {
+            if (!submitted) {
+                scheduledSplits.remove(segmentId);
+                markSplitFinished();
+            }
         }
         return true;
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentBusyException.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentBusyException.java
@@ -1,6 +1,8 @@
 package org.hestiastore.index.segmentregistry;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.OperationStatus;
+
 /**
  * Signals that a segment operation cannot proceed because the target segment
  * or registry path is currently busy.
@@ -8,8 +10,15 @@ import org.hestiastore.index.OperationStatus;
  * This exception is internal to the segment registry package and is translated
  * to {@link OperationStatus#BUSY} at API boundaries.
  */
-final class SegmentBusyException extends RuntimeException {
+final class SegmentBusyException extends IndexException {
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a busy exception without a detail message.
+     */
+    SegmentBusyException() {
+        super();
+    }
 
     /**
      * Creates a busy exception with the provided detail message.

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryCache.java
@@ -10,9 +10,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
@@ -27,8 +27,9 @@ import org.hestiastore.index.segment.SegmentId;
  * block each other.</li>
  * <li>Only the winning thread loads a missing entry; other threads wait on
  * the entry condition.</li>
- * <li>Eviction picks the least recently used READY entry and marks it as
- * UNLOADING before closing the segment outside the locks.</li>
+ * <li>Loads reserve a cache slot before building the segment; when the cache
+ * is full, dirty victims are closed only under capacity pressure instead of
+ * allocating unbounded extra segments.</li>
  * <li>Registry contract treats LOADING and UNLOADING differently:
  * LOADING is awaited on the same key, UNLOADING is surfaced as BUSY to
  * callers by registry layer decisions.</li>
@@ -39,7 +40,8 @@ import org.hestiastore.index.segment.SegmentId;
  */
 final class SegmentRegistryCache<K, V> {
 
-    private final ConcurrentHashMap<SegmentId, Entry<Segment<K, V>>> map = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<SegmentId, SegmentRegistryEntry<K, V>> map =
+            new ConcurrentHashMap<>();
     private final AtomicInteger size = new AtomicInteger();
     private final AtomicLong accessCx = new AtomicLong();
     private final ReentrantLock evictionLock = new ReentrantLock();
@@ -84,18 +86,18 @@ final class SegmentRegistryCache<K, V> {
         Vldtn.requireNonNull(key, "key");
         while (true) {
             final long currentAccessCx = accessCx.getAndIncrement();
-            Entry<Segment<K, V>> entry = map.get(key);
+            SegmentRegistryEntry<K, V> entry = map.get(key);
             if (entry == null) {
                 missCount.increment();
-                final Entry<Segment<K, V>> created = new Entry<>(
+                final SegmentRegistryEntry<K, V> created = new SegmentRegistryEntry<>(
                         currentAccessCx);
-                final Entry<Segment<K, V>> entryInMap = map.putIfAbsent(key,
-                        created);
+                final SegmentRegistryEntry<K, V> entryInMap = map
+                        .putIfAbsent(key, created);
                 if (entryInMap == null) {
                     // Winner path: created is now the value associated with key.
                     if (!created.tryStartLoad()) {
                         map.remove(key, created);
-                        throw new IllegalStateException(
+                        throw new IndexException(
                                 "Entry cannot start load from current state");
                     }
                     return loadValue(key, created);
@@ -115,7 +117,7 @@ final class SegmentRegistryCache<K, V> {
 
     Optional<Segment<K, V>> getIfReady(final SegmentId key) {
         Vldtn.requireNonNull(key, "key");
-        final Entry<Segment<K, V>> entry = map.get(key);
+        final SegmentRegistryEntry<K, V> entry = map.get(key);
         if (entry == null) {
             return Optional.empty();
         }
@@ -124,7 +126,7 @@ final class SegmentRegistryCache<K, V> {
 
     InvalidateStatus invalidate(final SegmentId key) {
         Vldtn.requireNonNull(key, "key");
-        final Entry<Segment<K, V>> entry = map.get(key);
+        final SegmentRegistryEntry<K, V> entry = map.get(key);
         if (entry == null) {
             return InvalidateStatus.REMOVED;
         }
@@ -138,7 +140,7 @@ final class SegmentRegistryCache<K, V> {
 
     InvalidateStatus forceInvalidate(final SegmentId key) {
         Vldtn.requireNonNull(key, "key");
-        final Entry<Segment<K, V>> entry = map.get(key);
+        final SegmentRegistryEntry<K, V> entry = map.get(key);
         if (entry == null) {
             return InvalidateStatus.REMOVED;
         }
@@ -150,7 +152,7 @@ final class SegmentRegistryCache<K, V> {
     }
 
     private InvalidateStatus unloadAndRemove(final SegmentId key,
-            final Entry<Segment<K, V>> entry) {
+            final SegmentRegistryEntry<K, V> entry) {
         final Segment<K, V> value = entry.getValueForUnload();
         if (value == null) {
             entry.cancelUnload();
@@ -194,7 +196,7 @@ final class SegmentRegistryCache<K, V> {
 
     List<Segment<K, V>> readyValuesSnapshot() {
         final List<Segment<K, V>> values = new ArrayList<>();
-        for (final Entry<Segment<K, V>> entry : map.values()) {
+        for (final SegmentRegistryEntry<K, V> entry : map.values()) {
             final Segment<K, V> readyValue = entry.getReadyValue();
             if (readyValue != null) {
                 values.add(readyValue);
@@ -204,28 +206,69 @@ final class SegmentRegistryCache<K, V> {
     }
 
     private Segment<K, V> loadValue(final SegmentId key,
-            final Entry<Segment<K, V>> entry) {
-        final Segment<K, V> value;
-        try {
-            value = Vldtn.requireNonNull(segmentOperations.loadSegment(key),
-                    "loadedValue");
-        } catch (final RuntimeException ex) {
-            entry.fail(ex);
+            final SegmentRegistryEntry<K, V> entry) {
+        if (!reserveSlotForLoad(key)) {
+            final SegmentBusyException failure = new SegmentBusyException();
+            entry.fail(failure);
             map.remove(key, entry);
-            throw ex;
+            throw failure;
         }
-        entry.finishLoad(value);
-        loadCount.increment();
-        size.incrementAndGet();
-        evictIfNeeded(key);
-        return value;
+        boolean loaded = false;
+        try {
+            final Segment<K, V> value = Vldtn.requireNonNull(
+                    segmentOperations.loadSegment(key), "loadedValue");
+            entry.finishLoad(value);
+            loaded = true;
+            loadCount.increment();
+            return value;
+        } catch (final IndexException ex) {
+            entry.fail(ex);
+            throw ex;
+        } catch (final RuntimeException ex) {
+            final IndexException failure = new IndexException(
+                    "Unable to load segment " + key, ex);
+            entry.fail(failure);
+            throw failure;
+        } finally {
+            if (!loaded) {
+                cleanupFailedLoad(key, entry);
+            }
+        }
     }
 
-    private void evictIfNeeded(final SegmentId exceptKey) {
-        if (size.get() <= limit.get()) {
-            return;
+    private void cleanupFailedLoad(final SegmentId key,
+            final SegmentRegistryEntry<K, V> entry) {
+        if (map.remove(key, entry)) {
+            size.decrementAndGet();
         }
-        evictSynchronouslyAboveLimit(exceptKey);
+        entry.cancelLoadIfNeeded();
+    }
+
+    private boolean reserveSlotForLoad(final SegmentId exceptKey) {
+        evictionLock.lock();
+        try {
+            while (size.get() >= limit.get()) {
+                final EvictionCandidate<K, V> candidate =
+                        selectCandidateForCapacityPressure(exceptKey);
+                if (candidate == null || !unloadAndFinalize(candidate, true)) {
+                    return false;
+                }
+            }
+            size.incrementAndGet();
+            return true;
+        } finally {
+            evictionLock.unlock();
+        }
+    }
+
+    private EvictionCandidate<K, V> selectCandidateForCapacityPressure(
+            final SegmentId exceptKey) {
+        final EvictionCandidate<K, V> cleanCandidate =
+                selectLeastRecentlyUsedCandidate(exceptKey, false);
+        if (cleanCandidate != null) {
+            return cleanCandidate;
+        }
+        return selectLeastRecentlyUsedCandidate(exceptKey, true);
     }
 
     boolean removeLastRecentUsedSegment(final SegmentId exceptKey) {
@@ -252,23 +295,24 @@ final class SegmentRegistryCache<K, V> {
             final SegmentId exceptKey) {
         evictionLock.lock();
         try {
-            return selectLeastRecentlyUsedCandidate(exceptKey);
+            return selectLeastRecentlyUsedCandidate(exceptKey, false);
         } finally {
             evictionLock.unlock();
         }
     }
 
     private EvictionCandidate<K, V> selectLeastRecentlyUsedCandidate(
-            final SegmentId exceptKey) {
+            final SegmentId exceptKey, final boolean force) {
         long oldestAccessCx = Long.MAX_VALUE;
         SegmentId oldestKey = null;
-        Entry<Segment<K, V>> oldestEntry = null;
-        for (final Map.Entry<SegmentId, Entry<Segment<K, V>>> mapEntry : map
+        SegmentRegistryEntry<K, V> oldestEntry = null;
+        for (final Map.Entry<SegmentId, SegmentRegistryEntry<K, V>> mapEntry : map
                 .entrySet()) {
             final SegmentId key = mapEntry.getKey();
             if (exceptKey == null || !exceptKey.equals(key)) {
-                final Entry<Segment<K, V>> entry = mapEntry.getValue();
-                final long entryAccessCx = getEvictionOrder(entry);
+                final SegmentRegistryEntry<K, V> entry = mapEntry
+                        .getValue();
+                final long entryAccessCx = getEvictionOrder(entry, force);
                 if (entryAccessCx != Long.MAX_VALUE
                         && entryAccessCx < oldestAccessCx) {
                     oldestAccessCx = entryAccessCx;
@@ -281,19 +325,27 @@ final class SegmentRegistryCache<K, V> {
             return null;
         }
         final Segment<K, V> value = oldestEntry.getReadyValue();
-        if (value == null || !unloadEligibility.canUnload(value)
+        if (value == null || !canSelectForUnload(value, force)
                 || !oldestEntry.tryStartUnload(value)) {
             return null;
         }
         return new EvictionCandidate<>(oldestKey, oldestEntry, value);
     }
 
-    private long getEvictionOrder(final Entry<Segment<K, V>> entry) {
+    private long getEvictionOrder(
+            final SegmentRegistryEntry<K, V> entry,
+            final boolean force) {
         final Segment<K, V> value = entry.getReadyValue();
-        if (value == null || !unloadEligibility.canUnload(value)) {
+        if (value == null || !canSelectForUnload(value, force)) {
             return Long.MAX_VALUE;
         }
         return entry.getEvictionOrder(value);
+    }
+
+    private boolean canSelectForUnload(final Segment<K, V> value,
+            final boolean force) {
+        return force ? unloadEligibility.canForceUnload(value)
+                : unloadEligibility.canUnload(value);
     }
 
     private boolean unloadValue(final Segment<K, V> value) {
@@ -325,7 +377,8 @@ final class SegmentRegistryCache<K, V> {
     }
 
     private boolean finalizeRemoval(final SegmentId key,
-            final Entry<Segment<K, V>> entry, final boolean eviction) {
+            final SegmentRegistryEntry<K, V> entry,
+            final boolean eviction) {
         final boolean removed = map.remove(key, entry);
         if (removed) {
             size.decrementAndGet();
@@ -342,200 +395,13 @@ final class SegmentRegistryCache<K, V> {
         BUSY
     }
 
-    enum EntryState {
-        LOADING,
-        READY,
-        UNLOADING
-    }
-
-    static final class EntryBusyException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
-    }
-
-    static final class Entry<V> {
-        private final ReentrantLock lock = new ReentrantLock();
-        private final Condition ready = lock.newCondition();
-        private volatile long accessCx;
-        private EntryState state = EntryState.LOADING;
-        private V value;
-        private RuntimeException failure;
-
-        Entry(final long accessCx) {
-            this.accessCx = accessCx;
-        }
-
-        boolean tryStartLoad() {
-            lock.lock();
-            try {
-                return state == EntryState.LOADING && value == null
-                        && failure == null;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        /**
-         * Waits for this key while loading is in progress and returns the
-         * currently visible value.
-         *
-         * @param currentAccessCx access sequence for recency tracking
-         * @return loaded value when READY, otherwise null when entry became
-         *         unavailable
-         */
-        V waitWhileLoading(final long currentAccessCx) {
-            lock.lock();
-            try {
-                while (state == EntryState.LOADING) {
-                    if (failure != null) {
-                        throw failure;
-                    }
-                    try {
-                        ready.await();
-                    } catch (final InterruptedException ex) {
-                        Thread.currentThread().interrupt();
-                        throw new IllegalStateException(
-                                "Interrupted while waiting for cache entry",
-                                ex);
-                    }
-                }
-                if (failure != null) {
-                    throw failure;
-                }
-                if (state == EntryState.READY) {
-                    accessCx = currentAccessCx;
-                    return value;
-                }
-                if (state == EntryState.UNLOADING) {
-                    throw new EntryBusyException();
-                }
-                return null;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        void finishLoad(final V value) {
-            lock.lock();
-            try {
-                if (state != EntryState.LOADING || this.value != null
-                        || failure != null) {
-                    throw new IllegalStateException(
-                            "Invalid transition to READY from " + state);
-                }
-                this.value = value;
-                this.state = EntryState.READY;
-                ready.signalAll();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        void fail(final RuntimeException failure) {
-            lock.lock();
-            try {
-                if (state != EntryState.LOADING || this.value != null
-                        || this.failure != null) {
-                    throw new IllegalStateException(
-                            "Invalid fail transition from " + state);
-                }
-                this.failure = failure;
-                ready.signalAll();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        long getEvictionOrder(final V expectedValue) {
-            lock.lock();
-            try {
-                if (state != EntryState.READY || value == null) {
-                    return Long.MAX_VALUE;
-                }
-                if (value != expectedValue) {
-                    return Long.MAX_VALUE;
-                }
-                return accessCx;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        boolean tryStartUnload(final V expectedValue) {
-            lock.lock();
-            try {
-                if (state != EntryState.READY || value == null) {
-                    return false;
-                }
-                if (value != expectedValue) {
-                    return false;
-                }
-                state = EntryState.UNLOADING;
-                return true;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        V getValueForUnload() {
-            lock.lock();
-            try {
-                if (state != EntryState.UNLOADING) {
-                    return null;
-                }
-                return value;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        void finishUnload() {
-            lock.lock();
-            try {
-                if (state != EntryState.UNLOADING) {
-                    throw new IllegalStateException(
-                            "Invalid transition to missing from " + state);
-                }
-                value = null;
-                ready.signalAll();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        void cancelUnload() {
-            lock.lock();
-            try {
-                if (state != EntryState.UNLOADING || value == null) {
-                    return;
-                }
-                state = EntryState.READY;
-                ready.signalAll();
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        V getReadyValue() {
-            lock.lock();
-            try {
-                if (state != EntryState.READY || value == null
-                        || failure != null) {
-                    return null;
-                }
-                return value;
-            } finally {
-                lock.unlock();
-            }
-        }
-    }
-
     private static final class EvictionCandidate<K, V> {
         private final SegmentId key;
-        private final Entry<Segment<K, V>> entry;
+        private final SegmentRegistryEntry<K, V> entry;
         private final Segment<K, V> value;
 
         private EvictionCandidate(final SegmentId key,
-                final Entry<Segment<K, V>> entry,
+                final SegmentRegistryEntry<K, V> entry,
                 final Segment<K, V> value) {
             this.key = key;
             this.entry = entry;

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntry.java
@@ -1,0 +1,259 @@
+package org.hestiastore.index.segmentregistry;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.segment.Segment;
+
+/**
+ * Coordinates one registry cache entry through load, ready, and unload states.
+ *
+ * @param <K> segment key type
+ * @param <V> segment value type
+ */
+final class SegmentRegistryEntry<K, V> {
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition ready = lock.newCondition();
+    private volatile long accessCx;
+    private EntryState state = EntryState.LOADING;
+    private Segment<K, V> value;
+    private IndexException failure;
+
+    /**
+     * Creates an entry with the initial access sequence used for eviction
+     * ordering.
+     *
+     * @param accessCx access sequence
+     */
+    SegmentRegistryEntry(final long accessCx) {
+        this.accessCx = accessCx;
+    }
+
+    /**
+     * Returns whether this newly created entry may perform the segment load.
+     *
+     * @return true when loading can start
+     */
+    boolean tryStartLoad() {
+        lock.lock();
+        try {
+            return state == EntryState.LOADING && value == null
+                    && failure == null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits for an in-progress load and returns the ready value.
+     *
+     * @param currentAccessCx access sequence for recency tracking
+     * @return loaded value when ready, otherwise null when unavailable
+     */
+    Segment<K, V> waitWhileLoading(final long currentAccessCx) {
+        lock.lock();
+        try {
+            while (state == EntryState.LOADING) {
+                if (failure != null) {
+                    throw failure;
+                }
+                try {
+                    ready.await();
+                } catch (final InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IndexException(
+                            "Interrupted while waiting for cache entry", ex);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+            if (state == EntryState.READY) {
+                accessCx = currentAccessCx;
+                return value;
+            }
+            if (state == EntryState.UNLOADING) {
+                throw new SegmentBusyException();
+            }
+            return null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Marks this entry ready with its loaded value.
+     *
+     * @param value loaded value
+     */
+    void finishLoad(final Segment<K, V> value) {
+        lock.lock();
+        try {
+            if (state != EntryState.LOADING || this.value != null
+                    || failure != null) {
+                throw new IndexException(
+                        "Invalid transition to READY from " + state);
+            }
+            this.value = value;
+            this.state = EntryState.READY;
+            ready.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Records a load failure and releases waiting readers.
+     *
+     * @param failure load failure
+     */
+    void fail(final IndexException failure) {
+        lock.lock();
+        try {
+            if (state != EntryState.LOADING || this.value != null
+                    || this.failure != null) {
+                throw new IndexException("Invalid fail transition from "
+                        + state);
+            }
+            this.failure = failure;
+            ready.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Cancels a still-loading entry and wakes waiters.
+     */
+    void cancelLoadIfNeeded() {
+        lock.lock();
+        try {
+            if (state == EntryState.LOADING && failure == null) {
+                failure = new SegmentBusyException();
+                ready.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns this entry's eviction order when the expected value is still
+     * ready.
+     *
+     * @param expectedValue value that must still be present
+     * @return access sequence, or {@link Long#MAX_VALUE} when not evictable
+     */
+    long getEvictionOrder(final Segment<K, V> expectedValue) {
+        lock.lock();
+        try {
+            if (state != EntryState.READY || value == null) {
+                return Long.MAX_VALUE;
+            }
+            if (value != expectedValue) {
+                return Long.MAX_VALUE;
+            }
+            return accessCx;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Starts unloading when this entry is ready and still holds the expected
+     * value.
+     *
+     * @param expectedValue value that must still be present
+     * @return true when unload ownership was acquired
+     */
+    boolean tryStartUnload(final Segment<K, V> expectedValue) {
+        lock.lock();
+        try {
+            if (state != EntryState.READY || value == null) {
+                return false;
+            }
+            if (value != expectedValue) {
+                return false;
+            }
+            state = EntryState.UNLOADING;
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the value currently owned by an unload operation.
+     *
+     * @return value being unloaded, or null when unload is not active
+     */
+    Segment<K, V> getValueForUnload() {
+        lock.lock();
+        try {
+            if (state != EntryState.UNLOADING) {
+                return null;
+            }
+            return value;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Completes an unload and wakes waiting readers.
+     */
+    void finishUnload() {
+        lock.lock();
+        try {
+            if (state != EntryState.UNLOADING) {
+                throw new IndexException(
+                        "Invalid transition to missing from " + state);
+            }
+            value = null;
+            ready.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Rolls an active unload back to ready.
+     */
+    void cancelUnload() {
+        lock.lock();
+        try {
+            if (state != EntryState.UNLOADING || value == null) {
+                return;
+            }
+            state = EntryState.READY;
+            ready.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the cached value only when this entry is ready.
+     *
+     * @return ready value, or null when loading, unloading, or failed
+     */
+    Segment<K, V> getReadyValue() {
+        lock.lock();
+        try {
+            if (state != EntryState.READY || value == null || failure != null) {
+                return null;
+            }
+            return value;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private enum EntryState {
+        LOADING,
+        READY,
+        UNLOADING
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -231,8 +231,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         final Segment<K, V> segment;
         try {
             segment = cache.get(segmentId);
-        } catch (final SegmentRegistryCache.EntryBusyException
-                | SegmentBusyException ex) {
+        } catch (final SegmentBusyException ex) {
             return OperationResult.busy();
         } catch (final RuntimeException ex) {
             logger.error("Failed to load segment '{}'.", segmentId, ex);

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentUnloadEligibility.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentUnloadEligibility.java
@@ -21,10 +21,19 @@ final class SegmentUnloadEligibility {
                 || isReadySegmentEvictable(segment));
     }
 
+    boolean canForceUnload(final Segment<?, ?> segment) {
+        return segment != null && (segment.getState() == SegmentState.CLOSED
+                || isReadySegmentWithId(segment));
+    }
+
     private boolean isReadySegmentEvictable(final Segment<?, ?> segment) {
         final boolean closing = gate.getState() != SegmentRegistryState.READY;
-        final SegmentId segmentId = segment.getId();
-        return segmentId != null && segment.getState() == SegmentState.READY
+        return isReadySegmentWithId(segment)
                 && (closing || segment.getNumberOfKeysInWriteCache() == 0);
+    }
+
+    private boolean isReadySegmentWithId(final Segment<?, ?> segment) {
+        final SegmentId segmentId = segment.getId();
+        return segmentId != null && segment.getState() == SegmentState.READY;
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/AbstractSegmentIndexTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/AbstractSegmentIndexTest.java
@@ -184,7 +184,7 @@ public abstract class AbstractSegmentIndexTest extends AbstractDataTest {
             final Map<SegmentId, ?> entries = (Map<SegmentId, ?>) mapField
                     .get(cache);
             final Class<?> entryClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$Entry");
+                    "org.hestiastore.index.segmentregistry.SegmentRegistryEntry");
             final Field valueField = entryClass.getDeclaredField("value");
             valueField.setAccessible(true);
             final Map<SegmentId, Segment<?, ?>> segments = new HashMap<>();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
+import static org.hestiastore.index.segmentregistry.SegmentRegistryCacheTestSupport.putReadyEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -376,7 +376,7 @@ class SegmentIndexAsyncMaintenanceTest {
             final Object registry, final SegmentId segmentId,
             final Segment<K, V> segment) {
         final Object cache = readCache(registry);
-        putCacheEntry(cache, segmentId, segment);
+        putReadyEntry(cache, segmentId, segment);
     }
 
     @SuppressWarnings("unchecked")
@@ -403,50 +403,4 @@ class SegmentIndexAsyncMaintenanceTest {
         }
     }
 
-    private static void putCacheEntry(final Object cache,
-            final SegmentId segmentId, final Segment<?, ?> segment) {
-        try {
-            final Field mapField = cache.getClass().getDeclaredField("map");
-            mapField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            final ConcurrentHashMap<SegmentId, Object> map =
-                    (ConcurrentHashMap<SegmentId, Object>) mapField
-                            .get(cache);
-            final Class<?> entryClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$Entry");
-            final var ctor = entryClass.getDeclaredConstructor(long.class);
-            ctor.setAccessible(true);
-            final Object entry = ctor.newInstance(0L);
-            final Field stateField = entryClass.getDeclaredField("state");
-            stateField.setAccessible(true);
-            final Class<?> stateClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$EntryState");
-            stateField.set(entry, enumConstant(stateClass, "READY"));
-            final Field valueField = entryClass.getDeclaredField("value");
-            valueField.setAccessible(true);
-            valueField.set(entry, segment);
-            if (map.put(segmentId, entry) == null) {
-                final Field sizeField = cache.getClass().getDeclaredField(
-                        "size");
-                sizeField.setAccessible(true);
-                final java.util.concurrent.atomic.AtomicInteger size =
-                        (java.util.concurrent.atomic.AtomicInteger) sizeField
-                                .get(cache);
-                size.incrementAndGet();
-            }
-        } catch (final ReflectiveOperationException ex) {
-            throw new IllegalStateException(
-                    "Unable to update registry cache for test", ex);
-        }
-    }
-
-    private static Object enumConstant(final Class<?> enumClass,
-            final String name) {
-        for (final Object constant : enumClass.getEnumConstants()) {
-            if (((Enum<?>) constant).name().equals(name)) {
-                return constant;
-            }
-        }
-        throw new IllegalArgumentException("Unknown enum constant: " + name);
-    }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
+import static org.hestiastore.index.segmentregistry.SegmentRegistryCacheTestSupport.putReadyEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
@@ -199,7 +199,7 @@ class SegmentIndexSessionRetryTest {
             final Object registry, final SegmentId segmentId,
             final Segment<K, V> segment) {
         final Object cache = readCache(registry);
-        putCacheEntry(cache, segmentId, segment);
+        putReadyEntry(cache, segmentId, segment);
     }
 
     @SuppressWarnings("unchecked")
@@ -226,47 +226,4 @@ class SegmentIndexSessionRetryTest {
         }
     }
 
-    private static void putCacheEntry(final Object cache,
-            final SegmentId segmentId, final Segment<?, ?> segment) {
-        try {
-            final Field mapField = cache.getClass().getDeclaredField("map");
-            mapField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            final ConcurrentHashMap<SegmentId, Object> map =
-                    (ConcurrentHashMap<SegmentId, Object>) mapField
-                            .get(cache);
-            final Class<?> entryClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$Entry");
-            final var ctor = entryClass.getDeclaredConstructor(long.class);
-            ctor.setAccessible(true);
-            final Object entry = ctor.newInstance(0L);
-            final Field stateField = entryClass.getDeclaredField("state");
-            stateField.setAccessible(true);
-            final Class<?> stateClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$EntryState");
-            stateField.set(entry, enumConstant(stateClass, "READY"));
-            final Field valueField = entryClass.getDeclaredField("value");
-            valueField.setAccessible(true);
-            valueField.set(entry, segment);
-            map.put(segmentId, entry);
-            final Field sizeField = cache.getClass().getDeclaredField("size");
-            sizeField.setAccessible(true);
-            final java.util.concurrent.atomic.AtomicInteger size = (java.util.concurrent.atomic.AtomicInteger) sizeField
-                    .get(cache);
-            size.incrementAndGet();
-        } catch (final ReflectiveOperationException ex) {
-            throw new IllegalStateException(
-                    "Unable to update registry cache for test", ex);
-        }
-    }
-
-    private static Object enumConstant(final Class<?> enumClass,
-            final String name) {
-        for (final Object constant : enumClass.getEnumConstants()) {
-            if (((Enum<?>) constant).name().equals(name)) {
-                return constant;
-            }
-        }
-        throw new IllegalArgumentException("Unknown enum constant: " + name);
-    }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/SplitPolicySchedulerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/SplitPolicySchedulerTest.java
@@ -1,0 +1,67 @@
+package org.hestiastore.index.segmentindex.core.split;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hestiastore.index.segmentindex.SegmentIndexState;
+import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfiguration;
+import org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexMaintenanceConfiguration;
+import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningState;
+import org.hestiastore.index.segmentindex.core.SegmentIndexRuntimeState;
+import org.hestiastore.index.segmentindex.core.routing.MappedSegmentLeaseService;
+import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SplitPolicySchedulerTest {
+
+    @Mock
+    private EffectiveIndexConfiguration<String, String> conf;
+
+    @Mock
+    private RuntimeTuningState runtimeTuningState;
+
+    @Mock
+    private SegmentRouteMap<String> keyToSegmentMap;
+
+    @Mock
+    private MappedSegmentLeaseService<String, String> segmentLeaseService;
+
+    @Mock
+    private SplitTaskCoordinator<String, String> splitExecutionCoordinator;
+
+    @Mock
+    private ScheduledExecutorService splitPolicyScheduler;
+
+    @Mock
+    private SegmentIndexRuntimeState runtimeState;
+
+    @Test
+    void workerSubmissionErrorReleasesReservedWorkers() {
+        final SplitWorkerState policyState = new SplitWorkerState();
+        final Executor workerExecutor = task -> {
+            throw new OutOfMemoryError("worker submit failed");
+        };
+        when(conf.maintenance()).thenReturn(
+                new EffectiveIndexMaintenanceConfiguration(3, 1, 1, 50, true));
+        when(runtimeState.currentState()).thenReturn(SegmentIndexState.READY);
+        final SplitPolicyScheduler<String, String> scheduler =
+                new SplitPolicyScheduler<>(conf, runtimeTuningState,
+                        keyToSegmentMap, segmentLeaseService,
+                        splitExecutionCoordinator, workerExecutor,
+                        splitPolicyScheduler, runtimeState,
+                        new SplitStatsRecorder(), policyState,
+                        new SplitCandidateQueue());
+
+        assertThrows(OutOfMemoryError.class, scheduler::requestFullSplitScan);
+
+        assertFalse(policyState.isWorkerActive());
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/SplitTaskCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/split/SplitTaskCoordinatorTest.java
@@ -1,6 +1,10 @@
 package org.hestiastore.index.segmentindex.core.split;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -143,16 +147,30 @@ class SplitTaskCoordinatorTest {
 
         verifyNoInteractions(splitCoordinator);
         final Runnable task = scheduledTask.get();
-        org.junit.jupiter.api.Assertions.assertNotNull(task);
-        org.junit.jupiter.api.Assertions.assertEquals(1,
-                coordinator.splitInFlightCount());
+        assertNotNull(task);
+        assertEquals(1, coordinator.splitInFlightCount());
 
         task.run();
 
         verify(splitCoordinator).tryPrepareSplit(segmentHandle, 100L, 101L);
         coordinator.awaitSplitsIdle(1_000L);
-        org.junit.jupiter.api.Assertions.assertEquals(0,
-                coordinator.splitInFlightCount());
+        assertEquals(0, coordinator.splitInFlightCount());
+    }
+
+    @Test
+    void failedSplitSubmissionClearsInFlightStateForErrors() {
+        final SegmentId segmentId = SegmentId.of(23);
+        final Executor splitExecutor = task -> {
+            throw new OutOfMemoryError("split executor failed");
+        };
+        final SplitTaskCoordinator<String, String> coordinator = newCoordinator(
+                splitExecutor);
+
+        assertThrows(OutOfMemoryError.class,
+                () -> coordinator.scheduleEligibleSplit(segmentId, 100L, 101L));
+
+        assertEquals(0, coordinator.splitInFlightCount());
+        assertFalse(coordinator.isSplitBlocked(segmentId));
     }
 
     @Test
@@ -179,10 +197,8 @@ class SplitTaskCoordinatorTest {
         scheduledTask.get().run();
 
         final SplitStats stats = statsRecorder.statsSnapshot(0, 0);
-        org.junit.jupiter.api.Assertions.assertEquals(3_000L,
-                stats.splitTaskStartDelayP95Micros());
-        org.junit.jupiter.api.Assertions.assertEquals(4_000L,
-                stats.splitTaskRunLatencyP95Micros());
+        assertEquals(3_000L, stats.splitTaskStartDelayP95Micros());
+        assertEquals(4_000L, stats.splitTaskRunLatencyP95Micros());
     }
 
     @Test
@@ -317,7 +333,7 @@ class SplitTaskCoordinatorTest {
         verify(splitLease).abort();
         verify(splitLease, never()).completeAfterPublish();
         verifyNoInteractions(splitPublishCoordinator);
-        org.junit.jupiter.api.Assertions.assertFalse(rescheduled);
+        assertFalse(rescheduled);
     }
 
     @Test
@@ -367,9 +383,8 @@ class SplitTaskCoordinatorTest {
         final boolean rescheduled = coordinator
                 .scheduleEligibleSplit(segmentId, 100L, 101L);
 
-        org.junit.jupiter.api.Assertions.assertFalse(rescheduled);
-        org.junit.jupiter.api.Assertions.assertEquals(1,
-                scheduledCount.get());
+        assertFalse(rescheduled);
+        assertEquals(1, scheduledCount.get());
     }
 
     @Test
@@ -399,9 +414,8 @@ class SplitTaskCoordinatorTest {
                 .scheduleEligibleSplit(segmentId, 100L,
                         currentKeys.get());
 
-        org.junit.jupiter.api.Assertions.assertTrue(rescheduled);
-        org.junit.jupiter.api.Assertions.assertEquals(2,
-                scheduledCount.get());
+        assertTrue(rescheduled);
+        assertEquals(2, scheduledCount.get());
     }
 
     @Test
@@ -428,9 +442,8 @@ class SplitTaskCoordinatorTest {
         final boolean rescheduled = coordinator
                 .scheduleEligibleSplit(segmentId, 100L, 101L);
 
-        org.junit.jupiter.api.Assertions.assertTrue(rescheduled);
-        org.junit.jupiter.api.Assertions.assertEquals(2,
-                scheduledCount.get());
+        assertTrue(rescheduled);
+        assertEquals(2, scheduledCount.get());
     }
 
     @Test
@@ -460,18 +473,15 @@ class SplitTaskCoordinatorTest {
         final boolean blockedByAdaptiveCooldown = coordinator
                 .scheduleEligibleSplit(segmentId, 100L, 101L);
 
-        org.junit.jupiter.api.Assertions
-                .assertFalse(blockedByAdaptiveCooldown);
-        org.junit.jupiter.api.Assertions.assertEquals(1,
-                scheduledCount.get());
+        assertFalse(blockedByAdaptiveCooldown);
+        assertEquals(1, scheduledCount.get());
 
         nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(800L));
         final boolean rescheduled = coordinator
                 .scheduleEligibleSplit(segmentId, 100L, 101L);
 
-        org.junit.jupiter.api.Assertions.assertTrue(rescheduled);
-        org.junit.jupiter.api.Assertions.assertEquals(2,
-                scheduledCount.get());
+        assertTrue(rescheduled);
+        assertEquals(2, scheduledCount.get());
     }
 
     private SplitTaskCoordinator<String, String> newCoordinator() {

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTest.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
@@ -270,16 +272,62 @@ class SegmentRegistryCacheTest {
         final ExecutionException firstFailure = assertThrows(
                 ExecutionException.class,
                 () -> futureGetWithTimeout(first));
-        assertSame(expected, firstFailure.getCause());
+        final IndexException firstCause = assertInstanceOf(
+                IndexException.class, firstFailure.getCause());
+        assertSame(expected, firstCause.getCause());
         for (final Future<Segment<Integer, String>> waiter : waiterFutures) {
             final ExecutionException waiterFailure = assertThrows(
                     ExecutionException.class,
                     () -> futureGetWithTimeout(waiter));
-            assertSame(expected, waiterFailure.getCause());
+            final IndexException waiterCause = assertInstanceOf(
+                    IndexException.class, waiterFailure.getCause());
+            assertSame(expected, waiterCause.getCause());
         }
         assertTrue(loads.get() >= 1 && loads.get() <= 2,
                 "Failure must fan out to threads already waiting on the failed entry;"
                         + " one retry after entry removal is acceptable.");
+    }
+
+    @Test
+    void getLoadErrorReleasesReservedSlotAndUnblocksWaiter()
+            throws Exception {
+        final AtomicInteger loads = new AtomicInteger();
+        final CountDownLatch loadStarted = new CountDownLatch(1);
+        final CountDownLatch waiterStarted = new CountDownLatch(1);
+        final CountDownLatch allowFailure = new CountDownLatch(1);
+        final OutOfMemoryError expected = new OutOfMemoryError("load failed");
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                1, key -> {
+                    loads.incrementAndGet();
+                    loadStarted.countDown();
+                    awaitLatch(allowFailure);
+                    throw expected;
+                }, segment -> {
+                });
+
+        final Future<Segment<Integer, String>> first = executor
+                .submit(() -> cache.get(id(1)));
+        assertTrue(loadStarted.await(1, TimeUnit.SECONDS));
+
+        final Future<Segment<Integer, String>> waiter = executor.submit(() -> {
+            waiterStarted.countDown();
+            return cache.get(id(1));
+        });
+        assertTrue(waiterStarted.await(1, TimeUnit.SECONDS));
+        allowFailure.countDown();
+
+        final ExecutionException firstFailure = assertThrows(
+                ExecutionException.class,
+                () -> futureGetWithTimeout(first));
+        assertSame(expected, firstFailure.getCause());
+        final ExecutionException waiterFailure = assertThrows(
+                ExecutionException.class,
+                () -> futureGetWithTimeout(waiter));
+        assertTrue(waiterFailure.getCause() == expected
+                || waiterFailure.getCause() instanceof SegmentBusyException);
+        assertEquals(0, cache.getSize());
+        assertTrue(loads.get() >= 1 && loads.get() <= 2,
+                "The waiter may observe the failed entry or retry after cleanup.");
     }
 
     @Test
@@ -389,7 +437,7 @@ class SegmentRegistryCacheTest {
             final Future<Segment<Integer, String>> loadSecond = executor
                     .submit(() -> cache.get(id(2)));
             assertTrue(closeStarted.await(1, TimeUnit.SECONDS));
-            assertEquals(2, cache.getSize());
+            assertEquals(1, cache.getSize());
             assertFalse(loadSecond.isDone());
 
             allowClose.countDown();
@@ -399,6 +447,31 @@ class SegmentRegistryCacheTest {
         } finally {
             unloadExecutor.shutdownNow();
         }
+    }
+
+    @Test
+    void getEvictsDirtyResidentSegmentsUnderCapacityPressure() {
+        final AtomicInteger loads = new AtomicInteger();
+        final List<Integer> closedIds = new CopyOnWriteArrayList<>();
+        final SegmentRegistryStateMachine gate = new SegmentRegistryStateMachine();
+        gate.finishFreezeToReady();
+        final SegmentRegistryCache<Integer, String> cache = newCache(
+                1, key -> {
+                    loads.incrementAndGet();
+                    return segmentWithWriteCache(key.getId(), 1);
+                }, value -> closedIds.add(value.getId().getId()),
+                Runnable::run, new SegmentUnloadEligibility(gate));
+
+        assertEquals(id(1), cache.get(id(1)).getId());
+        for (int segmentId = 2; segmentId <= 5; segmentId++) {
+            assertEquals(id(segmentId), cache.get(id(segmentId)).getId());
+            assertEquals(1, cache.getSize());
+        }
+
+        assertEquals(5, loads.get());
+        assertEquals(List.of(1, 2, 3, 4), closedIds);
+        assertEquals(1, cache.getSize());
+        assertEquals(id(5), cache.get(id(5)).getId());
     }
 
     @Test
@@ -451,17 +524,12 @@ class SegmentRegistryCacheTest {
                     }, unloadExecutor);
 
             assertEquals(id(1), cache.get(id(1)).getId());
-            assertEquals(id(2), cache.get(id(2)).getId());
+            assertThrows(SegmentBusyException.class,
+                    () -> cache.get(id(2)));
             assertTrue(closeStarted.await(1, TimeUnit.SECONDS));
 
-            waitUntil(() -> {
-                try {
-                    return id(1).equals(cache.get(id(1)).getId());
-                } catch (final SegmentRegistryCache.EntryBusyException ex) {
-                    return false;
-                }
-            }, 1000);
-            assertEquals(2, cache.getSize());
+            assertEquals(id(1), cache.get(id(1)).getId());
+            assertEquals(1, cache.getSize());
         } finally {
             unloadExecutor.shutdownNow();
         }
@@ -500,7 +568,7 @@ class SegmentRegistryCacheTest {
                 .submit(() -> cache.invalidate(id(1)));
         unloadStarted.await(1, TimeUnit.SECONDS);
 
-        assertThrows(SegmentRegistryCache.EntryBusyException.class,
+        assertThrows(SegmentBusyException.class,
                 () -> cache.get(id(1)));
 
         allowUnload.countDown();
@@ -528,7 +596,7 @@ class SegmentRegistryCacheTest {
         assertTrue(unloadStarted.await(1, TimeUnit.SECONDS));
 
         assertEquals(id(2), cache.get(id(2)).getId());
-        assertThrows(SegmentRegistryCache.EntryBusyException.class,
+        assertThrows(SegmentBusyException.class,
                 () -> cache.get(id(1)));
 
         allowUnload.countDown();
@@ -642,40 +710,6 @@ class SegmentRegistryCacheTest {
         assertEquals(1, loads.get());
     }
 
-    @Test
-    void entryTransitionsFromLoadingToReadyToUnloading() {
-        final SegmentRegistryCache.Entry<String> entry = new SegmentRegistryCache.Entry<>(
-                7L);
-
-        assertTrue(entry.tryStartLoad());
-
-        final String value = "value";
-        entry.finishLoad(value);
-        assertEquals(value, entry.waitWhileLoading(8L));
-
-        assertTrue(entry.tryStartUnload(value));
-        assertEquals(value, entry.getValueForUnload());
-        entry.finishUnload();
-
-        assertThrows(SegmentRegistryCache.EntryBusyException.class,
-                () -> entry.waitWhileLoading(9L));
-    }
-
-    @Test
-    void entryInvalidTransitionsFailPredictably() {
-        final SegmentRegistryCache.Entry<String> entry = new SegmentRegistryCache.Entry<>(
-                1L);
-
-        entry.finishLoad("value");
-
-        assertThrows(IllegalStateException.class,
-                () -> entry.finishLoad("other"));
-        final IllegalStateException failure = new IllegalStateException("boom");
-        assertThrows(IllegalStateException.class,
-                () -> entry.fail(failure));
-        assertThrows(IllegalStateException.class, entry::finishUnload);
-    }
-
     private static SegmentRegistryCache<Integer, String> newCache(
             final int limit,
             final Function<SegmentId, Segment<Integer, String>> loader,
@@ -699,6 +733,21 @@ class SegmentRegistryCacheTest {
             final Consumer<Segment<Integer, String>> unloader,
             final Executor unloadExecutor,
             final Predicate<Segment<Integer, String>> unloadablePredicate) {
+        final SegmentUnloadEligibility unloadEligibility = Mockito
+                .mock(SegmentUnloadEligibility.class);
+        Mockito.when(unloadEligibility.canUnload(Mockito.any()))
+                .thenAnswer(invocation -> unloadablePredicate
+                        .test(invocation.getArgument(0)));
+        return newCache(limit, loader, unloader, unloadExecutor,
+                unloadEligibility);
+    }
+
+    private static SegmentRegistryCache<Integer, String> newCache(
+            final int limit,
+            final Function<SegmentId, Segment<Integer, String>> loader,
+            final Consumer<Segment<Integer, String>> unloader,
+            final Executor unloadExecutor,
+            final SegmentUnloadEligibility unloadEligibility) {
         @SuppressWarnings("unchecked")
         final SegmentLoadCloseOperations<Integer, String> segmentOperations = Mockito
                 .mock(SegmentLoadCloseOperations.class);
@@ -710,11 +759,6 @@ class SegmentRegistryCacheTest {
             return null;
         }).when(segmentOperations)
                 .closeSegmentIfNeeded(Mockito.<Segment<Integer, String>>any());
-        final SegmentUnloadEligibility unloadEligibility = Mockito
-                .mock(SegmentUnloadEligibility.class);
-        Mockito.when(unloadEligibility.canUnload(Mockito.any()))
-                .thenAnswer(invocation -> unloadablePredicate
-                        .test(invocation.getArgument(0)));
         return new SegmentRegistryCache<>(limit, segmentOperations,
                 unloadEligibility, unloadExecutor);
     }
@@ -726,6 +770,14 @@ class SegmentRegistryCacheTest {
         Mockito.when(segment.getState()).thenReturn(SegmentState.READY);
         Mockito.when(segment.getNumberOfKeysInWriteCache()).thenReturn(0);
         Mockito.when(segment.close()).thenReturn(OperationResult.ok());
+        return segment;
+    }
+
+    private static Segment<Integer, String> segmentWithWriteCache(
+            final int id, final int writeCacheKeys) {
+        final Segment<Integer, String> segment = segment(id);
+        Mockito.when(segment.getNumberOfKeysInWriteCache())
+                .thenReturn(writeCacheKeys);
         return segment;
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTestSupport.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryCacheTestSupport.java
@@ -1,0 +1,54 @@
+package org.hestiastore.index.segmentregistry;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hestiastore.index.segment.Segment;
+import org.hestiastore.index.segment.SegmentId;
+
+/**
+ * Test-only access to private registry cache entries for cross-package tests.
+ */
+public final class SegmentRegistryCacheTestSupport {
+
+    private SegmentRegistryCacheTestSupport() {
+    }
+
+    /**
+     * Inserts a ready entry into a registry cache object.
+     *
+     * @param cache     registry cache instance
+     * @param segmentId segment id
+     * @param segment   ready segment
+     */
+    public static <K, V> void putReadyEntry(final Object cache,
+            final SegmentId segmentId, final Segment<K, V> segment) {
+        try {
+            final SegmentRegistryEntry<K, V> entry = new SegmentRegistryEntry<>(
+                    0L);
+            entry.finishLoad(segment);
+            if (readMap(cache).put(segmentId, entry) == null) {
+                readSize(cache).incrementAndGet();
+            }
+        } catch (final ReflectiveOperationException ex) {
+            throw new IllegalStateException(
+                    "Unable to update registry cache for test", ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentHashMap<SegmentId, Object> readMap(
+            final Object cache) throws ReflectiveOperationException {
+        final Field mapField = cache.getClass().getDeclaredField("map");
+        mapField.setAccessible(true);
+        return (ConcurrentHashMap<SegmentId, Object>) mapField.get(cache);
+    }
+
+    private static AtomicInteger readSize(final Object cache)
+            throws ReflectiveOperationException {
+        final Field sizeField = cache.getClass().getDeclaredField("size");
+        sizeField.setAccessible(true);
+        return (AtomicInteger) sizeField.get(cache);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntryTest.java
@@ -1,0 +1,53 @@
+package org.hestiastore.index.segmentregistry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.segment.Segment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SegmentRegistryEntryTest {
+
+    @Mock
+    private Segment<Integer, String> segment;
+
+    @Mock
+    private Segment<Integer, String> otherSegment;
+
+    @Test
+    void transitionsFromLoadingToReadyToUnloading() {
+        final SegmentRegistryEntry<Integer, String> entry = new SegmentRegistryEntry<>(
+                7L);
+
+        assertTrue(entry.tryStartLoad());
+
+        entry.finishLoad(segment);
+        assertEquals(segment, entry.waitWhileLoading(8L));
+
+        assertTrue(entry.tryStartUnload(segment));
+        assertEquals(segment, entry.getValueForUnload());
+        entry.finishUnload();
+
+        assertThrows(SegmentBusyException.class,
+                () -> entry.waitWhileLoading(9L));
+    }
+
+    @Test
+    void invalidTransitionsFailPredictably() {
+        final SegmentRegistryEntry<Integer, String> entry = new SegmentRegistryEntry<>(
+                1L);
+
+        entry.finishLoad(segment);
+
+        assertThrows(IndexException.class, () -> entry.finishLoad(otherSegment));
+        final IndexException failure = new IndexException("boom");
+        assertThrows(IndexException.class, () -> entry.fail(failure));
+        assertThrows(IndexException.class, entry::finishUnload);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplCloseTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplCloseTest.java
@@ -35,7 +35,7 @@ class SegmentRegistryImplCloseTest {
                 gate, 1, 2_000);
 
         final SegmentId segmentId = SegmentId.of(11);
-        final SegmentRegistryCache.Entry<Segment<Integer, String>> entry = new SegmentRegistryCache.Entry<>(
+        final SegmentRegistryEntry<Integer, String> entry = new SegmentRegistryEntry<>(
                 1L);
         readCacheMap(cache).put(segmentId, entry);
 
@@ -70,7 +70,7 @@ class SegmentRegistryImplCloseTest {
                 gate, 1, 40);
 
         final SegmentId segmentId = SegmentId.of(12);
-        final SegmentRegistryCache.Entry<Segment<Integer, String>> loadingEntry = new SegmentRegistryCache.Entry<>(
+        final SegmentRegistryEntry<Integer, String> loadingEntry = new SegmentRegistryEntry<>(
                 1L);
         readCacheMap(cache).put(segmentId, loadingEntry);
 
@@ -132,13 +132,13 @@ class SegmentRegistryImplCloseTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<SegmentId, SegmentRegistryCache.Entry<Segment<Integer, String>>> readCacheMap(
+    private static Map<SegmentId, SegmentRegistryEntry<Integer, String>> readCacheMap(
             final SegmentRegistryCache<Integer, String> cache) {
         try {
             final Field mapField = SegmentRegistryCache.class
                     .getDeclaredField("map");
             mapField.setAccessible(true);
-            return (Map<SegmentId, SegmentRegistryCache.Entry<Segment<Integer, String>>>) mapField
+            return (Map<SegmentId, SegmentRegistryEntry<Integer, String>>) mapField
                     .get(cache);
         } catch (final ReflectiveOperationException ex) {
             throw new IllegalStateException("Unable to access cache map", ex);

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
@@ -410,24 +410,14 @@ class SegmentRegistryImplTest {
     }
 
     private Object createLoadingEntry(final long accessCx) {
-        try {
-            final Class<?> entryClass = Class.forName(
-                    "org.hestiastore.index.segmentregistry.SegmentRegistryCache$Entry");
-            final java.lang.reflect.Constructor<?> constructor = entryClass
-                    .getDeclaredConstructor(long.class);
-            constructor.setAccessible(true);
-            return constructor.newInstance(accessCx);
-        } catch (final ReflectiveOperationException ex) {
-            throw new IllegalStateException("Unable to create loading entry",
-                    ex);
-        }
+        return new SegmentRegistryEntry<Integer, String>(accessCx);
     }
 
     private void finishLoad(final Object entry,
             final Segment<Integer, String> segment) {
         try {
             final java.lang.reflect.Method method = entry.getClass()
-                    .getDeclaredMethod("finishLoad", Object.class);
+                    .getDeclaredMethod("finishLoad", Segment.class);
             method.setAccessible(true);
             method.invoke(entry, segment);
         } catch (final ReflectiveOperationException ex) {
@@ -438,7 +428,7 @@ class SegmentRegistryImplTest {
     private boolean invokeTryStartUnload(final Object entry) {
         try {
             final java.lang.reflect.Method method = entry.getClass()
-                    .getDeclaredMethod("tryStartUnload", Object.class);
+                    .getDeclaredMethod("tryStartUnload", Segment.class);
             method.setAccessible(true);
             return ((Boolean) method.invoke(entry, getReadyValue(entry)))
                     .booleanValue();

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentUnloadEligibilityTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentUnloadEligibilityTest.java
@@ -62,6 +62,31 @@ class SegmentUnloadEligibilityTest {
     }
 
     @Test
+    void canForceUnloadReturnsTrueForDirtyReadySegmentWhenRegistryReady() {
+        final SegmentRegistryStateMachine gate = new SegmentRegistryStateMachine();
+        gate.finishFreezeToReady();
+        final SegmentUnloadEligibility eligibility = new SegmentUnloadEligibility(
+                gate);
+        @SuppressWarnings("unchecked")
+        final Segment<Integer, String> segment = Mockito.mock(Segment.class);
+        when(segment.getId()).thenReturn(SegmentId.of(9));
+        when(segment.getState()).thenReturn(SegmentState.READY);
+
+        assertTrue(eligibility.canForceUnload(segment));
+    }
+
+    @Test
+    void canForceUnloadReturnsFalseForReadySegmentWithoutId() {
+        final SegmentUnloadEligibility eligibility = new SegmentUnloadEligibility(
+                new SegmentRegistryStateMachine());
+        @SuppressWarnings("unchecked")
+        final Segment<Integer, String> segment = Mockito.mock(Segment.class);
+        when(segment.getState()).thenReturn(SegmentState.READY);
+
+        assertFalse(eligibility.canForceUnload(segment));
+    }
+
+    @Test
     void canUnloadReturnsTrueForDirtyReadySegmentWhenRegistryClosing() {
         final SegmentUnloadEligibility eligibility = new SegmentUnloadEligibility(
                 new SegmentRegistryStateMachine());


### PR DESCRIPTION
## Summary
- reserve segment registry cache capacity before loading segment instances
- force-evict dirty ready segments under capacity pressure or return busy instead of growing unbounded
- keep split policy scans on already-loaded mapped segments and harden split worker cleanup

## Tests
- git diff --check
- mvn -pl engine -Dtest=SegmentRegistryCacheTest,SegmentUnloadEligibilityTest,SplitPolicySchedulerTest,SplitTaskCoordinatorTest,MappedSegmentLeaseServiceTest,MappedSegmentLeaseServiceBehaviorTest test
- mvn clean verify