### PR TITLE
Limit internal visibility cleanup

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/chunkstorecache/ChunkStoreCacheKey.java
+++ b/engine/src/main/java/org/hestiastore/index/chunkstorecache/ChunkStoreCacheKey.java
@@ -7,7 +7,7 @@ import org.hestiastore.index.Vldtn;
 /**
  * Versioned key for one parsed persisted chunk page.
  */
-public final class ChunkStoreCacheKey {
+final class ChunkStoreCacheKey {
 
     private final String ownerId;
     private final long activeVersion;
@@ -30,20 +30,20 @@ public final class ChunkStoreCacheKey {
      * @param chunkPosition chunk start position
      * @return cache key
      */
-    public static ChunkStoreCacheKey of(final String ownerId,
+    static ChunkStoreCacheKey of(final String ownerId,
             final long activeVersion, final long chunkPosition) {
         return new ChunkStoreCacheKey(ownerId, activeVersion, chunkPosition);
     }
 
-    public String ownerId() {
+    String ownerId() {
         return ownerId;
     }
 
-    public long activeVersion() {
+    long activeVersion() {
         return activeVersion;
     }
 
-    public long chunkPosition() {
+    long chunkPosition() {
         return chunkPosition;
     }
 

--- a/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockReaderEmpty.java
+++ b/engine/src/main/java/org/hestiastore/index/datablockfile/DataBlockReaderEmpty.java
@@ -5,7 +5,7 @@ import org.hestiastore.index.AbstractCloseableResource;
 /**
  * Data block reader that does not read any data.
  */
-public class DataBlockReaderEmpty extends AbstractCloseableResource
+class DataBlockReaderEmpty extends AbstractCloseableResource
         implements DataBlockReader {
 
     @Override

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentFilesRenamer.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentFilesRenamer.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  * Provides a utility method to rename all files associated with a segment from
  * one SegmentFiles instance to another.
  */
-public class SegmentFilesRenamer {
+class SegmentFilesRenamer {
 
     private static final Logger logger = LoggerFactory
             .getLogger(SegmentFilesRenamer.class);
@@ -25,7 +25,7 @@ public class SegmentFilesRenamer {
      * @param <K>            the key type
      * @param <V>            the value type
      */
-    public <K, V> void renameFiles(final SegmentFiles<K, V> from,
+    <K, V> void renameFiles(final SegmentFiles<K, V> from,
             final SegmentFiles<K, V> to,
             final SegmentPropertiesManager fromProperties) {
         Vldtn.requireNonNull(from, "from");

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
@@ -243,7 +243,7 @@ public interface SegmentIndex<K, V> extends CloseableResource {
             final Directory directory,
             final IndexConfiguration<M, N> userProvidedConfiguration,
             final ChunkFilterProviderResolver chunkFilterProviderResolver) {
-        return operation(
+        return bootstrapOperation(
                 requireDirectory(directory),
                 requireUserProvidedConfiguration(userProvidedConfiguration),
                 chunkFilterProviderResolver,
@@ -255,14 +255,14 @@ public interface SegmentIndex<K, V> extends CloseableResource {
             final IndexConfiguration<M, N> userProvidedConfiguration,
             final ChunkFilterProviderResolver chunkFilterProviderResolver,
             final HestiaStoreRuntime runtime) {
-        return operation(
+        return bootstrapOperation(
                 requireDirectory(directory),
                 requireUserProvidedConfiguration(userProvidedConfiguration),
                 chunkFilterProviderResolver,
                 HestiaStoreRuntimeAccess.borrowed(runtime));
     }
 
-    private static <M, N> SegmentIndexBootstrapOperation<M, N> operation(
+    private static <M, N> SegmentIndexBootstrapOperation<M, N> bootstrapOperation(
             final Directory directory,
             final IndexConfiguration<M, N> userProvidedConfiguration,
             final ChunkFilterProviderResolver chunkFilterProviderResolver,

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/monitoring/SegmentRuntimeMetrics.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/monitoring/SegmentRuntimeMetrics.java
@@ -31,7 +31,7 @@ final class SegmentRuntimeMetrics {
             new ArrayList<>();
 
     void setTotalMappedStableSegmentCount(final int count) {
-        totalMappedStableSegmentCount = nonNegative(count,
+        totalMappedStableSegmentCount = nonNegativeInt(count,
                 "totalMappedStableSegmentCount");
     }
 
@@ -72,7 +72,7 @@ final class SegmentRuntimeMetrics {
     }
 
     void setUnloadedMappedStableSegmentCount(final int count) {
-        unloadedMappedStableSegmentCount = nonNegative(count,
+        unloadedMappedStableSegmentCount = nonNegativeInt(count,
                 "unloadedMappedStableSegmentCount");
     }
 
@@ -83,31 +83,31 @@ final class SegmentRuntimeMetrics {
     void addSegmentRuntimeSnapshot(final SegmentRuntimeSnapshot segmentRuntime) {
         final SegmentRuntimeSnapshot snapshot = Vldtn.requireNonNull(
                 segmentRuntime, "segmentRuntime");
-        final long numberOfKeys = nonNegative(snapshot.getNumberOfKeys(),
+        final long numberOfKeys = nonNegativeLong(snapshot.getNumberOfKeys(),
                 "numberOfKeys");
-        final long numberOfKeysInSegmentCache = nonNegative(
+        final long numberOfKeysInSegmentCache = nonNegativeLong(
                 snapshot.getNumberOfKeysInSegmentCache(),
                 "numberOfKeysInSegmentCache");
-        final int numberOfKeysInWriteCache = nonNegative(
+        final int numberOfKeysInWriteCache = nonNegativeInt(
                 snapshot.getNumberOfKeysInWriteCache(),
                 "numberOfKeysInWriteCache");
-        final int numberOfDeltaCacheFiles = nonNegative(
+        final int numberOfDeltaCacheFiles = nonNegativeInt(
                 snapshot.getNumberOfDeltaCacheFiles(),
                 "numberOfDeltaCacheFiles");
-        final long compactRequestCount = nonNegative(
+        final long compactRequestCount = nonNegativeLong(
                 snapshot.getNumberOfCompacts(), "compactRequestCount");
-        final long flushRequestCount = nonNegative(snapshot.getNumberOfFlushes(),
-                "flushRequestCount");
-        final long bloomFilterRequestCount = nonNegative(
+        final long flushRequestCount = nonNegativeLong(
+                snapshot.getNumberOfFlushes(), "flushRequestCount");
+        final long bloomFilterRequestCount = nonNegativeLong(
                 snapshot.getBloomFilterRequestCount(),
                 "bloomFilterRequestCount");
-        final long bloomFilterRefusedCount = nonNegative(
+        final long bloomFilterRefusedCount = nonNegativeLong(
                 snapshot.getBloomFilterRefusedCount(),
                 "bloomFilterRefusedCount");
-        final long bloomFilterPositiveCount = nonNegative(
+        final long bloomFilterPositiveCount = nonNegativeLong(
                 snapshot.getBloomFilterPositiveCount(),
                 "bloomFilterPositiveCount");
-        final long bloomFilterFalsePositiveCount = nonNegative(
+        final long bloomFilterFalsePositiveCount = nonNegativeLong(
                 snapshot.getBloomFilterFalsePositiveCount(),
                 "bloomFilterFalsePositiveCount");
 
@@ -171,11 +171,11 @@ final class SegmentRuntimeMetrics {
         return List.copyOf(stableSegmentRuntimeSnapshots);
     }
 
-    private static int nonNegative(final int value, final String name) {
+    private static int nonNegativeInt(final int value, final String name) {
         return Vldtn.requireGreaterThanOrEqualToZero(value, name);
     }
 
-    private static long nonNegative(final long value, final String name) {
+    private static long nonNegativeLong(final long value, final String name) {
         return Vldtn.requireGreaterThanOrEqualToZero(value, name);
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/sorteddatafile/sort/EntryIteratorWithCurrentComparator.java
+++ b/engine/src/main/java/org/hestiastore/index/sorteddatafile/sort/EntryIteratorWithCurrentComparator.java
@@ -13,7 +13,7 @@ import org.hestiastore.index.Vldtn;
  * @param <K> key type
  * @param <V> value type
  */
-public class EntryIteratorWithCurrentComparator<K, V>
+class EntryIteratorWithCurrentComparator<K, V>
         implements Comparator<EntryIteratorWithCurrent<K, V>> {
 
     private final Comparator<K> keyComparator;
@@ -23,7 +23,7 @@ public class EntryIteratorWithCurrentComparator<K, V>
      *
      * @param keyComparator comparator for keys
      */
-    public EntryIteratorWithCurrentComparator(
+    EntryIteratorWithCurrentComparator(
             final Comparator<K> keyComparator) {
         this.keyComparator = Vldtn.requireNonNull(keyComparator,
                 "keyComparator");

--- a/engine/src/main/java/org/hestiastore/index/sorteddatafile/sort/MergedEntryIterator.java
+++ b/engine/src/main/java/org/hestiastore/index/sorteddatafile/sort/MergedEntryIterator.java
@@ -22,7 +22,7 @@ import org.hestiastore.index.Vldtn;
  * @param <K> key type
  * @param <V> value type
  */
-public final class MergedEntryIterator<K, V>
+final class MergedEntryIterator<K, V>
         extends AbstractCloseableResource implements EntryIteratorWithCurrent<K, V> {
 
     private final List<EntryIteratorWithCurrent<K, V>> iterators;
@@ -81,7 +81,7 @@ public final class MergedEntryIterator<K, V>
      *
      * @return iterator with the lowest key, or empty when none are available
      */
-    public Optional<EntryIteratorWithCurrent<K, V>> findIteratorWithLowestKey() {
+    Optional<EntryIteratorWithCurrent<K, V>> findIteratorWithLowestKey() {
         final Comparator<EntryIteratorWithCurrent<K, V>> comparator = new EntryIteratorWithCurrentComparator<>(
                 keyComparator);
         final List<EntryIteratorWithCurrent<K, V>> toRemove = new ArrayList<>();

--- a/index-tools/src/main/java/org/hestiastore/indextools/ExportCommand.java
+++ b/index-tools/src/main/java/org/hestiastore/indextools/ExportCommand.java
@@ -5,6 +5,7 @@ import java.io.BufferedWriter;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -230,9 +231,8 @@ final class ExportCommand {
         long recordCount = 0L;
         try (OutputStream output = newBufferedFileOutput(dataFile,
                 manifest.getCompression())) {
-            try (BufferedWriter writer = new java.io.BufferedWriter(
-                    new java.io.OutputStreamWriter(output,
-                            StandardCharsets.UTF_8))) {
+            try (BufferedWriter writer = new BufferedWriter(
+                    new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
                 try (Stream<Entry<Object, Object>> stream = index
                         .getStream(SegmentWindow.unbounded(),
                                 SegmentIteratorIsolation.FULL_ISOLATION)) {

--- a/monitoring-console-web/src/main/java/org/hestiastore/console/web/ConsoleBackendClient.java
+++ b/monitoring-console-web/src/main/java/org/hestiastore/console/web/ConsoleBackendClient.java
@@ -659,8 +659,8 @@ public class ConsoleBackendClient {
                 return method + " " + path + FAILED_SEPARATOR
                         + response.statusCode() + " " + code + " " + message;
             }
-        } catch (final Exception ignore) {
-            // Fallback to plain body below.
+        } catch (final Exception e) {
+            logger.trace("Response body is not a JSON error payload.", e);
         }
         return method + " " + path + FAILED_SEPARATOR + response.statusCode()
                 + " body=" + body;
@@ -1359,7 +1359,7 @@ public class ConsoleBackendClient {
             if (jvmHeapCommittedBytes <= 0L) {
                 return 0L;
             }
-            return Math.round((heapFreeBytes() * 100D) / jvmHeapCommittedBytes);
+            return Math.round(heapFreeBytes() * 100D / jvmHeapCommittedBytes);
         }
 
         /**
@@ -1392,7 +1392,7 @@ public class ConsoleBackendClient {
                 return 0L;
             }
             return Math.round(
-                    (Math.max(0L, totalSegmentCacheKeys) * 100D) / limit);
+                    Math.max(0L, totalSegmentCacheKeys) * 100D / limit);
         }
 
         /**
@@ -1404,7 +1404,7 @@ public class ConsoleBackendClient {
             if (cacheLimit <= 0) {
                 return 0L;
             }
-            return Math.round((Math.max(0, cacheSize) * 100D) / cacheLimit);
+            return Math.round(Math.max(0, cacheSize) * 100D / cacheLimit);
         }
 
         /**
@@ -1490,7 +1490,7 @@ public class ConsoleBackendClient {
         if (deltaOps <= 0L || deltaNanos <= 0L) {
             return new Throughput(0D, OPS_PER_SECOND);
         }
-        double value = (deltaOps * 1_000_000_000D) / deltaNanos;
+        double value = deltaOps * 1_000_000_000D / deltaNanos;
         String unit = OPS_PER_SECOND;
         if (value >= 10_000D) {
             value /= 1_000D;
@@ -1528,7 +1528,7 @@ public class ConsoleBackendClient {
         if (deltaCount <= 0L || deltaNanos <= 0L) {
             return new CounterRate(0D, "/s");
         }
-        final double perSecond = (deltaCount * 1_000_000_000D) / deltaNanos;
+        final double perSecond = deltaCount * 1_000_000_000D / deltaNanos;
         if (perSecond >= 1D) {
             return new CounterRate(perSecond, "/s");
         }
@@ -1612,7 +1612,7 @@ public class ConsoleBackendClient {
                 return 0L;
             }
             return Math.round(
-                    (Math.max(0L, totalSegmentCacheKeys) * 100D) / limit);
+                    Math.max(0L, totalSegmentCacheKeys) * 100D / limit);
         }
 
         /**
@@ -1639,7 +1639,7 @@ public class ConsoleBackendClient {
             if (total <= 0L) {
                 return 0L;
             }
-            return Math.round((cacheHitCount * 100D) / total);
+            return Math.round(cacheHitCount * 100D / total);
         }
 
         /**
@@ -1651,7 +1651,7 @@ public class ConsoleBackendClient {
             if (cacheLimit <= 0) {
                 return 0L;
             }
-            return Math.round((Math.max(0, cacheSize) * 100D) / cacheLimit);
+            return Math.round(Math.max(0, cacheSize) * 100D / cacheLimit);
         }
 
         /**

--- a/monitoring-console-web/src/main/java/org/hestiastore/console/web/MonitoringConsoleWebController.java
+++ b/monitoring-console-web/src/main/java/org/hestiastore/console/web/MonitoringConsoleWebController.java
@@ -288,9 +288,9 @@ public class MonitoringConsoleWebController {
         final long cacheLimit = nodes.stream()
                 .mapToLong(ConsoleBackendClient.NodeRow::cacheLimit).sum();
         final long cacheHitRatio = cacheHits + cacheMisses == 0L ? 0L
-                : Math.round((cacheHits * 100D) / (cacheHits + cacheMisses));
+                : Math.round(cacheHits * 100D / (cacheHits + cacheMisses));
         final long cacheFillRatio = cacheLimit == 0L ? 0L
-                : Math.round((cacheSize * 100D) / cacheLimit);
+                : Math.round(cacheSize * 100D / cacheLimit);
         model.addAttribute("nodes", nodes);
         model.addAttribute("statNodes", nodes.size());
         model.addAttribute("statNodesDisplay",

--- a/monitoring-rest-json/src/main/java/org/hestiastore/management/restjson/ManagementAgentServer.java
+++ b/monitoring-rest-json/src/main/java/org/hestiastore/management/restjson/ManagementAgentServer.java
@@ -842,7 +842,7 @@ public final class ManagementAgentServer
 
     private List<RegisteredIndex> activeIndexesSnapshot() {
         final List<RegisteredIndex> active = new ArrayList<>();
-        for (final java.util.Map.Entry<String, SegmentIndex<?, ?>> entry : indexes
+        for (final Map.Entry<String, SegmentIndex<?, ?>> entry : indexes
                 .entrySet()) {
             final String name = entry.getKey();
             final SegmentIndex<?, ?> index = entry.getValue();


### PR DESCRIPTION
## Summary
- limit visibility for internal helper classes and package-local methods
- remove/clarify unused private helper overloads flagged by PMD
- clean PMD style findings in tools and monitoring modules

## Tests
- mvn clean verify
- mvn -DskipTests pmd:pmd