### PR TITLE
Add MDC to bootstrap memory logs

### DIFF
--- a/engine/src/integration-test/java/org/hestiastore/index/it/IndexLoggingMessageIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/IndexLoggingMessageIT.java
@@ -24,35 +24,41 @@ import org.junit.jupiter.api.Test;
 class IndexLoggingMessageIT {
 
     private static final String LOCK_FILE_NAME = ".lock";
+    private static final String INDEX_NAME = "logging-message-it";
     private static final String LOG_PATTERN = "%d{ISO8601} %-5level [%t] "
             + "index='%X{index.name}' %msg%n%throwable";
-    private static final String EXPECTED_BOOTSTRAP_FORMAT_FRAGMENT = " INFO  [main] index='' ";
+    private static final String EXPECTED_INDEX_CONTEXT_FORMAT_FRAGMENT =
+            " INFO  [main] index='" + INDEX_NAME + "' ";
+    private static final String EXPECTED_EMPTY_INDEX_CONTEXT_FORMAT_FRAGMENT =
+            " INFO  [main] index='' ";
     private static final String EXPECTED_RECOVERY_MESSAGE = "Recovered stale index lock (.lock). Index is going to be checked "
             + "for consistency and unlocked.";
 
     @Test
-    void verify_bootstrap_log_omits_index_name_when_context_logging_enabled() {
+    void verify_bootstrap_log_includes_index_name_when_context_logging_enabled() {
         final Directory directory = new MemDirectory();
         final IndexConfiguration<Integer, String> configuration = IndexConfiguration.<Integer, String>builder()
                 .identity(identity -> identity.keyClass(Integer.class)
                         .valueClass(String.class)
-                        .name("logging-message-it"))
+                        .name(INDEX_NAME))
                 .logging(logging -> logging.contextEnabled(true))
                 .build();
         final String logs = prepareLogMessages(directory, configuration);
-        assertBootstrapRecoveryLog(logs);
+        assertBootstrapRecoveryLog(logs,
+                EXPECTED_INDEX_CONTEXT_FORMAT_FRAGMENT);
     }
 
     @Test
-    void verify_bootstrap_log_omits_index_name_when_context_logging_uses_default() {
+    void verify_bootstrap_log_includes_index_name_when_context_logging_uses_default() {
         final Directory directory = new MemDirectory();
         final IndexConfiguration<Integer, String> configuration = IndexConfiguration.<Integer, String>builder()
                 .identity(identity -> identity.keyClass(Integer.class)
                         .valueClass(String.class)
-                        .name("logging-message-it"))
+                        .name(INDEX_NAME))
                 .build();
         final String logs = prepareLogMessages(directory, configuration);
-        assertBootstrapRecoveryLog(logs);
+        assertBootstrapRecoveryLog(logs,
+                EXPECTED_INDEX_CONTEXT_FORMAT_FRAGMENT);
     }
 
     @Test
@@ -61,17 +67,19 @@ class IndexLoggingMessageIT {
         final IndexConfiguration<Integer, String> configuration = IndexConfiguration.<Integer, String>builder()
                 .identity(identity -> identity.keyClass(Integer.class)
                         .valueClass(String.class)
-                        .name("logging-message-it"))
+                        .name(INDEX_NAME))
                 .logging(logging -> logging.contextEnabled(false))
                 .build();
         final String logs = prepareLogMessages(directory, configuration);
-        assertBootstrapRecoveryLog(logs);
+        assertBootstrapRecoveryLog(logs,
+                EXPECTED_EMPTY_INDEX_CONTEXT_FORMAT_FRAGMENT);
     }
 
-    private static void assertBootstrapRecoveryLog(final String logs) {
+    private static void assertBootstrapRecoveryLog(final String logs,
+            final String expectedFormatFragment) {
         assertAll(
                 () -> assertTrue(
-                        logs.contains(EXPECTED_BOOTSTRAP_FORMAT_FRAGMENT),
+                        logs.contains(expectedFormatFragment),
                         () -> "Expected formatted INFO log fragment in:\n"
                                 + logs),
                 () -> assertTrue(logs.contains(EXPECTED_RECOVERY_MESSAGE),

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
@@ -135,30 +135,55 @@ public final class SegmentIndexBootstrapOperation<K, V> {
             }
             sessionResources.acquireDirectoryLock(directory);
             resolveConfiguration(mode, state, configurationManager);
-            resolveTypeDescriptors(state);
-            writeConfiguration(state, configurationManager);
-            openKeyToSegmentMap(state);
-            createStartupMemoryEstimate(state);
-            logStartupMemoryEstimate(state);
-            createExecutorRegistry(state);
-            createChunkStoreCache(state);
-            openSegmentRegistry(state);
-            openCoreStorage(state);
-            createRuntimeTopology(state, sessionResources);
-            openRuntimeWal(state);
-            createMaintenance(state, sessionResources);
-            initializeWal(state, sessionResources);
-            createRuntimeMonitoring(state, sessionResources);
-            createRuntimeTuning(state);
-            createOperationAccess(state, sessionResources);
-            transferRuntimeCloseOwnership(state, sessionResources);
-            createIndex(state, sessionResources);
-            completeStartup(state, sessionResources);
-            applyContextLogging(state);
-            return Optional.of(state.getIndex());
+            return openConfiguredSessionWithContext(state, sessionResources,
+                    configurationManager);
         } catch (final RuntimeException failure) {
             throw closeAfterFailedBootstrap(state, failure);
         }
+    }
+
+    private Optional<SegmentIndex<K, V>> openConfiguredSessionWithContext(
+            final BootstrapState<K, V> state,
+            final SegmentIndexRuntimeResources<K, V> sessionResources,
+            final IndexConfigurationManager<K, V> configurationManager) {
+        final EffectiveIndexConfiguration<K, V> configuration =
+                state.getConfiguration();
+        if (!configuration.logging().contextEnabled()) {
+            return openConfiguredSession(state, sessionResources,
+                    configurationManager);
+        }
+        try (IndexMdcScope ignored = new IndexMdcScope(
+                configuration.identity().name())) {
+            return openConfiguredSession(state, sessionResources,
+                    configurationManager);
+        }
+    }
+
+    private Optional<SegmentIndex<K, V>> openConfiguredSession(
+            final BootstrapState<K, V> state,
+            final SegmentIndexRuntimeResources<K, V> sessionResources,
+            final IndexConfigurationManager<K, V> configurationManager) {
+        resolveTypeDescriptors(state);
+        writeConfiguration(state, configurationManager);
+        openKeyToSegmentMap(state);
+        createStartupMemoryEstimate(state);
+        logStartupMemoryEstimate(state);
+        createExecutorRegistry(state);
+        createChunkStoreCache(state);
+        openSegmentRegistry(state);
+        openCoreStorage(state);
+        createRuntimeTopology(state, sessionResources);
+        openRuntimeWal(state);
+        createMaintenance(state, sessionResources);
+        initializeWal(state, sessionResources);
+        createRuntimeMonitoring(state, sessionResources);
+        createRuntimeTuning(state);
+        createOperationAccess(state, sessionResources);
+        transferRuntimeCloseOwnership(state, sessionResources);
+        createIndex(state, sessionResources);
+        completeStartup(state, sessionResources);
+        applyContextLogging(state);
+        return Optional.of(state.getIndex());
     }
 
     private boolean checkExistingConfiguration(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
@@ -253,11 +253,13 @@ class SegmentIndexBootstrapOperationTest {
         try {
             final SegmentIndex<Integer, String> index = operation(
                     new MemDirectory(),
-                    buildConf("bootstrap-operation-memory-estimate", false))
+                    buildConf("bootstrap-operation-memory-estimate", true))
                     .create();
             try {
+                final List<LogEvent> memoryEstimateEvents = appender
+                        .eventsStartingWith("memory-estimate ");
                 final List<String> loggedReportLines = appender
-                        .messagesStartingWith("memory-estimate ")
+                        .messages(memoryEstimateEvents)
                         .stream()
                         .map(message -> message
                                 .substring("memory-estimate ".length()))
@@ -265,6 +267,10 @@ class SegmentIndexBootstrapOperationTest {
 
                 assertEquals(index.startupMemoryEstimate().lines(),
                         loggedReportLines);
+                assertTrue(memoryEstimateEvents.stream()
+                        .allMatch(event -> "bootstrap-operation-memory-estimate"
+                                .equals(event.getContextData()
+                                        .getValue(MDC_INDEX_NAME_KEY))));
                 printReport("bootstrap-complete",
                         index.startupMemoryEstimate());
                 assertTrue(appender.countMessageStartingWith(
@@ -600,7 +606,7 @@ class SegmentIndexBootstrapOperationTest {
 
         private final LoggerContext loggerContext;
         private final String loggerConfigName;
-        private final List<String> messages = Collections
+        private final List<LogEvent> events = Collections
                 .synchronizedList(new ArrayList<>());
 
         private TestLogAppender(final String name,
@@ -630,23 +636,34 @@ class SegmentIndexBootstrapOperationTest {
 
         @Override
         public void append(final LogEvent event) {
-            messages.add(event.getMessage().getFormattedMessage());
+            events.add(event.toImmutable());
         }
 
         long countMessageStartingWith(final String prefix) {
-            synchronized (messages) {
-                return messages.stream()
+            synchronized (events) {
+                return messages(events).stream()
                         .filter(message -> message.startsWith(prefix))
                         .count();
             }
         }
 
         List<String> messagesStartingWith(final String prefix) {
-            synchronized (messages) {
-                return messages.stream()
-                        .filter(message -> message.startsWith(prefix))
+            return messages(eventsStartingWith(prefix));
+        }
+
+        List<LogEvent> eventsStartingWith(final String prefix) {
+            synchronized (events) {
+                return events.stream()
+                        .filter(event -> event.getMessage()
+                                .getFormattedMessage().startsWith(prefix))
                         .toList();
             }
+        }
+
+        List<String> messages(final List<LogEvent> sourceEvents) {
+            return sourceEvents.stream()
+                    .map(event -> event.getMessage().getFormattedMessage())
+                    .toList();
         }
 
         void detach() {


### PR DESCRIPTION
## Summary
- populate index MDC during the configured bootstrap sequence
- verify startup memory-estimate INFO logs include index.name when context logging is enabled/default
- keep disabled context logging behavior unchanged

## Tests
- mvn -pl engine -Dtest=SegmentIndexBootstrapOperationTest test
- mvn -pl engine -Dtest=SegmentIndexBootstrapOperationTest -Dit.test=IndexLoggingMessageIT verify
- mvn clean verify