### PR TITLE
Bump JUnit dependencies to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>2.0.18</slf4j.version>
         <log4j.version>3.0.0-beta2</log4j.version>
-        <junit.jupiter.version>6.1.0</junit.jupiter.version>
-        <junit.platform.version>6.1.0</junit.platform.version>
+        <junit.jupiter.version>6.1.1</junit.jupiter.version>
+        <junit.platform.version>6.1.1</junit.platform.version>
         <failsafe.plugin.version>3.5.6</failsafe.plugin.version>
         <surefire.plugin.version>3.5.6</surefire.plugin.version>
         <mockito.version>5.23.0</mockito.version>


### PR DESCRIPTION
Summary:
- Bumps junit.jupiter.version from 6.1.0 to 6.1.1.
- Bumps junit.platform.version from 6.1.0 to 6.1.1.
- Replaces stale Dependabot PRs #301 and #302 with a clean devel-based branch.

Tests:
- mvn clean verify
- mvn clean site
- python3 scripts/check_docs_nav.py