### PR TITLE
Format startup memory report as tables

### DIFF
--- a/docs/operations/memory-estimate.md
+++ b/docs/operations/memory-estimate.md
@@ -17,7 +17,15 @@ it as a sizing hint, then verify real usage with JVM and application monitoring.
 
 ## How to read the report
 
-The report puts the final estimate first and then expands the calculated areas:
+The report uses fixed-width text tables with three columns:
+
+- `Component`: short name for the calculated area, input, or constant.
+- `Estimate`: estimated memory or configured value.
+- `Description`: formula, input context, or reason why an estimate is unknown.
+
+Long descriptions wrap onto continuation rows so each report line stays within
+the fixed report width. The final estimate appears first, followed by the
+calculated memory areas:
 
 - `Total index memory`: all segments, chunk-store page cache, and maintenance
   overhead.
@@ -34,17 +42,16 @@ The report puts the final estimate first and then expands the calculated areas:
   used by key/value cache estimates.
 - `Key/position entry`: key size, integer position size, and fixed per-entry
   overhead used by scarce-index estimates.
-- `Formula constants`: fixed constants used by the estimator. This section is
-  shown for transparency and is not added separately to the total.
-- `Other requirements`: related settings reported for context but not included
-  in the total.
+- `Key/segment-id entry`: key size and segment id size used by the segment
+  routing map.
+- `Inputs and constants`: configuration values and fixed assumptions used by
+  the estimator. Values such as `Write-buffer keys` are reported for context
+  and are not added to the total.
 
-The tree keeps each detail line aligned under the value it explains. Area
-branches such as `All segments`, `One cached segment`, `Segment routing map`,
-and `Chunk-store page cache` show their configuration inputs below the memory
-area they affect. `Bloom filter` and `Scarce index` are shown as per-segment
-areas when they can contribute to loaded segment memory. `Scarce index` groups
-the maximum sparse-entry count calculation and the reused `Key/position entry`.
+Area rows such as `Delta cache`, `Chunk-store page cache`, and `Maintenance
+overhead` summarize the formula in the description column. Supporting rows in
+`Entry sizes` and `Inputs and constants` show the entry-size assumptions and
+configuration values used by those formulas.
 
 ## What the report uses
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimator.java
@@ -1,5 +1,7 @@
 package org.hestiastore.index.segmentindex.core.session;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -20,6 +22,13 @@ final class IndexMemoryEstimator {
     static final int SCARCE_INDEX_POSITION_BYTES = 4;
     static final int FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES = 16 * 1024;
     static final int TEMPORARY_MEMORY_MARGIN_PERCENT = 25;
+
+    private static final int TABLE_WIDTH = 80;
+    private static final int COMPONENT_WIDTH = 22;
+    private static final int ESTIMATE_WIDTH = 10;
+    private static final int TABLE_RESERVED_WIDTH = 12;
+    private static final int DESCRIPTION_WIDTH = TABLE_WIDTH
+            - COMPONENT_WIDTH - ESTIMATE_WIDTH - TABLE_RESERVED_WIDTH;
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final String UNKNOWN = "unknown";
@@ -96,106 +105,17 @@ final class IndexMemoryEstimator {
 
         final StringBuilder out = new StringBuilder();
         appendTitle(out);
-        appendParentEstimateTreeLine(out, "", "├─ ", "Total index memory",
-                total,
-                "needs segment, page-cache, and maintenance estimates");
-        appendParentEstimateTreeLine(out, "│  ", "├─ ", "All segments",
-                allSegments, "needs complete segment and routing estimates",
-                formatCount(resolved.segment().cachedSegmentLimit())
-                        + " segment cache slots");
-        appendParentEstimateTreeLine(out, "│  │  ", "├─ ",
-                "One cached segment", oneCachedSegment,
-                "needs key and value descriptor estimates",
-                "multiplied by "
-                        + formatCount(resolved.segment().cachedSegmentLimit())
-                        + " segment cache slots");
-        appendEstimateTreeLine(out, "│  │  │  ", "├─ ", "Delta cache",
-                oneDeltaCache,
-                "needs key and value descriptor estimates",
-                "configured max number of keys in cache: "
-                        + formatCount(resolved.segment().cacheKeyLimit()),
-                "key/value entry: " + estimateText(entryEstimate));
-        appendEstimateTreeLine(out, "│  │  │  ", "├─ ",
-                "Bloom filter", oneBloomFilter, "",
-                "configured bloom filter size: " + formatBytes(
-                        resolved.bloomFilter().indexSizeBytes()));
-        appendParentEstimateTreeLine(out, "│  │  │  ", "├─ ",
-                "Scarce index", oneScarceIndex,
-                "needs key descriptor estimate");
-        appendTreeLine(out, "│  │  │  │  ", "├─ ",
-                "Max number of keys in scarce index",
-                formatCount(maxScarceIndexKeys),
-                "max number of keys in segment: "
-                        + formatCount(resolved.segment().maxKeys()),
-                "number of keys per page: "
-                        + formatCount(resolved.segment().chunkKeyLimit()));
-        appendTreeLine(out, "│  │  │  │  ", "└─ ",
-                "Key/position entry", estimateText(scarceEntryEstimate));
-        appendEstimateTreeLine(out, "│  │  │  ", "└─ ", "Segment runtime",
-                oneSegmentInfrastructure, "",
-                "overhead: "
-                        + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES));
-        appendParentEstimateTreeLine(out, "│  │  ", "└─ ", "Segment routing map",
-                routeMap, "needs key descriptor estimate");
-        appendTreeLine(out, "│  │     ", "├─ ",
-                "Number of segment routes", formatCount(resolvedRouteCount));
-        appendTreeLine(out, "│  │     ", "└─ ",
-                "Key/segment-id entry", estimateText(routeEntryEstimate),
-                "key: " + estimateText(keyEstimate),
-                "segment id: " + formatBytes(SEGMENT_ID_ESTIMATE_BYTES));
-        appendEstimateTreeLine(out, "│  ", "├─ ",
-                "Chunk-store page cache", chunkStoreCache,
-                "needs key and value descriptor estimates",
-                formatCount(resolved.chunkStoreCache().pageLimit())
-                        + " pages",
-                "chunk keys per page: "
-                        + formatCount(resolved.segment().chunkKeyLimit()),
-                "page overhead: " + formatBytes(PAGE_OVERHEAD_BYTES),
-                "key/value entry: " + estimateText(entryEstimate));
-        appendEstimateTreeLine(out, "│  ", "└─ ", "Maintenance overhead",
-                temporaryMemoryMargin,
-                "needs memory before maintenance and key/value entry estimates",
-                "maintenance threads: "
-                        + formatCount(resolved.maintenance().indexThreads()),
-                "max(" + TEMPORARY_MEMORY_MARGIN_PERCENT
-                        + "% of memory before maintenance = "
-                        + memoryText(steadyState) + ",",
-                "one delta cache = "
-                        + memoryText(oneDeltaCache) + ")");
-        appendTreeLine(out, "", "├─ ", "Key/value entry",
-                estimateText(entryEstimate),
-                "key: " + descriptorName(keyDescriptor) + ", "
-                        + aboutText(keyEstimate),
-                "value: " + descriptorName(valueDescriptor) + ", "
-                        + aboutText(valueEstimate),
-                "overhead: " + formatBytes(ENTRY_OVERHEAD_BYTES));
-        appendTreeLine(out, "", "├─ ", "Key/position entry",
-                estimateText(scarceEntryEstimate),
-                "key: " + descriptorName(keyDescriptor) + ", "
-                        + aboutText(keyEstimate),
-                "integer position: TypeDescriptorInteger, "
-                        + "about " + formatBytes(SCARCE_INDEX_POSITION_BYTES),
-                "overhead: " + formatBytes(ENTRY_OVERHEAD_BYTES));
-        appendTreeLine(out, "", "├─ ", "Formula constants",
-                "shown for transparency, not added separately",
-                "fixed per loaded/cached segment: about "
-                        + formatBytes(FIXED_SEGMENT_RUNTIME_OVERHEAD_BYTES),
-                "chunk-store page overhead: "
-                        + formatBytes(PAGE_OVERHEAD_BYTES),
-                "route-map segment id: "
-                        + formatBytes(SEGMENT_ID_ESTIMATE_BYTES),
-                "maintenance overhead: max("
-                        + TEMPORARY_MEMORY_MARGIN_PERCENT
-                        + "% of memory before maintenance,",
-                "one delta cache)");
-        appendTreeLine(out, "", "├─ ", "Other requirements",
-                "reported but not included",
-                "index write-buffer keys: " + formatCount(
-                        resolved.writePath().indexBufferedWriteKeyLimit()));
-        appendTreeLine(out, "", "└─ ", "Notes", "rough estimate only",
-                "not a JVM cap or measured allocation",
-                "usage depends on JVM layout, GC, workload, and snapshots",
-                "details: docs/operations/memory-estimate.md");
+        appendIncludedMemoryTable(out, resolved, resolvedRouteCount,
+                maxScarceIndexKeys, entryEstimate, total, allSegments,
+                oneCachedSegment, oneDeltaCache, oneBloomFilter,
+                oneScarceIndex, oneSegmentInfrastructure, routeMap,
+                chunkStoreCache, steadyState, temporaryMemoryMargin);
+        appendEntrySizeTable(out, keyDescriptor, valueDescriptor, keyEstimate,
+                valueEstimate, entryEstimate, scarceEntryEstimate,
+                routeEntryEstimate);
+        appendInputTable(out, resolved, resolvedRouteCount,
+                maxScarceIndexKeys);
+        appendNotes(out);
         out.append("End memory estimate").append(LINE_SEPARATOR);
         return new MemoryEstimateReport(out.toString().lines().toList(),
                 total.isPresent(), total);
@@ -400,63 +320,254 @@ final class IndexMemoryEstimator {
                 : UNKNOWN;
     }
 
-    private static void appendEstimateTreeLine(final StringBuilder out,
-            final String prefix, final String connector, final String label,
-            final OptionalLong estimateBytes, final String unknownReason,
-            final String... details) {
-        appendEstimateTreeLine(out, prefix, connector, label, estimateBytes,
-                unknownReason, false, details);
+    private static void appendIncludedMemoryTable(final StringBuilder out,
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final int resolvedRouteCount, final long maxScarceIndexKeys,
+            final OptionalLong entryEstimate, final OptionalLong total,
+            final OptionalLong allSegments,
+            final OptionalLong oneCachedSegment,
+            final OptionalLong oneDeltaCache,
+            final OptionalLong oneBloomFilter,
+            final OptionalLong oneScarceIndex,
+            final OptionalLong oneSegmentInfrastructure,
+            final OptionalLong routeMap,
+            final OptionalLong chunkStoreCache,
+            final OptionalLong steadyState,
+            final OptionalLong temporaryMemoryMargin) {
+        appendTableTitle(out, "Included memory");
+        appendEstimateRow(out, "Total index memory", total,
+                "needs segment, page-cache, and maintenance estimates",
+                "segments + page cache + maintenance overhead");
+        appendEstimateRow(out, "All segments", allSegments,
+                "needs complete segment and routing estimates",
+                "cached segment slots: "
+                        + formatCount(resolved.segment().cachedSegmentLimit())
+                        + "; cached segments + routing map");
+        appendEstimateRow(out, "One cached segment", oneCachedSegment,
+                "needs key and value descriptor estimates",
+                "delta cache + bloom filter + scarce index + segment runtime");
+        appendEstimateRow(out, "Delta cache", oneDeltaCache,
+                "needs key and value descriptor estimates",
+                "cache key limit: "
+                        + formatCount(resolved.segment().cacheKeyLimit())
+                        + "; cache key limit * key/value entry "
+                        + estimateText(entryEstimate));
+        appendEstimateRow(out, "Bloom filter", oneBloomFilter, "",
+                "configured bloom filter size: "
+                        + formatBytes(resolved.bloomFilter()
+                                .indexSizeBytes()));
+        appendEstimateRow(out, "Scarce index", oneScarceIndex,
+                "needs key descriptor estimate",
+                "max scarce keys: " + formatCount(maxScarceIndexKeys)
+                        + "; max scarce keys * key/position entry");
+        appendEstimateRow(out, "Segment runtime", oneSegmentInfrastructure, "",
+                "fixed overhead per cached segment");
+        appendEstimateRow(out, "Segment routing map", routeMap,
+                "needs key descriptor estimate",
+                "route count: " + formatCount(resolvedRouteCount)
+                        + "; route count * key/segment-id entry");
+        appendEstimateRow(out, "Chunk-store page cache", chunkStoreCache,
+                "needs key and value descriptor estimates",
+                "pages: " + formatCount(
+                        resolved.chunkStoreCache().pageLimit())
+                        + "; pages * (page overhead + chunk keys per page "
+                        + "* key/value entry)");
+        appendEstimateRow(out, "Maintenance overhead",
+                temporaryMemoryMargin,
+                "needs memory before maintenance and key/value entry estimates",
+                "max(" + TEMPORARY_MEMORY_MARGIN_PERCENT
+                        + "% of memory before maintenance = "
+                        + memoryText(steadyState)
+                        + ", one delta cache = "
+                        + memoryText(oneDeltaCache) + ")");
+        appendTableFooter(out);
     }
 
-    private static void appendParentEstimateTreeLine(final StringBuilder out,
-            final String prefix, final String connector, final String label,
-            final OptionalLong estimateBytes, final String unknownReason,
-            final String... details) {
-        appendEstimateTreeLine(out, prefix, connector, label, estimateBytes,
-                unknownReason, true, details);
+    private static void appendEntrySizeTable(final StringBuilder out,
+            final TypeDescriptor<?> keyDescriptor,
+            final TypeDescriptor<?> valueDescriptor,
+            final OptionalInt keyEstimate,
+            final OptionalInt valueEstimate,
+            final OptionalLong entryEstimate,
+            final OptionalLong scarceEntryEstimate,
+            final OptionalLong routeEntryEstimate) {
+        appendTableTitle(out, "Entry sizes");
+        appendEstimateRow(out, "Key/value entry", entryEstimate,
+                "needs key and value descriptor estimates",
+                "key size + value size + overhead; key: "
+                        + descriptorName(keyDescriptor) + ", "
+                        + aboutText(keyEstimate) + "; value: "
+                        + descriptorName(valueDescriptor) + ", "
+                        + aboutText(valueEstimate) + "; overhead: "
+                        + formatBytes(ENTRY_OVERHEAD_BYTES));
+        appendEstimateRow(out, "Key/position entry", scarceEntryEstimate,
+                "needs key descriptor estimate",
+                "key size + integer position + overhead; key: "
+                        + descriptorName(keyDescriptor) + ", "
+                        + aboutText(keyEstimate)
+                        + "; integer position: TypeDescriptorInteger, about "
+                        + formatBytes(SCARCE_INDEX_POSITION_BYTES)
+                        + "; overhead: " + formatBytes(ENTRY_OVERHEAD_BYTES));
+        appendEstimateRow(out, "Key/segment-id entry", routeEntryEstimate,
+                "needs key descriptor estimate",
+                "key size + segment id size; key: "
+                        + estimateText(keyEstimate) + "; segment id: "
+                        + formatBytes(SEGMENT_ID_ESTIMATE_BYTES));
+        appendTableFooter(out);
     }
 
-    private static void appendEstimateTreeLine(final StringBuilder out,
-            final String prefix, final String connector, final String label,
+    private static void appendInputTable(final StringBuilder out,
+            final EffectiveIndexConfiguration<?, ?> resolved,
+            final int resolvedRouteCount, final long maxScarceIndexKeys) {
+        appendTableTitle(out, "Inputs and constants");
+        appendValueRow(out, "Cached segment slots",
+                formatCount(resolved.segment().cachedSegmentLimit()),
+                "multiplier for one cached segment");
+        appendValueRow(out, "Segment routes",
+                formatCount(resolvedRouteCount), "route-map entries");
+        appendValueRow(out, "Max scarce keys",
+                formatCount(maxScarceIndexKeys),
+                "ceil(max segment keys / chunk keys per page)");
+        appendValueRow(out, "Chunk-store pages",
+                formatCount(resolved.chunkStoreCache().pageLimit()),
+                "configured page cache size");
+        appendValueRow(out, "Chunk keys per page",
+                formatCount(resolved.segment().chunkKeyLimit()),
+                "keys stored in one chunk-store page");
+        appendValueRow(out, "Page overhead", formatBytes(PAGE_OVERHEAD_BYTES),
+                "fixed overhead per chunk-store page");
+        appendValueRow(out, "Entry overhead",
+                formatBytes(ENTRY_OVERHEAD_BYTES),
+                "fixed overhead in key/value and key/position entries");
+        appendValueRow(out, "Maintenance threads",
+                formatCount(resolved.maintenance().indexThreads()),
+                "used by maintenance memory estimate");
+        appendValueRow(out, "Write-buffer keys",
+                formatCount(resolved.writePath()
+                        .indexBufferedWriteKeyLimit()),
+                "reported, not included in total");
+        appendTableFooter(out);
+    }
+
+    private static void appendNotes(final StringBuilder out) {
+        out.append("Notes:").append(LINE_SEPARATOR);
+        out.append("rough estimate only").append(LINE_SEPARATOR);
+        out.append("not a JVM cap or measured allocation")
+                .append(LINE_SEPARATOR);
+        out.append("usage depends on JVM layout, GC, workload, and snapshots")
+                .append(LINE_SEPARATOR);
+        out.append("details: docs/operations/memory-estimate.md")
+                .append(LINE_SEPARATOR);
+    }
+
+    private static void appendEstimateRow(final StringBuilder out,
+            final String component, final OptionalLong estimateBytes,
+            final String unknownReason, final String description) {
+        appendValueRow(out, component, memoryText(estimateBytes),
+                estimateDescription(estimateBytes, unknownReason,
+                        description));
+    }
+
+    private static String estimateDescription(
             final OptionalLong estimateBytes, final String unknownReason,
-            final boolean childBranch, final String... details) {
-        final String[] resolvedDetails;
+            final String description) {
         if (estimateBytes.isEmpty() && !unknownReason.isBlank()) {
-            resolvedDetails = new String[details.length + 1];
-            resolvedDetails[0] = "reason: " + unknownReason;
-            System.arraycopy(details, 0, resolvedDetails, 1,
-                    details.length);
-        } else {
-            resolvedDetails = details;
+            return "reason: " + unknownReason + "; " + description;
         }
-        appendTreeLine(out, prefix, connector, label,
-                memoryText(estimateBytes), childBranch, resolvedDetails);
+        return description;
     }
 
-    private static void appendTreeLine(final StringBuilder out,
-            final String prefix, final String connector, final String label,
-            final String value, final String... details) {
-        appendTreeLine(out, prefix, connector, label, value, false, details);
+    private static void appendTableTitle(final StringBuilder out,
+            final String title) {
+        out.append(title).append(LINE_SEPARATOR);
+        appendTableHeader(out);
     }
 
-    private static void appendTreeLine(final StringBuilder out,
-            final String prefix, final String connector, final String label,
-            final String value, final boolean childBranch,
-            final String... details) {
-        final String lead = prefix + connector + label + " - ";
-        out.append(lead).append(value).append(LINE_SEPARATOR);
-        final String childMarker = childBranch ? "│" : "";
-        final String detailPrefix = prefix + continuation(connector)
-                + childMarker
-                + " ".repeat(label.length() + " - ".length()
-                        - childMarker.length());
-        for (final String detail : details) {
-            out.append(detailPrefix).append(detail).append(LINE_SEPARATOR);
+    private static void appendTableHeader(final StringBuilder out) {
+        appendTableSeparator(out);
+        appendTableLine(out, "Component", "Estimate", "Description");
+        appendTableSeparator(out);
+    }
+
+    private static void appendTableFooter(final StringBuilder out) {
+        appendTableSeparator(out);
+    }
+
+    private static void appendTableSeparator(final StringBuilder out) {
+        out.append('+')
+                .append("-".repeat(COMPONENT_WIDTH + 2))
+                .append('+')
+                .append("-".repeat(ESTIMATE_WIDTH + 2))
+                .append('+')
+                .append("-".repeat(DESCRIPTION_WIDTH + 2))
+                .append('+')
+                .append(LINE_SEPARATOR);
+    }
+
+    private static void appendValueRow(final StringBuilder out,
+            final String component, final String estimate,
+            final String description) {
+        final List<String> componentLines = wrapCell(component,
+                COMPONENT_WIDTH);
+        final List<String> estimateLines = wrapCell(estimate, ESTIMATE_WIDTH);
+        final List<String> descriptionLines = wrapCell(description,
+                DESCRIPTION_WIDTH);
+        final int rowCount = Math.max(componentLines.size(), Math.max(
+                estimateLines.size(), descriptionLines.size()));
+        for (int index = 0; index < rowCount; index++) {
+            appendTableLine(out, cellLine(componentLines, index),
+                    cellLine(estimateLines, index),
+                    cellLine(descriptionLines, index));
         }
     }
 
-    private static String continuation(final String connector) {
-        return connector.startsWith("├") ? "│  " : "   ";
+    private static void appendTableLine(final StringBuilder out,
+            final String component, final String estimate,
+            final String description) {
+        final String line = String.format(Locale.ROOT,
+                "| %-" + COMPONENT_WIDTH + "s | %-" + ESTIMATE_WIDTH
+                        + "s | %-" + DESCRIPTION_WIDTH + "s |",
+                component, estimate, description);
+        out.append(line).append(LINE_SEPARATOR);
+    }
+
+    private static String cellLine(final List<String> lines,
+            final int index) {
+        return index < lines.size() ? lines.get(index) : "";
+    }
+
+    private static List<String> wrapCell(final String value,
+            final int width) {
+        final String normalized = Vldtn.requireNonNull(value, "value").trim();
+        if (normalized.isEmpty()) {
+            return List.of("");
+        }
+        final List<String> lines = new ArrayList<>();
+        String currentLine = "";
+        for (final String word : normalized.split("\\s+")) {
+            String remainingWord = word;
+            while (remainingWord.length() > width) {
+                if (!currentLine.isEmpty()) {
+                    lines.add(currentLine);
+                    currentLine = "";
+                }
+                lines.add(remainingWord.substring(0, width));
+                remainingWord = remainingWord.substring(width);
+            }
+            if (currentLine.isEmpty()) {
+                currentLine = remainingWord;
+            } else if (currentLine.length() + 1
+                    + remainingWord.length() <= width) {
+                currentLine = currentLine + " " + remainingWord;
+            } else {
+                lines.add(currentLine);
+                currentLine = remainingWord;
+            }
+        }
+        if (!currentLine.isEmpty()) {
+            lines.add(currentLine);
+        }
+        return lines;
     }
 
     private static String descriptorName(final TypeDescriptor<?> descriptor) {

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/IndexMemoryEstimatorTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
-
 import org.hestiastore.index.datatype.ByteArray;
 import org.hestiastore.index.datatype.NullValue;
 import org.hestiastore.index.datatype.TypeDescriptor;
@@ -35,67 +33,59 @@ class IndexMemoryEstimatorTest {
         assertTrue(estimate.isComplete());
         assertEquals(93_330L, estimate.totalEstimatedBytes().orElseThrow());
         final String log = estimate.text();
-        assertTrue(log.contains("Estimated memory use at startup"));
-        assertTrue(log.contains("├─ Total index memory - 91.14 KiB"));
-        assertTrue(log.contains("│  ├─ All segments - 72.91 KiB"));
-        assertTrue(log.contains(
-                "│  │  │              3 segment cache slots"));
-        assertTrue(log.contains(
-                "│  │  ├─ One cached segment - 24.30 KiB"));
-        assertTrue(log.contains(
-                "│  └─ Maintenance overhead - 18.23 KiB"));
-        assertLineAppearsBefore(log, "├─ Total index memory - 91.14 KiB",
-                "├─ Key/value entry - 228 B");
-        assertTrue(log.contains(
-                "not a JVM cap or measured allocation"));
-        assertTrue(log.contains("├─ Key/value entry - 228 B"));
-        assertLineAppearsBefore(log, "├─ Key/value entry - 228 B",
-                "├─ Key/position entry - 104 B");
-        assertTrue(log.contains("├─ Key/position entry - 104 B"));
-        assertTrue(log.contains("overhead: 96 B"));
-        assertTrue(log.contains(
-                "├─ Formula constants - shown for transparency, not added separately"));
-        assertTrue(log.contains(
-                "fixed per loaded/cached segment: about 16.00 KiB"));
-        assertTrue(log.contains(
-                "details: docs/operations/memory-estimate.md"));
-        assertTrue(log.contains(
-                "│  │  │  └─ Segment runtime - 16.00 KiB"));
-        assertTrue(log.contains(
-                "│  │  │  ├─ Scarce index - 5.08 KiB"));
-        assertTrue(log.contains(
-                "│  │  │  │  ├─ Max number of keys in scarce index - 50"));
-        assertDetailAlignsWithValue(estimate,
-                "│  │  │  │  ├─ Max number of keys in scarce index - 50",
-                "max number of keys in segment: 100");
-        assertTrue(log.contains(
-                "number of keys per page: 2"));
-        assertFalse(log.contains(
-                "│  │  │  │  │        max number of keys in segment: 100"));
-        assertFalse(log.contains(
-                "│  │  │  │  │  │                                    max number of keys in segment: 100"));
-        assertTrue(log.contains(
-                "│  │  │  │  └─ Key/position entry - 104 B"));
-        assertTrue(log.contains(
-                "key: TypeDescriptorInteger, about 4 B"));
-        assertTrue(log.contains(
-                "integer position: TypeDescriptorInteger, about 4 B"));
-        assertTrue(log.contains(
-                "├─ Other requirements - reported but not included"));
-        assertTrue(log.contains("index write-buffer keys: 18"));
-        assertTrue(log.contains("chunk keys per page: 2"));
-        assertTrue(log.contains("configured bloom filter size: 1.00 KiB"));
-        assertTrue(log.contains(
-                "│  │  │  ├─ Delta cache - 2.23 KiB"));
-        assertTrue(log.contains(
-                "configured max number of keys in cache: 10"));
-        assertTrue(log.contains("key/value entry: 228 B"));
+        assertContains(log, "Estimated memory use at startup");
+        assertContains(log, "Included memory");
+        assertContains(log,
+                "+------------------------+------------+--------------------------------------+");
+        assertContains(log,
+                "| Total index memory     | 91.14 KiB  | segments + page cache + maintenance  |");
+        assertContains(log,
+                "| All segments           | 72.91 KiB  | cached segment slots: 3; cached      |");
+        assertContains(log,
+                "| One cached segment     | 24.30 KiB  | delta cache + bloom filter + scarce  |");
+        assertContains(log,
+                "| Delta cache            | 2.23 KiB   | cache key limit: 10; cache key limit |");
+        assertContains(log,
+                "| Bloom filter           | 1.00 KiB   | configured bloom filter size: 1.00   |");
+        assertContains(log,
+                "| Scarce index           | 5.08 KiB   | max scarce keys: 50; max scarce keys |");
+        assertContains(log,
+                "| Segment runtime        | 16.00 KiB  | fixed overhead per cached segment    |");
+        assertContains(log,
+                "| Maintenance overhead   | 18.23 KiB  | max(25% of memory before maintenance |");
+        assertLineAppearsBefore(log, "| Total index memory",
+                "Entry sizes");
+        assertContains(log,
+                "not a JVM cap or measured allocation");
+        assertContains(log,
+                "| Key/value entry        | 228 B      | key size + value size + overhead;    |");
+        assertLineAppearsBefore(log, "| Key/value entry        | 228 B",
+                "| Key/position entry     | 104 B");
+        assertContains(log,
+                "| Key/position entry     | 104 B      | key size + integer position +        |");
+        assertContains(log, "overhead: 96 B");
+        assertContains(log,
+                "| Entry overhead         | 96 B       | fixed overhead in key/value and      |");
+        assertContains(log,
+                "details: docs/operations/memory-estimate.md");
+        assertContains(log,
+                "| Max scarce keys        | 50         | ceil(max segment keys / chunk keys   |");
+        assertContains(log, "per page)");
+        assertContains(log,
+                "key: TypeDescriptorInteger, about 4");
+        assertContains(log,
+                "integer position:");
+        assertContains(log, "Write-buffer keys");
+        assertContains(log, "reported, not included in total");
+        assertContains(log, "Chunk keys per page");
+        assertContains(log,
+                "configured bloom filter size: 1.00");
+        assertContains(log, "key/value entry 228 B");
         assertFalse(log.contains(
                 "entry overhead: 96 B inside key/value entry"));
-        assertDetailAlignsWithValue(estimate,
-                "│  │  ├─ One cached segment - 24.30 KiB",
-                "multiplied by 3 segment cache slots");
-        assertTrue(log.contains("End memory estimate"));
+        assertContains(log, "End memory estimate");
+        assertFalse(log.contains("├─"));
+        assertFalse(log.contains("│"));
         assertFalse(log.contains("based on:"));
         assertFalse(log.contains("reported only"));
     }
@@ -113,12 +103,16 @@ class IndexMemoryEstimatorTest {
         printReport("chunk-store-cache", estimate);
 
         assertEquals(97_880L, estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "│  ├─ Chunk-store page cache - 3.55 KiB"));
-        assertTrue(estimate.text().contains("7 pages"));
-        assertTrue(estimate.text().contains("chunk keys per page: 2"));
-        assertTrue(estimate.text().contains("page overhead: 64 B"));
-        assertTrue(estimate.text().contains("key/value entry: 228 B"));
+        assertContains(estimate.text(),
+                "| Chunk-store page cache | 3.55 KiB   | pages: 7; pages * (page overhead +   |");
+        assertContains(estimate.text(),
+                "| Chunk-store pages      | 7          | configured page cache size           |");
+        assertContains(estimate.text(),
+                "| Chunk keys per page    | 2          | keys stored in one chunk-store page  |");
+        assertContains(estimate.text(),
+                "| Page overhead          | 64 B       | fixed overhead per chunk-store page  |");
+        assertContains(estimate.text(),
+                "| Key/value entry        | 228 B");
     }
 
     @Test
@@ -134,12 +128,12 @@ class IndexMemoryEstimatorTest {
         printReport("cached-segment-limit", estimate);
 
         assertEquals(155_550L, estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "│  ├─ All segments - 121.52 KiB"));
-        assertTrue(estimate.text().contains(
-                "│  │  ├─ One cached segment - 24.30 KiB"));
-        assertTrue(estimate.text().contains(
-                "5 segment cache slots"));
+        assertContains(estimate.text(),
+                "| All segments           | 121.52 KiB | cached segment slots: 5; cached      |");
+        assertContains(estimate.text(),
+                "| One cached segment     | 24.30 KiB");
+        assertContains(estimate.text(),
+                "| Cached segment slots   | 5          | multiplier for one cached segment    |");
     }
 
     @Test
@@ -154,16 +148,13 @@ class IndexMemoryEstimatorTest {
         printReport("route-count", estimate);
 
         assertEquals(93_430L, estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "│  │  └─ Segment routing map - 80 B"));
-        assertTrue(estimate.text().contains(
-                "│  │     ├─ Number of segment routes - 10"));
-        assertTrue(estimate.text().contains(
-                "│  │     └─ Key/segment-id entry - 8 B"));
-        assertDetailAlignsWithValue(estimate,
-                "│  │     └─ Key/segment-id entry - 8 B",
-                "key: 4 B");
-        assertTrue(estimate.text().contains("segment id: 4 B"));
+        assertContains(estimate.text(),
+                "| Segment routing map    | 80 B       | route count: 10; route count *       |");
+        assertContains(estimate.text(),
+                "| Segment routes         | 10         | route-map entries                    |");
+        assertContains(estimate.text(),
+                "| Key/segment-id entry   | 8 B        | key size + segment id size; key: 4   |");
+        assertContains(estimate.text(), "B; segment id: 4 B");
         assertFalse(estimate.text().contains("segment id: 16 B"));
         assertFalse(estimate.text().contains("route-map tree entry"));
     }
@@ -181,17 +172,13 @@ class IndexMemoryEstimatorTest {
         printReport("cache-key-limits", estimate);
 
         assertEquals(101_880L, estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "│  │  │  ├─ Delta cache - 4.45 KiB"));
-        assertTrue(estimate.text().contains(
-                "configured max number of keys in cache: 20"));
-        assertTrue(estimate.text().contains("key/value entry: 228 B"));
-        assertTrue(estimate.text().contains(
-                "│  └─ Maintenance overhead - 19.90 KiB"));
-        assertTrue(estimate.text().contains(
-                "max(25% of memory before maintenance = 79.59 KiB,"));
-        assertTrue(estimate.text().contains(
-                "one delta cache = 4.45 KiB)"));
+        assertContains(estimate.text(),
+                "| Delta cache            | 4.45 KiB   | cache key limit: 20; cache key limit |");
+        assertContains(estimate.text(), "key/value entry 228 B");
+        assertContains(estimate.text(),
+                "| Maintenance overhead   | 19.90 KiB  | max(25% of memory before maintenance |");
+        assertContains(estimate.text(),
+                "= 79.59 KiB, one delta cache = 4.45");
     }
 
     @Test
@@ -208,15 +195,15 @@ class IndexMemoryEstimatorTest {
 
         assertEquals(1_425_282_600L,
                 estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "├─ Total index memory - 1.33 GiB"));
-        assertTrue(estimate.text().contains(
-                "│  ├─ All segments - 1.06 GiB"));
-        assertTrue(estimate.text().contains(
-                "│  │  │  ├─ Delta cache - 108.72 MiB"));
-        assertTrue(estimate.text().contains(
-                "configured max number of keys in cache: 500,000"));
-        assertTrue(estimate.text().contains("key/value entry: 228 B"));
+        assertContains(estimate.text(),
+                "| Total index memory     | 1.33 GiB");
+        assertContains(estimate.text(),
+                "| All segments           | 1.06 GiB");
+        assertContains(estimate.text(),
+                "| Delta cache            | 108.72 MiB");
+        assertContains(estimate.text(),
+                "cache key limit: 500,000");
+        assertContains(estimate.text(), "key/value entry 228 B");
     }
 
     @Test
@@ -233,14 +220,18 @@ class IndexMemoryEstimatorTest {
 
         assertEquals(1_429_074_220L,
                 estimate.totalEstimatedBytes().orElseThrow());
-        assertTrue(estimate.text().contains(
-                "├─ Total index memory - 1.33 GiB"));
-        assertTrue(estimate.text().contains(
-                "│  ├─ Chunk-store page cache - 1.06 GiB"));
-        assertTrue(estimate.text().contains("50,000 pages"));
-        assertTrue(estimate.text().contains("chunk keys per page: 100"));
-        assertTrue(estimate.text().contains("page overhead: 64 B"));
-        assertTrue(estimate.text().contains("key/value entry: 228 B"));
+        assertContains(estimate.text(),
+                "| Total index memory     | 1.33 GiB");
+        assertContains(estimate.text(),
+                "| Chunk-store page cache | 1.06 GiB");
+        assertContains(estimate.text(),
+                "| Chunk-store pages      | 50,000");
+        assertContains(estimate.text(),
+                "| Chunk keys per page    | 100");
+        assertContains(estimate.text(),
+                "| Page overhead          | 64 B");
+        assertContains(estimate.text(),
+                "| Key/value entry        | 228 B");
     }
 
     @Test
@@ -257,13 +248,14 @@ class IndexMemoryEstimatorTest {
         assertFalse(estimate.isComplete());
         assertTrue(estimate.totalEstimatedBytes().isEmpty());
         final String log = estimate.text();
-        assertTrue(log.contains("value: TypeDescriptorByteArray, unknown"));
-        assertTrue(log.contains(
-                "│  │  │  ├─ Delta cache - unknown"));
-        assertTrue(log.contains(
-                "reason: needs key and value descriptor estimates"));
-        assertTrue(log.contains("Bloom filter"));
-        assertTrue(log.contains("├─ Total index memory - unknown"));
+        assertContains(log, "value: TypeDescriptorByteArray,");
+        assertContains(log,
+                "| Delta cache            | unknown    | reason: needs key and value          |");
+        assertContains(log,
+                "reason: needs key and value");
+        assertContains(log, "Bloom filter");
+        assertContains(log,
+                "| Total index memory     | unknown    | reason: needs segment, page-cache,   |");
     }
 
     @Test
@@ -279,9 +271,9 @@ class IndexMemoryEstimatorTest {
 
         assertTrue(estimate.isComplete());
         assertTrue(estimate.totalEstimatedBytes().isPresent());
-        assertTrue(estimate.text().contains(
-                "├─ Key/value entry - 100 B"));
-        assertTrue(estimate.text().contains("overhead: 96 B"));
+        assertContains(estimate.text(),
+                "| Key/value entry        | 100 B");
+        assertContains(estimate.text(), "overhead: 96 B");
     }
 
     @Test
@@ -298,16 +290,12 @@ class IndexMemoryEstimatorTest {
 
         final String log = estimate.text();
         assertTrue(estimate.isComplete());
-        assertTrue(log.contains("│  │  │  ├─ Scarce index - 11.13 KiB"));
-        assertTrue(log.contains(
-                "│  │  │  │  └─ Key/position entry - 228 B"));
-        assertLineAppearsBefore(log, "├─ Key/value entry - 228 B",
-                "├─ Key/position entry - 228 B");
-        assertDetailAlignsWithValue(estimate,
-                "├─ Key/position entry - 228 B",
-                "key: TypeDescriptorShortString, about 128 B");
-        assertTrue(log.contains(
-                "integer position: TypeDescriptorInteger, about 4 B"));
+        assertContains(log, "| Scarce index           | 11.13 KiB");
+        assertContains(log, "| Key/position entry     | 228 B");
+        assertLineAppearsBefore(log, "| Key/value entry        | 228 B",
+                "| Key/position entry     | 228 B");
+        assertContains(log, "TypeDescriptorShortString, about 128");
+        assertContains(log, "integer position:");
     }
 
     private static <V> EffectiveIndexConfiguration<Integer, V> effectiveConfiguration(
@@ -396,23 +384,13 @@ class IndexMemoryEstimatorTest {
 
     private static void assertReadableLineLengths(
             final MemoryEstimateReport report) {
-        report.lines().forEach(line -> assertTrue(line.length() <= 100,
+        report.lines().forEach(line -> assertTrue(line.length() <= 80,
                 () -> "Report line is too long: " + line));
     }
 
-    private static void assertDetailAlignsWithValue(
-            final MemoryEstimateReport report, final String treeLine,
-            final String detail) {
-        final List<String> lines = report.lines();
-        final int lineIndex = lines.indexOf(treeLine);
-
-        assertTrue(lineIndex >= 0, () -> "Missing line: " + treeLine);
-        final String detailLine = lines.get(lineIndex + 1);
-        final int valueColumn = treeLine.indexOf(" - ") + " - ".length();
-
-        assertEquals(valueColumn, detailLine.indexOf(detail));
-        assertTrue(detailLine.substring(0, valueColumn).contains("│"),
-                () -> "Missing tree connection before detail: " + detailLine);
+    private static void assertContains(final String log,
+            final String expected) {
+        assertTrue(log.contains(expected), () -> "Missing text: " + expected);
     }
 
     private static void assertLineAppearsBefore(final String log,

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperationTest.java
@@ -146,7 +146,7 @@ class SegmentIndexBootstrapOperationTest {
             assertInstanceOf(SegmentIndexMdcLoggingAdapter.class, index);
             assertTrue(index.startupMemoryEstimate().isComplete());
             assertTrue(index.startupMemoryEstimate().text().contains(
-                    "├─ Total index memory - "));
+                    "| Total index memory"));
         } finally {
             index.close();
         }
@@ -183,7 +183,7 @@ class SegmentIndexBootstrapOperationTest {
                             .maintenance().registryLifecycleThreads());
             assertTrue(index.startupMemoryEstimate().isComplete());
             assertTrue(index.startupMemoryEstimate().text().contains(
-                    "├─ Total index memory - "));
+                    "| Total index memory"));
         } finally {
             index.close();
         }


### PR DESCRIPTION
## Summary
- Replace the startup memory estimate tree with fixed-width ASCII tables.
- Wrap table descriptions so report lines stay within the 80-character report width.
- Update memory estimate docs and tests for the new layout.

## Tests
- mvn -pl engine -Dtest=IndexMemoryEstimatorTest,SegmentIndexBootstrapOperationTest test
- python3 scripts/check_docs_nav.py
- mkdocs build --strict
- mvn clean verify