### PR TITLE
Add monitoring console start script

### DIFF
--- a/docs/configuration/monitoring-console.md
+++ b/docs/configuration/monitoring-console.md
@@ -68,6 +68,29 @@ Open:
 
 - [http://127.0.0.1:8090/](http://127.0.0.1:8090/)
 
+## Start against running nodes
+
+Use `monitoring-console-web/scripts/start.sh` when the monitored stores are
+already running and each store exposes `monitoring-rest-json`.
+
+Pass one or more monitoring API base URLs. Use the base URL of each node, not
+the `/api/v1/report` path:
+
+```bash
+./monitoring-console-web/scripts/start.sh http://localhost:8091
+./monitoring-console-web/scripts/start.sh http://localhost:8091 http://localhost:8092
+```
+
+The script assigns the nodes as `node-1`, `node-2`, and so on, builds
+`monitoring-console-web`, and starts the web UI on
+[http://127.0.0.1:8090/](http://127.0.0.1:8090/).
+
+Override the web UI port with `WEB_PORT`:
+
+```bash
+WEB_PORT=18090 ./monitoring-console-web/scripts/start.sh http://localhost:8091
+```
+
 ## One-command local demo (direct mode)
 
 This command starts:

--- a/monitoring-console-web/pom.xml
+++ b/monitoring-console-web/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
+        <log4j.version>2.25.4</log4j.version>
         <junit.jupiter.version>5.12.2</junit.jupiter.version>
         <junit.platform.version>1.12.2</junit.platform.version>
     </properties>

--- a/monitoring-console-web/scripts/start.sh
+++ b/monitoring-console-web/scripts/start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+WEB_PORT="${WEB_PORT:-8090}"
+
+usage() {
+  echo "Usage: ./monitoring-console-web/scripts/start.sh <monitoring-api-base-url> [monitoring-api-base-url ...]" >&2
+  echo "Example: ./monitoring-console-web/scripts/start.sh http://localhost:8091" >&2
+  echo "Set WEB_PORT to override the web console port. Default: 8090." >&2
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+check_port_available() {
+  local port="$1"
+  if lsof -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "Port ${port} is already in use. Set WEB_PORT to another value." >&2
+    exit 1
+  fi
+}
+
+if [[ "$#" -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+spring_jvm_args=("-Dserver.port=${WEB_PORT}")
+endpoints=()
+node_index=0
+for endpoint in "$@"; do
+  if [[ ! "${endpoint}" =~ ^https?:// ]]; then
+    echo "Monitoring API endpoint must start with http:// or https://: ${endpoint}" >&2
+    exit 1
+  fi
+
+  endpoint="${endpoint%/}"
+  endpoints+=("${endpoint}")
+  node_number=$((node_index + 1))
+  spring_jvm_args+=(
+    "-Dhestia.console.web.nodes[${node_index}].node-id=node-${node_number}"
+    "-Dhestia.console.web.nodes[${node_index}].node-name=node-${node_number}"
+    "-Dhestia.console.web.nodes[${node_index}].base-url=${endpoint}"
+  )
+  node_index=$((node_index + 1))
+done
+
+for command in lsof mvn; do
+  require_command "${command}"
+done
+
+check_port_available "${WEB_PORT}"
+
+echo "Starting HestiaStore monitoring console on http://127.0.0.1:${WEB_PORT}/ ..."
+for i in "${!endpoints[@]}"; do
+  echo "  node-$((i + 1)): ${endpoints[$i]}"
+done
+
+mvn -q -pl monitoring-console-web -am -DskipTests install
+
+exec mvn -q \
+  -pl monitoring-console-web \
+  -Dspring-boot.run.jvmArguments="${spring_jvm_args[*]}" \
+  spring-boot:run


### PR DESCRIPTION
## Summary
- add a module-local monitoring console start script for running against one or more existing monitoring-rest-json endpoints
- pin the web module Log4j version to the Spring Boot-compatible Log4j 2 line
- document the new launcher in the monitoring console configuration guide

## Verification
- bash -n monitoring-console-web/scripts/start.sh
- ./monitoring-console-web/scripts/start.sh (expected usage error)
- ./monitoring-console-web/scripts/start.sh localhost:8091 (expected validation error)
- python3 scripts/check_docs_nav.py
- mkdocs build --strict
- mvn -pl monitoring-console-web -am -DskipTests install
- WEB_PORT=18094 ./monitoring-console-web/scripts/start.sh http://127.0.0.1:8091 (started successfully, then stopped)

Note: a pre-existing unstaged change remains in engine/src/test/java/org/hestiastore/index/ByteToolTest.java and is not part of this PR.