### PR TITLE
Optimize concurrent route leasing

### DIFF
--- a/benchmarks/profiles/segment-index-route-leasing.json
+++ b/benchmarks/profiles/segment-index-route-leasing.json
@@ -1,0 +1,36 @@
+{
+  "profile": "segment-index-route-leasing",
+  "description": "Focused steady-state RouteTopology lease scaling for one hot route and distributed routes.",
+  "benchmarks": [
+    {
+      "label": "route-lease-1-route-1-thread",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "1", "-p", "routeCount=1", "-prof", "gc"]
+    },
+    {
+      "label": "route-lease-1-route-10-threads",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "10", "-p", "routeCount=1", "-prof", "gc"]
+    },
+    {
+      "label": "route-lease-1-route-40-threads",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "40", "-p", "routeCount=1", "-prof", "gc"]
+    },
+    {
+      "label": "route-lease-64-routes-1-thread",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "1", "-p", "routeCount=64", "-prof", "gc"]
+    },
+    {
+      "label": "route-lease-64-routes-10-threads",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "10", "-p", "routeCount=64", "-prof", "gc"]
+    },
+    {
+      "label": "route-lease-64-routes-40-threads",
+      "include": "org.hestiastore.benchmark.segmentindex.RouteTopologyLeaseBenchmark",
+      "args": ["-wi", "3", "-i", "5", "-f", "3", "-w", "1s", "-r", "1s", "-t", "40", "-p", "routeCount=64", "-prof", "gc"]
+    }
+  ]
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/RouteTopologyLeaseBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/RouteTopologyLeaseBenchmark.java
@@ -1,0 +1,146 @@
+package org.hestiastore.benchmark.segmentindex;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segment.SegmentId;
+import org.hestiastore.index.segmentindex.SegmentWindow;
+import org.hestiastore.index.segmentindex.core.routing.RouteTopology;
+import org.hestiastore.index.segmentindex.core.routing.RouteTopology.RouteLeaseResult;
+import org.hestiastore.index.segmentindex.routemap.PersistentSegmentRouteMap;
+import org.hestiastore.index.segmentindex.routemap.RouteMapSnapshot;
+import org.hestiastore.index.segmentindex.routemap.RouteSplitPlan;
+import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.ThreadParams;
+
+/**
+ * Measures steady-state route lease acquisition and release without segment
+ * storage work.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@State(Scope.Benchmark)
+public class RouteTopologyLeaseBenchmark {
+
+    @Param({ "1", "64" })
+    private int routeCount;
+
+    private SegmentRouteMap<Integer> routeMap;
+    private RouteTopology<Integer> topology;
+    private List<SegmentId> routeIds;
+    private long version;
+
+    /**
+     * Creates the requested number of runtime routes.
+     */
+    @Setup(Level.Trial)
+    public void setup() {
+        routeMap = new PersistentSegmentRouteMap<>(new MemDirectory(),
+                new TypeDescriptorInteger());
+        routeMap.extendMaxKeyIfNeeded(Integer.valueOf(routeCount));
+        splitTailRoutes();
+        final RouteMapSnapshot<Integer> snapshot = routeMap.snapshot();
+        routeIds = snapshot.getSegmentIds(SegmentWindow.unbounded());
+        if (routeIds.size() != routeCount) {
+            throw new IllegalStateException(String.format(
+                    "Expected %d routes but created %d.", routeCount,
+                    routeIds.size()));
+        }
+        topology = RouteTopology.create(snapshot, 1, 1_000);
+        version = snapshot.version();
+    }
+
+    /**
+     * Closes the temporary route map after each fork.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (routeMap != null && !routeMap.wasClosed()) {
+            routeMap.close();
+        }
+    }
+
+    /**
+     * Acquires and immediately releases one route lease.
+     *
+     * @param cursor thread-local route selector
+     */
+    @Benchmark
+    public void acquireAndRelease(final RouteCursor cursor) {
+        final SegmentId segmentId = routeIds.get(cursor.next(routeCount));
+        final RouteLeaseResult result = topology.tryAcquire(segmentId, version);
+        if (!result.isAcquired()) {
+            throw new IllegalStateException(
+                    "Steady-state route lease was not acquired.");
+        }
+        result.lease().close();
+    }
+
+    private void splitTailRoutes() {
+        SegmentId tailSegmentId = SegmentId.of(0);
+        int nextSegmentId = 1;
+        for (int boundary = 1; boundary < routeCount; boundary++) {
+            final SegmentId lowerSegmentId = SegmentId.of(nextSegmentId++);
+            final SegmentId upperSegmentId = SegmentId.of(nextSegmentId++);
+            final RouteSplitPlan<Integer> split = new RouteSplitPlan<>(
+                    tailSegmentId, lowerSegmentId, upperSegmentId,
+                    Integer.valueOf(boundary), Integer.valueOf(routeCount));
+            if (!routeMap.tryReplaceRouteWithSplit(split)) {
+                throw new IllegalStateException(
+                        "Unable to create benchmark route topology.");
+            }
+            tailSegmentId = upperSegmentId;
+        }
+    }
+
+    /**
+     * Thread-local route selection state that avoids a shared benchmark
+     * counter.
+     */
+    @State(Scope.Thread)
+    public static class RouteCursor {
+
+        private int nextRoute;
+
+        /**
+         * Seeds each benchmark thread at a different route.
+         *
+         * @param threadParams JMH thread metadata
+         */
+        @Setup(Level.Trial)
+        public void setup(final ThreadParams threadParams) {
+            nextRoute = threadParams.getThreadIndex();
+        }
+
+        /**
+         * Returns the next route index for this benchmark thread.
+         *
+         * @param bound number of available routes
+         * @return route index
+         */
+        int next(final int bound) {
+            final int current = nextRoute >= bound ? nextRoute % bound
+                    : nextRoute;
+            nextRoute = current + 1 == bound ? 0 : current + 1;
+            return current;
+        }
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteDrainHandle.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteDrainHandle.java
@@ -5,27 +5,36 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 
+/**
+ * Drain handle bound to the exact route entry moved out of active state.
+ */
 final class RouteDrainHandle implements RouteTopology.RouteDrain {
 
-    private final RouteTopology<?> topology;
+    private final RouteEntry entry;
     private final SegmentId segmentId;
     private final AtomicBoolean completed = new AtomicBoolean();
 
-    RouteDrainHandle(final RouteTopology<?> topology,
+    /**
+     * Creates a drain bound to its exact route entry.
+     *
+     * @param entry draining route entry
+     * @param segmentId draining segment id
+     */
+    RouteDrainHandle(final RouteEntry entry,
             final SegmentId segmentId) {
-        this.topology = Vldtn.requireNonNull(topology, "topology");
+        this.entry = Vldtn.requireNonNull(entry, "entry");
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");
     }
 
     @Override
     public void awaitDrained() {
-        topology.awaitDrained(segmentId);
+        entry.awaitDrained(segmentId);
     }
 
     @Override
     public void abort() {
         if (completed.compareAndSet(false, true)) {
-            topology.abortDrain(segmentId);
+            entry.markActive();
         }
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteEntry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteEntry.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.segmentindex.core.routing;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 
@@ -8,6 +9,7 @@ import org.hestiastore.index.segment.SegmentId;
  */
 final class RouteEntry {
 
+    private final Object monitor = new Object();
     private RouteState state;
     private long inFlight;
 
@@ -15,47 +17,159 @@ final class RouteEntry {
         this.state = Vldtn.requireNonNull(state, "state");
     }
 
+    /**
+     * Returns the current lifecycle state guarded with the lease count.
+     *
+     * @return route lifecycle state
+     */
     RouteState state() {
-        return state;
-    }
-
-    boolean isActive() {
-        return state == RouteState.ACTIVE;
-    }
-
-    boolean isRetired() {
-        return state == RouteState.RETIRED;
-    }
-
-    boolean hasInFlight() {
-        return inFlight > 0L;
-    }
-
-    long inFlight() {
-        return inFlight;
-    }
-
-    void acquireLease() {
-        inFlight++;
-    }
-
-    void releaseLease(final SegmentId segmentId) {
-        if (inFlight <= 0L) {
-            throw new IllegalStateException(String.format(
-                    "Route '%s' lease count is already zero.", segmentId));
+        synchronized (monitor) {
+            return state;
         }
-        inFlight--;
     }
 
-    void markDraining() {
-        state = RouteState.DRAINING;
+    /**
+     * Returns whether this route currently accepts leases.
+     *
+     * @return true when the route is active
+     */
+    boolean isActive() {
+        synchronized (monitor) {
+            return state == RouteState.ACTIVE;
+        }
     }
 
+    /**
+     * Returns whether this route has left the published topology.
+     *
+     * @return true when the route is retired
+     */
+    boolean isRetired() {
+        synchronized (monitor) {
+            return state == RouteState.RETIRED;
+        }
+    }
+
+    /**
+     * Returns whether at least one acquired lease remains open.
+     *
+     * @return true when a lease remains open
+     */
+    boolean hasInFlight() {
+        synchronized (monitor) {
+            return inFlight > 0L;
+        }
+    }
+
+    /**
+     * Returns the exact number of acquired leases.
+     *
+     * @return acquired lease count
+     */
+    long inFlight() {
+        synchronized (monitor) {
+            return inFlight;
+        }
+    }
+
+    /**
+     * Atomically acquires a lease only while the route remains active.
+     *
+     * @return true when the lease count was incremented
+     */
+    boolean tryAcquireLease() {
+        synchronized (monitor) {
+            if (state != RouteState.ACTIVE) {
+                return false;
+            }
+            if (inFlight == Long.MAX_VALUE) {
+                throw new IllegalStateException(
+                        "Route lease count reached its maximum value.");
+            }
+            inFlight++;
+            return true;
+        }
+    }
+
+    /**
+     * Atomically returns one lease and reports completed retirement.
+     *
+     * @param segmentId segment id used in validation failures
+     * @return true when the route is retired and no leases remain
+     */
+    boolean releaseLease(final SegmentId segmentId) {
+        synchronized (monitor) {
+            if (inFlight == 0L) {
+                throw new IllegalStateException(String.format(
+                        "Route '%s' lease count is already zero.", segmentId));
+            }
+            inFlight--;
+            if (inFlight == 0L && state != RouteState.ACTIVE) {
+                monitor.notifyAll();
+            }
+            return inFlight == 0L && state == RouteState.RETIRED;
+        }
+    }
+
+    /**
+     * Atomically refuses new leases while preserving the current lease count.
+     *
+     * @return true when this call started the drain
+     */
+    boolean tryMarkDraining() {
+        synchronized (monitor) {
+            if (state != RouteState.ACTIVE) {
+                return false;
+            }
+            state = RouteState.DRAINING;
+            return true;
+        }
+    }
+
+    /**
+     * Restores a draining route after an aborted split operation.
+     */
     void markActive() {
-        state = RouteState.ACTIVE;
+        synchronized (monitor) {
+            if (state == RouteState.DRAINING) {
+                state = RouteState.ACTIVE;
+            }
+        }
     }
 
-    void markRetired() {
-        state = RouteState.RETIRED;
+    /**
+     * Prevents future leases after the route leaves the published topology.
+     *
+     * @return true when no leases remain at retirement time
+     */
+    boolean markRetired() {
+        synchronized (monitor) {
+            state = RouteState.RETIRED;
+            if (inFlight == 0L) {
+                monitor.notifyAll();
+            }
+            return inFlight == 0L;
+        }
+    }
+
+    /**
+     * Waits on this route only until its acquired leases are returned.
+     *
+     * @param segmentId segment id used in interruption failures
+     */
+    void awaitDrained(final SegmentId segmentId) {
+        synchronized (monitor) {
+            while (inFlight > 0L) {
+                try {
+                    monitor.wait();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IndexException(String.format(
+                            "Interrupted while waiting for route '%s' to drain.",
+                            segmentId),
+                            e);
+                }
+            }
+        }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteLeaseHandle.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteLeaseHandle.java
@@ -5,15 +5,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 
+/**
+ * Idempotent lease handle that releases the exact acquired route entry.
+ */
 final class RouteLeaseHandle implements RouteTopology.RouteLease {
 
     private final RouteTopology<?> topology;
+    private final RouteEntry entry;
     private final SegmentId segmentId;
     private final AtomicBoolean closed = new AtomicBoolean();
 
+    /**
+     * Creates a lease bound to its acquired entry.
+     *
+     * @param topology owning route topology
+     * @param entry acquired route entry
+     * @param segmentId acquired segment id
+     */
     RouteLeaseHandle(final RouteTopology<?> topology,
-            final SegmentId segmentId) {
+            final RouteEntry entry, final SegmentId segmentId) {
         this.topology = Vldtn.requireNonNull(topology, "topology");
+        this.entry = Vldtn.requireNonNull(entry, "entry");
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");
     }
 
@@ -25,7 +37,7 @@ final class RouteLeaseHandle implements RouteTopology.RouteLease {
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            topology.releaseLease(segmentId);
+            topology.releaseLease(entry, segmentId);
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteTopology.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/RouteTopology.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hestiastore.index.BusyRetryPolicy;
-import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segmentindex.SegmentWindow;
@@ -25,10 +25,11 @@ public final class RouteTopology<K> {
 
     private static final String OPERATION_DRAIN = "drainRouteLeases";
 
-    private final Object monitor = new Object();
-    private final Map<SegmentId, RouteEntry> routes = new HashMap<>();
+    private final Object reconciliationMonitor = new Object();
+    private final Set<RouteEntry> pendingRetiredEntries = ConcurrentHashMap
+            .newKeySet();
     private final BusyRetryPolicy retryPolicy;
-    private long version;
+    private volatile RouteView routeView = new RouteView(Map.of(), 0L);
 
     RouteTopology(final RouteMapSnapshot<K> snapshot,
             final BusyRetryPolicy retryPolicy) {
@@ -65,18 +66,20 @@ public final class RouteTopology<K> {
     public RouteLeaseResult tryAcquire(final SegmentId segmentId,
             final long expectedVersion) {
         Vldtn.requireNonNull(segmentId, "segmentId");
-        synchronized (monitor) {
-            if (version != expectedVersion) {
-                return RouteLeaseAttempt.staleTopology();
-            }
-            final RouteEntry entry = routes.get(segmentId);
-            if (entry == null || !entry.isActive()) {
-                return RouteLeaseAttempt.routeUnavailable();
-            }
-            entry.acquireLease();
-            return RouteLeaseAttempt
-                    .acquired(new RouteLeaseHandle(this, segmentId));
+        final RouteView currentView = routeView;
+        if (currentView.version() != expectedVersion) {
+            return RouteLeaseAttempt.staleTopology();
         }
+        final RouteEntry entry = currentView.routes().get(segmentId);
+        if (entry == null || !entry.tryAcquireLease()) {
+            return RouteLeaseAttempt.routeUnavailable();
+        }
+        if (routeView != currentView) {
+            releaseLease(entry, segmentId);
+            return RouteLeaseAttempt.staleTopology();
+        }
+        return RouteLeaseAttempt
+                .acquired(new RouteLeaseHandle(this, entry, segmentId));
     }
 
     /**
@@ -87,15 +90,11 @@ public final class RouteTopology<K> {
      */
     public Optional<RouteDrain> tryBeginDrain(final SegmentId segmentId) {
         Vldtn.requireNonNull(segmentId, "segmentId");
-        synchronized (monitor) {
-            final RouteEntry entry = routes.get(segmentId);
-            if (entry == null || !entry.isActive()) {
-                return Optional.empty();
-            }
-            entry.markDraining();
-            monitor.notifyAll();
-            return Optional.of(new RouteDrainHandle(this, segmentId));
+        final RouteEntry entry = routeView.routes().get(segmentId);
+        if (entry == null || !entry.tryMarkDraining()) {
+            return Optional.empty();
         }
+        return Optional.of(new RouteDrainHandle(entry, segmentId));
     }
 
     /**
@@ -103,7 +102,7 @@ public final class RouteTopology<K> {
      */
     public void drain() {
         final long startNanos = retryPolicy.startNanos();
-        while (hasInFlightLeasesSnapshot()) {
+        while (hasInFlightLeases()) {
             retryPolicy.backoffOrThrow(startNanos, OPERATION_DRAIN, null);
         }
     }
@@ -118,15 +117,23 @@ public final class RouteTopology<K> {
                 "snapshot");
         final List<SegmentId> activeSegmentIds = nonNullSnapshot
                 .getSegmentIds(SegmentWindow.unbounded());
-        synchronized (monitor) {
-            if (nonNullSnapshot.version() < version) {
+        synchronized (reconciliationMonitor) {
+            final RouteView currentView = routeView;
+            if (nonNullSnapshot.version() < currentView.version()) {
                 return;
             }
             final Set<SegmentId> activeIds = new HashSet<>(activeSegmentIds);
-            activeIds.forEach(this::ensureActiveRoute);
-            retireRoutesMissingFrom(activeIds);
-            version = nonNullSnapshot.version();
-            monitor.notifyAll();
+            if (nonNullSnapshot.version() == currentView.version()
+                    && currentView.routes().keySet().equals(activeIds)) {
+                return;
+            }
+            final Map<SegmentId, RouteEntry> updatedRoutes = new HashMap<>(
+                    currentView.routes());
+            activeIds.forEach(
+                    segmentId -> ensureActiveRoute(updatedRoutes, segmentId));
+            retireRoutesMissingFrom(updatedRoutes, activeIds);
+            routeView = new RouteView(Map.copyOf(updatedRoutes),
+                    nonNullSnapshot.version());
         }
     }
 
@@ -136,60 +143,35 @@ public final class RouteTopology<K> {
      * @return topology version
      */
     public long version() {
-        synchronized (monitor) {
-            return version;
+        return routeView.version();
+    }
+
+    /**
+     * Releases the directly referenced route entry without another route-map
+     * lookup.
+     *
+     * @param entry leased route entry
+     * @param segmentId leased segment id
+     */
+    void releaseLease(final RouteEntry entry, final SegmentId segmentId) {
+        if (entry.releaseLease(segmentId)) {
+            pendingRetiredEntries.remove(entry);
         }
     }
 
-    void releaseLease(final SegmentId segmentId) {
-        synchronized (monitor) {
-            final RouteEntry entry = routes.get(segmentId);
-            if (entry == null) {
-                return;
-            }
-            entry.releaseLease(segmentId);
-            if (!entry.hasInFlight() && entry.isRetired()) {
-                routes.remove(segmentId);
-            }
-            monitor.notifyAll();
-        }
-    }
-
-    void awaitDrained(final SegmentId segmentId) {
-        synchronized (monitor) {
-            while (inFlightCount(segmentId) > 0) {
-                try {
-                    monitor.wait();
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IndexException(String.format(
-                            "Interrupted while waiting for route '%s' to drain.",
-                            segmentId),
-                            e);
-                }
-            }
-        }
-    }
-
-    void abortDrain(final SegmentId segmentId) {
-        synchronized (monitor) {
-            final RouteEntry entry = routes.get(segmentId);
-            if (entry != null && entry.state() == RouteState.DRAINING) {
-                entry.markActive();
-            }
-            monitor.notifyAll();
-        }
-    }
-
-    private void ensureActiveRoute(final SegmentId segmentId) {
-        final RouteEntry entry = routes.get(segmentId);
+    private void ensureActiveRoute(
+            final Map<SegmentId, RouteEntry> updatedRoutes,
+            final SegmentId segmentId) {
+        final RouteEntry entry = updatedRoutes.get(segmentId);
         if (entry == null || entry.isRetired()) {
-            routes.put(segmentId, new RouteEntry(RouteState.ACTIVE));
+            updatedRoutes.put(segmentId, new RouteEntry(RouteState.ACTIVE));
         }
     }
 
-    private void retireRoutesMissingFrom(final Set<SegmentId> activeIds) {
-        final Iterator<Map.Entry<SegmentId, RouteEntry>> iterator = routes
+    private void retireRoutesMissingFrom(
+            final Map<SegmentId, RouteEntry> updatedRoutes,
+            final Set<SegmentId> activeIds) {
+        final Iterator<Map.Entry<SegmentId, RouteEntry>> iterator = updatedRoutes
                 .entrySet().iterator();
         while (iterator.hasNext()) {
             final Map.Entry<SegmentId, RouteEntry> route = iterator.next();
@@ -197,26 +179,39 @@ public final class RouteTopology<K> {
                 continue;
             }
             final RouteEntry entry = route.getValue();
-            if (!entry.hasInFlight()) {
-                iterator.remove();
-            } else {
-                entry.markRetired();
+            pendingRetiredEntries.add(entry);
+            final boolean retiredWithoutLeases = entry.markRetired();
+            iterator.remove();
+            if (retiredWithoutLeases) {
+                pendingRetiredEntries.remove(entry);
             }
         }
     }
 
-    private long inFlightCount(final SegmentId segmentId) {
-        final RouteEntry entry = routes.get(segmentId);
-        return entry == null ? 0L : entry.inFlight();
-    }
-
     private boolean hasInFlightLeases() {
-        return routes.values().stream().anyMatch(RouteEntry::hasInFlight);
+        return routeView.routes().values().stream()
+                .anyMatch(RouteEntry::hasInFlight)
+                || pendingRetiredEntries.stream()
+                        .anyMatch(RouteEntry::hasInFlight);
     }
 
-    private boolean hasInFlightLeasesSnapshot() {
-        synchronized (monitor) {
-            return hasInFlightLeases();
+    private static final class RouteView {
+
+        private final Map<SegmentId, RouteEntry> routes;
+        private final long version;
+
+        private RouteView(final Map<SegmentId, RouteEntry> routes,
+                final long version) {
+            this.routes = routes;
+            this.version = version;
+        }
+
+        private Map<SegmentId, RouteEntry> routes() {
+            return routes;
+        }
+
+        private long version() {
+            return version;
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/routing/RouteEntryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/routing/RouteEntryTest.java
@@ -5,6 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segment.SegmentId;
 import org.junit.jupiter.api.Test;
 
@@ -14,12 +22,12 @@ class RouteEntryTest {
     void acquireAndReleaseLeaseTracksInflightCount() {
         final RouteEntry entry = new RouteEntry(RouteState.ACTIVE);
 
-        entry.acquireLease();
+        assertTrue(entry.tryAcquireLease());
 
         assertTrue(entry.hasInFlight());
         assertEquals(1L, entry.inFlight());
 
-        entry.releaseLease(SegmentId.of(1));
+        assertFalse(entry.releaseLease(SegmentId.of(1)));
 
         assertFalse(entry.hasInFlight());
         assertEquals(0L, entry.inFlight());
@@ -38,13 +46,78 @@ class RouteEntryTest {
     void stateTransitionsAreExplicit() {
         final RouteEntry entry = new RouteEntry(RouteState.ACTIVE);
 
-        entry.markDraining();
+        assertTrue(entry.tryMarkDraining());
         assertEquals(RouteState.DRAINING, entry.state());
+        assertFalse(entry.tryAcquireLease());
 
         entry.markActive();
         assertTrue(entry.isActive());
+        assertTrue(entry.tryAcquireLease());
+        entry.releaseLease(SegmentId.of(1));
 
         entry.markRetired();
         assertTrue(entry.isRetired());
+        assertFalse(entry.tryAcquireLease());
+    }
+
+    @Test
+    void abortDrainPreservesInflightLeaseCount() {
+        final RouteEntry entry = new RouteEntry(RouteState.ACTIVE);
+        assertTrue(entry.tryAcquireLease());
+
+        assertTrue(entry.tryMarkDraining());
+        entry.markActive();
+
+        assertTrue(entry.isActive());
+        assertEquals(1L, entry.inFlight());
+        assertFalse(entry.releaseLease(SegmentId.of(1)));
+    }
+
+    @Test
+    void awaitDrainedPreservesInterruptStatus() {
+        final RouteEntry entry = new RouteEntry(RouteState.ACTIVE);
+        final SegmentId segmentId = SegmentId.of(1);
+        assertTrue(entry.tryAcquireLease());
+        assertTrue(entry.tryMarkDraining());
+        Thread.currentThread().interrupt();
+
+        try {
+            assertThrows(IndexException.class,
+                    () -> entry.awaitDrained(segmentId));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+            entry.releaseLease(segmentId);
+        }
+    }
+
+    @Test
+    void concurrentAcquireAndReleaseKeepsCountBalanced() throws Exception {
+        final RouteEntry entry = new RouteEntry(RouteState.ACTIVE);
+        final ExecutorService executor = Executors.newFixedThreadPool(16);
+        final List<Callable<Void>> tasks = new ArrayList<>();
+        for (int thread = 0; thread < 16; thread++) {
+            tasks.add(() -> {
+                for (int iteration = 0; iteration < 10_000; iteration++) {
+                    if (!entry.tryAcquireLease()) {
+                        throw new IllegalStateException(
+                                "Active route rejected a lease.");
+                    }
+                    entry.releaseLease(SegmentId.of(1));
+                }
+                return null;
+            });
+        }
+
+        try {
+            final List<Future<Void>> results = executor.invokeAll(tasks);
+            for (final Future<Void> result : results) {
+                result.get();
+            }
+            assertEquals(0L, entry.inFlight());
+            assertTrue(entry.isActive());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/routing/RouteTopologyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/routing/RouteTopologyTest.java
@@ -34,7 +34,7 @@ class RouteTopologyTest {
     void setUp() {
         keyToSegmentMap = new PersistentSegmentRouteMap<>(new MemDirectory(),
                 new TypeDescriptorInteger());
-        executor = Executors.newSingleThreadExecutor();
+        executor = Executors.newFixedThreadPool(4);
     }
 
     @AfterEach
@@ -64,7 +64,11 @@ class RouteTopologyTest {
     void drainWaitsForInflightLeaseAndRejectsNewLease() throws Exception {
         keyToSegmentMap.extendMaxKeyIfNeeded(100);
         final RouteTopology<Integer> topology = newTopology();
-        final RouteTopology.RouteLease lease = topology
+        final RouteTopology.RouteLease firstLease = topology
+                .tryAcquire(SegmentId.of(0), keyToSegmentMap.snapshot()
+                        .version())
+                .lease();
+        final RouteTopology.RouteLease secondLease = topology
                 .tryAcquire(SegmentId.of(0), keyToSegmentMap.snapshot()
                         .version())
                 .lease();
@@ -82,11 +86,54 @@ class RouteTopologyTest {
         assertTrue(topology.tryAcquire(SegmentId.of(0),
                 keyToSegmentMap.snapshot().version()).isRouteUnavailable());
 
-        lease.close();
+        firstLease.close();
+        assertFalse(waitFuture.isDone());
+        secondLease.close();
 
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
             waitFuture.get(5, TimeUnit.SECONDS);
         });
+    }
+
+    @Test
+    void acquireAndDrainRaceLeavesRouteUnavailableAfterDrainWins()
+            throws Exception {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteTopology<Integer> topology = newTopology();
+        final SegmentId segmentId = SegmentId.of(0);
+        final long version = keyToSegmentMap.snapshot().version();
+        final CountDownLatch ready = new CountDownLatch(2);
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final Future<RouteTopology.RouteLeaseResult> acquireFuture = executor
+                .submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return topology.tryAcquire(segmentId, version);
+                });
+        final Future<RouteTopology.RouteDrain> drainFuture = executor
+                .submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return topology.tryBeginDrain(segmentId).orElseThrow();
+                });
+
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        start.countDown();
+        final RouteTopology.RouteLeaseResult acquire = acquireFuture.get(5,
+                TimeUnit.SECONDS);
+        final RouteTopology.RouteDrain drain = drainFuture.get(5,
+                TimeUnit.SECONDS);
+
+        assertTrue(topology.tryAcquire(segmentId, version)
+                .isRouteUnavailable());
+        if (acquire.isAcquired()) {
+            acquire.lease().close();
+        } else {
+            assertTrue(acquire.isRouteUnavailable());
+        }
+        assertTimeoutPreemptively(Duration.ofSeconds(5), drain::awaitDrained);
+        drain.abort();
     }
 
     @Test
@@ -112,6 +159,97 @@ class RouteTopologyTest {
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
             waitFuture.get(5, TimeUnit.SECONDS);
         });
+    }
+
+    @Test
+    void routeDrainDoesNotBlockAnotherRoute() {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteTopology<Integer> topology = newTopology();
+        applySplitPlan();
+        topology.reconcile(keyToSegmentMap.snapshot());
+        final long version = keyToSegmentMap.snapshot().version();
+        final RouteTopology.RouteLease lower = topology
+                .tryAcquire(SegmentId.of(1), version).lease();
+        final RouteTopology.RouteDrain drain = topology
+                .tryBeginDrain(SegmentId.of(1)).orElseThrow();
+
+        try (RouteTopology.RouteLease upper = topology
+                .tryAcquire(SegmentId.of(2), version).lease()) {
+            assertEquals(SegmentId.of(2), upper.segmentId());
+            assertTrue(topology.tryAcquire(SegmentId.of(1), version)
+                    .isRouteUnavailable());
+        } finally {
+            lower.close();
+        }
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), drain::awaitDrained);
+        drain.abort();
+    }
+
+    @Test
+    void reconcileRetainsRetiredLeaseForGlobalDrain() throws Exception {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteTopology<Integer> topology = newTopology();
+        final RouteTopology.RouteLease parent = topology
+                .tryAcquire(SegmentId.of(0), keyToSegmentMap.snapshot()
+                        .version())
+                .lease();
+        applySplitPlan();
+        topology.reconcile(keyToSegmentMap.snapshot());
+        final CountDownLatch waiting = new CountDownLatch(1);
+
+        final Future<?> waitFuture = executor.submit(() -> {
+            waiting.countDown();
+            topology.drain();
+        });
+
+        assertTrue(waiting.await(5, TimeUnit.SECONDS));
+        assertFalse(waitFuture.isDone());
+        parent.close();
+        assertTimeoutPreemptively(Duration.ofSeconds(5),
+                () -> waitFuture.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void abortDrainAllowsAnotherDrainCycle() {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteTopology<Integer> topology = newTopology();
+        final SegmentId segmentId = SegmentId.of(0);
+
+        topology.tryBeginDrain(segmentId).orElseThrow().abort();
+
+        try (RouteTopology.RouteLease lease = topology
+                .tryAcquire(segmentId, keyToSegmentMap.snapshot().version())
+                .lease()) {
+            assertEquals(segmentId, lease.segmentId());
+        }
+        final RouteTopology.RouteDrain secondDrain = topology
+                .tryBeginDrain(segmentId).orElseThrow();
+        secondDrain.awaitDrained();
+        secondDrain.abort();
+        try (RouteTopology.RouteLease lease = topology.tryAcquire(segmentId,
+                keyToSegmentMap.snapshot().version()).lease()) {
+            assertEquals(segmentId, lease.segmentId());
+        }
+    }
+
+    @Test
+    void closingLeaseConcurrentlyIsIdempotent() throws Exception {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteTopology<Integer> topology = newTopology();
+        final long version = keyToSegmentMap.snapshot().version();
+        final RouteTopology.RouteLease lease = topology
+                .tryAcquire(SegmentId.of(0), version).lease();
+
+        final Future<?> firstClose = executor.submit(lease::close);
+        final Future<?> secondClose = executor.submit(lease::close);
+
+        firstClose.get(5, TimeUnit.SECONDS);
+        secondClose.get(5, TimeUnit.SECONDS);
+        try (RouteTopology.RouteLease nextLease = topology
+                .tryAcquire(SegmentId.of(0), version).lease()) {
+            assertEquals(SegmentId.of(0), nextLease.segmentId());
+        }
     }
 
     @Test
@@ -165,6 +303,45 @@ class RouteTopologyTest {
         assertEquals(newerSnapshot.version(), topology.version());
         assertTrue(topology.tryAcquire(SegmentId.of(0),
                 olderSnapshot.version()).isStaleTopology());
+        assertTrue(topology.tryAcquire(SegmentId.of(0),
+                newerSnapshot.version()).isRouteUnavailable());
+        try (RouteTopology.RouteLease lease = topology
+                .tryAcquire(SegmentId.of(1), newerSnapshot.version())
+                .lease()) {
+            assertEquals(SegmentId.of(1), lease.segmentId());
+        }
+    }
+
+    @Test
+    void concurrentReconcileKeepsNewestTopology() throws Exception {
+        keyToSegmentMap.extendMaxKeyIfNeeded(100);
+        final RouteMapSnapshot<Integer> olderSnapshot = keyToSegmentMap.snapshot();
+        final RouteTopology<Integer> topology = RouteTopology.create(
+                olderSnapshot, 1, 1000);
+        applySplitPlan();
+        final RouteMapSnapshot<Integer> newerSnapshot = keyToSegmentMap.snapshot();
+        final CountDownLatch ready = new CountDownLatch(2);
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final Future<?> olderReconcile = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            topology.reconcile(olderSnapshot);
+            return null;
+        });
+        final Future<?> newerReconcile = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            topology.reconcile(newerSnapshot);
+            return null;
+        });
+
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        start.countDown();
+        olderReconcile.get(5, TimeUnit.SECONDS);
+        newerReconcile.get(5, TimeUnit.SECONDS);
+
+        assertEquals(newerSnapshot.version(), topology.version());
         assertTrue(topology.tryAcquire(SegmentId.of(0),
                 newerSnapshot.version()).isRouteUnavailable());
         try (RouteTopology.RouteLease lease = topology


### PR DESCRIPTION
## Summary

- replace the index-wide steady-state route lease monitor with per-route concurrency state
- publish immutable versioned topology views while keeping reconciliation serialized
- bind lease and drain handles directly to their exact route entry
- retain outstanding retired entries so global drain continues to observe their leases
- add a focused six-case JMH route-leasing profile and expanded concurrency coverage

## Why

Every point read and write previously synchronized twice on the same topology-wide monitor: once during acquisition and once during release. This serialized operations for unrelated segments and dominated blocked stack samples under load.

A packed `AtomicLong` implementation was measured but rejected because it regressed the 40-thread single-hot-route benchmark by approximately 74%. The final per-route monitor design is simpler and performed substantially better for both hot and distributed routes.

## Impact

Public routing APIs and `MappedSegmentLeaseService` behavior remain unchanged. Normal acquisition and release no longer take the topology reconciliation monitor, and release no longer performs a second route-map lookup.

Paired local JMH results on the same host and JVM:

| Case | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| 1 route, 1 thread | 27.92M ops/s | 132.09M ops/s | +373% |
| 1 route, 40 threads | 13.00M ops/s | 34.73M ops/s | +167% |
| 64 routes, 1 thread | 23.51M ops/s | 140.95M ops/s | +500% |
| 64 routes, 40 threads | 11.18M ops/s | 46.38M ops/s | +315% |

Normalized allocation remained approximately 16 B/op. Short 40-thread end-to-end hot-write and live-read confirmations showed no regression.

## Validation

- focused routing tests: 50 tests passed
- benchmark profile contract tests passed with `-DskipTests=false`
- focused JMH smoke execution passed
- paired baseline/candidate route-leasing profile completed
- stack sampling no longer attributed blocked samples to the topology-wide lease monitor
- `mvn clean verify` passed
- `git diff --check` passed
