### PR TITLE
Optimize segment point-operation synchronization

### DIFF
--- a/benchmarks/results/segment-registry-ready-fast-path-after.json
+++ b/benchmarks/results/segment-registry-ready-fast-path-after.json
@@ -1,0 +1,52 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "mode" : "thrpt",
+        "threads" : 4,
+        "forks" : 3,
+        "jvm" : "/opt/homebrew/Cellar/openjdk@25/25.0.3/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.3",
+        "warmupIterations" : 3,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "chunkStoreCachePageLimit" : "0",
+            "keyCount" : "12000",
+            "maxKeysInChunk" : "256",
+            "readPathMode" : "live",
+            "snappy" : "true",
+            "valueLength" : "64"
+        },
+        "primaryMetric" : {
+            "score" : 3410560.6503526773,
+            "scoreError" : 792803.4715538438,
+            "scoreConfidence" : [2617757.1787988334, 4203364.121906521],
+            "scorePercentiles" : {
+                "0.0" : 1970310.8002714224,
+                "50.0" : 3559831.7972033666,
+                "90.0" : 4281892.515544642,
+                "95.0" : 4423283.23772421,
+                "99.0" : 4423283.23772421,
+                "99.9" : 4423283.23772421,
+                "99.99" : 4423283.23772421,
+                "99.999" : 4423283.23772421,
+                "99.9999" : 4423283.23772421,
+                "100.0" : 4423283.23772421
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [2956154.5019409154, 3897029.564229072, 3963958.2415447775, 3775766.6975606508, 3923010.933346802],
+                [3957545.8281819294, 4423283.23772421, 4187632.0340915965, 3166712.679702875, 2728680.86570193],
+                [3401171.7537934687, 2004865.35331788, 1970310.8002714224, 3559831.7972033666, 3242455.4666792573]
+            ]
+        },
+        "secondaryMetrics" : {}
+    }
+]

--- a/benchmarks/results/segment-registry-ready-fast-path-before.json
+++ b/benchmarks/results/segment-registry-ready-fast-path-before.json
@@ -1,0 +1,52 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "mode" : "thrpt",
+        "threads" : 4,
+        "forks" : 3,
+        "jvm" : "/opt/homebrew/Cellar/openjdk@25/25.0.3/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.3",
+        "warmupIterations" : 3,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "chunkStoreCachePageLimit" : "0",
+            "keyCount" : "12000",
+            "maxKeysInChunk" : "256",
+            "readPathMode" : "live",
+            "snappy" : "true",
+            "valueLength" : "64"
+        },
+        "primaryMetric" : {
+            "score" : 2625001.005673966,
+            "scoreError" : 534574.7887757173,
+            "scoreConfidence" : [2090426.2168982485, 3159575.7944496833],
+            "scorePercentiles" : {
+                "0.0" : 1521488.2072862664,
+                "50.0" : 2861384.2073329054,
+                "90.0" : 3106902.0619898597,
+                "95.0" : 3260879.7002017843,
+                "99.0" : 3260879.7002017843,
+                "99.9" : 3260879.7002017843,
+                "99.99" : 3260879.7002017843,
+                "99.999" : 3260879.7002017843,
+                "99.9999" : 3260879.7002017843,
+                "100.0" : 3260879.7002017843
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [2993513.7206109706, 2866783.046569527, 2837144.677838758, 2990448.801362156, 3004250.30318191],
+                [3260879.7002017843, 2919539.0964195407, 2893728.3216833128, 2776271.5322891744, 2861384.2073329054],
+                [2340115.3138961177, 1998810.2365197125, 1521488.2072862664, 2085318.6507311016, 2025339.26918625]
+            ]
+        },
+        "secondaryMetrics" : {}
+    }
+]

--- a/benchmarks/results/segment-registry-ready-fast-path-comparison.md
+++ b/benchmarks/results/segment-registry-ready-fast-path-comparison.md
@@ -1,0 +1,54 @@
+# Segment Registry READY Fast-Path Comparison
+
+Comparison date: 2026-07-21
+
+Environment:
+
+- JMH 1.37
+- OpenJDK 25.0.3
+- Four benchmark threads
+- Live read path with the chunk-store page cache disabled
+
+## Throughput command
+
+```sh
+java -jar benchmarks/target/benchmarks-1.0.1-SNAPSHOT.jar \
+  'SegmentIndexGetBenchmark.getHitSync' \
+  -t 4 -wi 3 -i 5 -f 3 -r 1s -w 1s \
+  -p snappy=true -p ioThreads=1 \
+  -p readPathMode=live -p chunkStoreCachePageLimit=0 \
+  -rf json -rff <output>.json
+```
+
+## Results
+
+| Measurement | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Mean throughput | 2,625,001 ops/s | 3,410,561 ops/s | +29.9% |
+| Sample median | 2,861,384 ops/s | 3,559,832 ops/s | +24.4% |
+| JMH error (99.9%) | 534,575 ops/s | 792,803 ops/s | — |
+
+The throughput signal is positive, but the 99.9% confidence intervals overlap
+because the short local runs were noisy. The result should therefore be treated
+as directional rather than a precise expected gain.
+
+Raw JMH output:
+
+- `segment-registry-ready-fast-path-before.json`
+- `segment-registry-ready-fast-path-after.json`
+
+## Stack-profile comparison
+
+Both profiles used two one-second warmups, four one-second measurements, one
+fork, and a five-millisecond sampling period.
+
+| Thread-state sample | Before | After |
+| --- | ---: | ---: |
+| Raw `WAITING` samples | 27.8% | 3.6% |
+| Initial registry-load entry lock | 50.8% of `WAITING` | 0% |
+| Blocking-wrapper second-load entry lock | 36.5% of `WAITING` | 0% |
+| Raw `BLOCKED` samples | 1.0% | 10.6% |
+
+The two targeted `SegmentRegistryEntry.waitWhileLoading()` contention paths
+were removed. The post-change profile instead identifies
+`SessionOperationGate` monitor entry/exit as the next synchronization bottleneck.

--- a/benchmarks/results/session-operation-gate-after.json
+++ b/benchmarks/results/session-operation-gate-after.json
@@ -1,0 +1,75 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "mode" : "thrpt",
+        "threads" : 4,
+        "forks" : 3,
+        "jvm" : "/opt/homebrew/Cellar/openjdk@25/25.0.3/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.3",
+        "warmupIterations" : 3,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "chunkStoreCachePageLimit" : "0",
+            "keyCount" : "12000",
+            "maxKeysInChunk" : "256",
+            "readPathMode" : "live",
+            "snappy" : "true",
+            "valueLength" : "64"
+        },
+        "primaryMetric" : {
+            "score" : 3071857.2500895136,
+            "scoreError" : 501543.48167185474,
+            "scoreConfidence" : [
+                2570313.7684176587,
+                3573400.7317613685
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2600507.575496899,
+                "50.0" : 2831501.0855914075,
+                "90.0" : 3779203.3282955424,
+                "95.0" : 3930097.695690786,
+                "99.0" : 3930097.695690786,
+                "99.9" : 3930097.695690786,
+                "99.99" : 3930097.695690786,
+                "99.999" : 3930097.695690786,
+                "99.9999" : 3930097.695690786,
+                "100.0" : 3930097.695690786
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2915276.877946824,
+                    2831501.0855914075,
+                    2600507.575496899,
+                    2702034.404732333,
+                    2699207.102839545
+                ],
+                [
+                    3930097.695690786,
+                    3678607.08336538,
+                    3590088.2871843586,
+                    2714776.5852788854,
+                    2733466.0765597057
+                ],
+                [
+                    3582889.382833146,
+                    2674344.1972489962,
+                    2643200.6695517786,
+                    3191661.164016401,
+                    3590200.5630062525
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/benchmarks/results/session-operation-gate-before.json
+++ b/benchmarks/results/session-operation-gate-before.json
@@ -1,0 +1,75 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "mode" : "thrpt",
+        "threads" : 4,
+        "forks" : 3,
+        "jvm" : "/opt/homebrew/Cellar/openjdk@25/25.0.3/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.3",
+        "warmupIterations" : 3,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "chunkStoreCachePageLimit" : "0",
+            "keyCount" : "12000",
+            "maxKeysInChunk" : "256",
+            "readPathMode" : "live",
+            "snappy" : "true",
+            "valueLength" : "64"
+        },
+        "primaryMetric" : {
+            "score" : 3176390.7041667164,
+            "scoreError" : 611418.3198899975,
+            "scoreConfidence" : [
+                2564972.384276719,
+                3787809.024056714
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2100805.2039401373,
+                "50.0" : 3277956.3686266774,
+                "90.0" : 3912505.9170454843,
+                "95.0" : 4285919.181380273,
+                "99.0" : 4285919.181380273,
+                "99.9" : 4285919.181380273,
+                "99.99" : 4285919.181380273,
+                "99.999" : 4285919.181380273,
+                "99.9999" : 4285919.181380273,
+                "100.0" : 4285919.181380273
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3185200.8109359406,
+                    3089495.484617835,
+                    2508781.864663804,
+                    3524268.403816066,
+                    3299672.413777409
+                ],
+                [
+                    3663563.740822292,
+                    4285919.181380273,
+                    3041050.8539051106,
+                    2687227.3345642285,
+                    3463908.9975445773
+                ],
+                [
+                    2354928.1241375525,
+                    2100805.2039401373,
+                    3277956.3686266774,
+                    3508003.5541093345,
+                    3655078.2256595115
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/benchmarks/results/session-operation-gate-comparison.md
+++ b/benchmarks/results/session-operation-gate-comparison.md
@@ -1,0 +1,47 @@
+# SessionOperationGate comparison
+
+## Scope
+
+- Benchmark: `SegmentIndexGetBenchmark.getHitSync`
+- Read path: `live`
+- Chunk-store cache pages: `0`
+- Threads: `4`
+- Warmup/measurement/forks: `3 x 1 s` / `5 x 1 s` / `3`
+- Runtime: OpenJDK 25.0.3
+- Both runs include the same uncommitted SegmentRegistry optimization baseline.
+
+## Targeted throughput
+
+| Version | Score | 99.9% confidence interval |
+| --- | ---: | ---: |
+| Monitor counter | 3,176,391 ops/s | 2,564,972–3,787,809 ops/s |
+| Atomic counter | 3,071,857 ops/s | 2,570,314–3,573,401 ops/s |
+
+The candidate score is 3.3% lower, but the confidence intervals overlap
+heavily. This measurement does not establish either a regression or an
+improvement.
+
+## Stack sampling
+
+Before the change, 5.1% of samples were `BLOCKED`. Gate increment and decrement
+accounted for 3.3% of all samples and 64.1% of blocked samples. In addition,
+`Object.notifyAll()` from gate completion accounted for 4.5% of all samples in
+the `RUNNABLE` state.
+
+After the change, no `SessionOperationGate` increment, decrement, monitor, or
+`Object.notifyAll()` frame appeared in blocked or runnable hot-path samples.
+The remaining blocked samples were in route-lease acquisition and release.
+
+## Canonical smoke profile
+
+The `segment-index-pr-smoke` profile was run before and after with identical
+settings. Its one-fork, three-iteration workloads produced large changes in
+both directions, with confidence errors commonly larger than the reported
+scores. It is too noisy to establish a regression or improvement for this
+change.
+
+## Conclusion
+
+The intended synchronization contention was removed. The collected throughput
+measurements are inconclusive and do not demonstrate a regression outside
+measurement noise.

--- a/docs/refactor-backlog.md
+++ b/docs/refactor-backlog.md
@@ -27,6 +27,14 @@
 
 ## Done (Archive)
 
+[x] 99. Replace `SessionOperationGate` per-operation monitor contention with atomic in-flight tracking and bounded close-side drain polling (Risk: MEDIUM)
+    - Focused session concurrency tests, benchmark module tests, and the full
+      Maven verification pipeline pass.
+    - Targeted JMH stack sampling removed all `SessionOperationGate` blocked
+      frames and the per-operation `Object.notifyAll()` frame.
+    - The targeted throughput result moved by -3.3%, with heavily overlapping
+      confidence intervals; the canonical smoke profile was also too noisy to
+      establish a throughput regression or improvement.
 [x] 97. Clarify `core.session` responsibility boundaries by moving topology runtime composition to route/topology internals, giving core storage its own open spec and observer types, and preserving lifecycle behavior.
 [x] 98. Simplify SegmentIndex initialization after the broad assembly refactor by keeping explicit opening points for bootstrap, session startup, and runtime resources while removing pattern-only assembler/request/components layers.
 [x] 89. Rework split routing around a runtime `RouteTopology` so route handoff, draining, and split publish are owned by topology code while `SegmentRegistry` remains responsible only for physical segment instances and `SegmentRouteMap` remains responsible only for persisted routing.

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SessionOperationGate.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SessionOperationGate.java
@@ -1,18 +1,28 @@
 package org.hestiastore.index.segmentindex.core.session;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
 /**
  * Tracks foreground segment-index operations and waits for them during close.
  *
  * <p>
- * The gate tracks synchronous operations while they execute and exposes a wait
- * point used by close coordination. Lifecycle validation remains the caller's
- * responsibility and should be performed inside the tracked operation.
+ * Foreground admission uses an atomic in-flight counter so ordinary operations
+ * do not contend on the close-side drain mechanism. Lifecycle validation
+ * remains the caller's responsibility and should be performed inside the
+ * tracked operation. Callers must enter the closing state before waiting for
+ * the counter to drain.
  * </p>
  */
 public final class SessionOperationGate {
 
-    private final Object operationMonitor = new Object();
-    private int syncOperationsInFlight;
+    private static final long INITIAL_WAIT_NANOS = TimeUnit.MICROSECONDS
+            .toNanos(50);
+    private static final long MAX_WAIT_NANOS = TimeUnit.MILLISECONDS
+            .toNanos(1);
+
+    private final AtomicInteger syncOperationsInFlight = new AtomicInteger();
     private final ThreadLocal<Integer> syncOperationDepth = ThreadLocal
             .withInitial(() -> 0);
 
@@ -58,24 +68,20 @@ public final class SessionOperationGate {
     }
 
     /**
-     * Waits until currently tracked foreground operations finish.
+     * Waits with bounded backoff until tracked foreground operations finish.
+     * The caller must stop admitting operational work before invoking this
+     * method.
      */
     void awaitOperationDrain() {
         if (isInSyncOperation()) {
             throw new IllegalStateException(
                     "close() must not be called from an index operation.");
         }
-        synchronized (operationMonitor) {
-            while (syncOperationsInFlight > 0) {
-                try {
-                    operationMonitor.wait();
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException(
-                            "Interrupted while waiting for tracked operations to finish.",
-                            e);
-                }
-            }
+        long waitNanos = INITIAL_WAIT_NANOS;
+        while (syncOperationsInFlight.get() > 0) {
+            LockSupport.parkNanos(waitNanos);
+            throwIfInterrupted();
+            waitNanos = Math.min(MAX_WAIT_NANOS, waitNanos << 1);
         }
     }
 
@@ -84,15 +90,19 @@ public final class SessionOperationGate {
     }
 
     private void incrementSyncOperations() {
-        synchronized (operationMonitor) {
-            syncOperationsInFlight++;
-        }
+        syncOperationsInFlight.incrementAndGet();
     }
 
     private void decrementSyncOperations() {
-        synchronized (operationMonitor) {
-            syncOperationsInFlight--;
-            operationMonitor.notifyAll();
+        syncOperationsInFlight.decrementAndGet();
+    }
+
+    private static void throwIfInterrupted() {
+        if (Thread.interrupted()) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted while waiting for tracked operations to finish.",
+                    new InterruptedException());
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -1,7 +1,7 @@
 package org.hestiastore.index.segmentregistry;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.EntryIterator;
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Registry-backed implementation of retry-aware blocking segment operations.
+ * Uses the segment supplied during registry lookup directly and reloads only
+ * after that segment has closed.
  *
  * @param <K> key type
  * @param <V> value type
@@ -31,18 +33,34 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
             .getLogger(DefaultBlockingSegment.class);
 
     private final SegmentId segmentId;
-    private final Supplier<Segment<K, V>> segmentLoader;
+    private final AtomicReference<Segment<K, V>> segment;
+    private final BlockingSegmentRegistryAdapter<K, V> segmentRegistry;
     private final BusyRetryPolicy retryPolicy;
     private final boolean automaticMaintenanceEnabled;
     private final Runtime runtime;
 
+    /**
+     * Creates a blocking handle for an already loaded segment.
+     *
+     * @param segmentId requested segment id
+     * @param segment initial loaded segment
+     * @param segmentRegistry registry adapter used only to recover a closed
+     *        segment
+     * @param retryPolicy retry policy for transient operation outcomes
+     * @param automaticMaintenanceEnabled whether full write caches are
+     *        retryable
+     */
     DefaultBlockingSegment(final SegmentId segmentId,
-            final Supplier<Segment<K, V>> segmentLoader,
+            final Segment<K, V> segment,
+            final BlockingSegmentRegistryAdapter<K, V> segmentRegistry,
             final BusyRetryPolicy retryPolicy,
             final boolean automaticMaintenanceEnabled) {
+        final Segment<K, V> loadedSegment = Vldtn.requireNonNull(segment,
+                "segment");
         this.segmentId = Vldtn.requireNonNull(segmentId, "segmentId");
-        this.segmentLoader = Vldtn.requireNonNull(segmentLoader,
-                "segmentLoader");
+        this.segment = new AtomicReference<>(loadedSegment);
+        this.segmentRegistry = Vldtn.requireNonNull(segmentRegistry,
+                "segmentRegistry");
         this.retryPolicy = Vldtn.requireNonNull(retryPolicy, "retryPolicy");
         this.automaticMaintenanceEnabled = automaticMaintenanceEnabled;
         this.runtime = new RuntimeView();
@@ -55,7 +73,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public Segment<K, V> getSegment() {
-        return segmentLoader.get();
+        return currentSegment();
     }
 
     @Override
@@ -65,7 +83,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<V> tryGet(final K key) {
-        return segmentLoader.get().get(key);
+        return currentSegment().get(key);
     }
 
     @Override
@@ -75,7 +93,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryPut(final K key, final V value) {
-        return segmentLoader.get().put(key, value);
+        return currentSegment().put(key, value);
     }
 
     @Override
@@ -92,7 +110,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
     public OperationResult<EntryIterator<K, V>> tryOpenIterator(
             final SegmentIteratorIsolation isolation) {
         Vldtn.requireNonNull(isolation, "isolation");
-        return segmentLoader.get().openIterator(isolation);
+        return currentSegment().openIterator(isolation);
     }
 
     @Override
@@ -110,7 +128,7 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryFlush() {
-        return segmentLoader.get().flush();
+        return currentSegment().flush();
     }
 
     @Override
@@ -120,36 +138,76 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public OperationResult<Void> tryCompact() {
-        return segmentLoader.get().compact();
+        return currentSegment().compact();
     }
 
     @Override
     public K checkAndRepairConsistency() {
-        return segmentLoader.get().checkAndRepairConsistency();
+        return currentSegment().checkAndRepairConsistency();
     }
 
     @Override
     public void invalidateIterators() {
-        segmentLoader.get().invalidateIterators();
+        currentSegment().invalidateIterators();
+    }
+
+    /**
+     * Replaces a closed segment generation with the loaded generation returned
+     * by the registry. A live generation is never overwritten by a stale
+     * concurrent lookup.
+     *
+     * @param loadedSegment loaded segment generation
+     */
+    void updateSegment(final Segment<K, V> loadedSegment) {
+        final Segment<K, V> replacement = Vldtn.requireNonNull(loadedSegment,
+                "loadedSegment");
+        Segment<K, V> current = segment.get();
+        while (current != replacement
+                && current.getState() == SegmentState.CLOSED) {
+            if (segment.compareAndSet(current, replacement)) {
+                return;
+            }
+            current = segment.get();
+        }
     }
 
     private <T> T runBlocking(final String operation,
             final Function<Segment<K, V>, OperationResult<T>> action) {
         final long startNanos = retryPolicy.startNanos();
         while (true) {
-            final Segment<K, V> segment = segmentLoader.get();
-            final OperationResult<T> result = action.apply(segment);
+            final Segment<K, V> current = segment.get();
+            final OperationResult<T> result = action.apply(current);
             if (result.getStatus() == OperationStatus.OK) {
                 return result.getValue();
             }
             if (isRetryable(result.getStatus())) {
                 logRetryableWriteCacheFull(operation, result.getStatus(),
-                        segment);
+                        current);
                 retryPolicy.backoffOrThrow(startNanos, operation, segmentId);
+                reloadClosedSegment(result.getStatus(), current);
                 continue;
             }
             throw operationFailure(operation, result.getStatus());
         }
+    }
+
+    private Segment<K, V> currentSegment() {
+        final Segment<K, V> current = segment.get();
+        if (current.getState() != SegmentState.CLOSED) {
+            return current;
+        }
+        reloadClosedSegment(OperationStatus.CLOSED, current);
+        return segment.get();
+    }
+
+    private void reloadClosedSegment(final OperationStatus status,
+            final Segment<K, V> closedSegment) {
+        if (status != OperationStatus.CLOSED
+                || segment.get() != closedSegment) {
+            return;
+        }
+        final Segment<K, V> loaded = segmentRegistry.loadSegment(segmentId);
+        segment.compareAndSet(closedSegment, loaded);
     }
 
     private boolean isRetryable(final OperationStatus status) {
@@ -186,47 +244,47 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
         @Override
         public SegmentState getState() {
-            return segmentLoader.get().getState();
+            return currentSegment().getState();
         }
 
         @Override
         public SegmentStats getStats() {
-            return segmentLoader.get().getStats();
+            return currentSegment().getStats();
         }
 
         @Override
         public SegmentRuntimeSnapshot getRuntimeSnapshot() {
-            return segmentLoader.get().getRuntimeSnapshot();
+            return currentSegment().getRuntimeSnapshot();
         }
 
         @Override
         public long getNumberOfKeys() {
-            return segmentLoader.get().getNumberOfKeys();
+            return currentSegment().getNumberOfKeys();
         }
 
         @Override
         public int getNumberOfKeysInWriteCache() {
-            return segmentLoader.get().getNumberOfKeysInWriteCache();
+            return currentSegment().getNumberOfKeysInWriteCache();
         }
 
         @Override
         public long getNumberOfKeysInCache() {
-            return segmentLoader.get().getNumberOfKeysInCache();
+            return currentSegment().getNumberOfKeysInCache();
         }
 
         @Override
         public long getNumberOfKeysInSegmentCache() {
-            return segmentLoader.get().getNumberOfKeysInSegmentCache();
+            return currentSegment().getNumberOfKeysInSegmentCache();
         }
 
         @Override
         public int getNumberOfDeltaCacheFiles() {
-            return segmentLoader.get().getNumberOfDeltaCacheFiles();
+            return currentSegment().getNumberOfDeltaCacheFiles();
         }
 
         @Override
         public void updateRuntimeLimits(final SegmentRuntimeLimits limits) {
-            segmentLoader.get().applyRuntimeLimits(
+            currentSegment().applyRuntimeLimits(
                     Vldtn.requireNonNull(limits, "limits"));
         }
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntry.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntry.java
@@ -8,6 +8,9 @@ import org.hestiastore.index.segment.Segment;
 
 /**
  * Coordinates one registry cache entry through load, ready, and unload states.
+ * READY reads are lock-free; the volatile state transition safely publishes
+ * the value written before it. Lifecycle transitions remain serialized by the
+ * entry lock.
  *
  * @param <K> segment key type
  * @param <V> segment value type
@@ -17,7 +20,7 @@ final class SegmentRegistryEntry<K, V> {
     private final ReentrantLock lock = new ReentrantLock();
     private final Condition ready = lock.newCondition();
     private volatile long accessCx;
-    private EntryState state = EntryState.LOADING;
+    private volatile EntryState state = EntryState.LOADING;
     private Segment<K, V> value;
     private IndexException failure;
 
@@ -53,6 +56,11 @@ final class SegmentRegistryEntry<K, V> {
      * @return loaded value when ready, otherwise null when unavailable
      */
     Segment<K, V> waitWhileLoading(final long currentAccessCx) {
+        final Segment<K, V> readyValue = getReadyValue();
+        if (readyValue != null) {
+            accessCx = currentAccessCx;
+            return readyValue;
+        }
         lock.lock();
         try {
             while (state == EntryState.LOADING) {
@@ -235,20 +243,17 @@ final class SegmentRegistryEntry<K, V> {
     }
 
     /**
-     * Returns the cached value only when this entry is ready.
+     * Returns the cached value without locking only when this entry is ready.
+     * Reading the volatile READY state makes the previously stored value
+     * visible to the caller.
      *
      * @return ready value, or null when loading, unloading, or failed
      */
     Segment<K, V> getReadyValue() {
-        lock.lock();
-        try {
-            if (state != EntryState.READY || value == null || failure != null) {
-                return null;
-            }
-            return value;
-        } finally {
-            lock.unlock();
+        if (state != EntryState.READY) {
+            return null;
         }
+        return value;
     }
 
     private enum EntryState {

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/SegmentRegistryImpl.java
@@ -48,7 +48,7 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
     private final BlockingSegmentRegistryAdapter<K, V> blockingFacade;
     private final SegmentRegistry.Materialization<K, V> materialization;
     private final SegmentRegistry.Runtime<K, V> runtime;
-    private final ConcurrentMap<SegmentId, BlockingSegment<K, V>> blockingSegments;
+    private final ConcurrentMap<SegmentId, DefaultBlockingSegment<K, V>> blockingSegments;
     private final boolean automaticMaintenanceEnabled;
 
     /**
@@ -100,8 +100,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
     public BlockingSegment<K, V> loadSegment(final SegmentId segmentId) {
         final SegmentId validatedSegmentId = Vldtn.requireNonNull(segmentId,
                 SEGMENT_ID_PARAMETER);
-        blockingFacade.loadSegment(validatedSegmentId);
-        return toBlockingSegment(validatedSegmentId);
+        return toBlockingSegment(validatedSegmentId,
+                blockingFacade.loadSegment(validatedSegmentId));
     }
 
     @Override
@@ -110,7 +110,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         final SegmentId validatedSegmentId = Vldtn.requireNonNull(segmentId,
                 SEGMENT_ID_PARAMETER);
         return blockingFacade.tryGetSegment(validatedSegmentId)
-                .map(ignored -> toBlockingSegment(validatedSegmentId));
+                .map(segment -> toBlockingSegment(validatedSegmentId,
+                        segment));
     }
 
     @Override
@@ -122,13 +123,14 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
             return Optional.empty();
         }
         return cache.getIfReady(validatedSegmentId)
-                .map(ignored -> toBlockingSegment(validatedSegmentId));
+                .map(segment -> toBlockingSegment(validatedSegmentId,
+                        segment));
     }
 
     @Override
     public BlockingSegment<K, V> createSegment() {
         final Segment<K, V> created = blockingFacade.createSegment();
-        return toBlockingSegment(created.getId());
+        return toBlockingSegment(created.getId(), created);
     }
 
     @Override
@@ -321,7 +323,8 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
 
     private List<BlockingSegment<K, V>> loadedBlockingSegmentsSnapshot() {
         return loadedSegmentsSnapshot().stream()
-                .map(segment -> toBlockingSegment(segment.getId())).toList();
+                .map(segment -> toBlockingSegment(segment.getId(), segment))
+                .toList();
     }
 
     /** {@inheritDoc} */
@@ -336,11 +339,15 @@ final class SegmentRegistryImpl<K, V> extends SegmentRegistryStatusAccess<K, V>
         return runtime;
     }
 
-    private BlockingSegment<K, V> toBlockingSegment(final SegmentId segmentId) {
-        return blockingSegments.computeIfAbsent(segmentId,
-                id -> new DefaultBlockingSegment<>(id,
-                        () -> blockingFacade.loadSegment(id),
-                        blockingRetryPolicy, automaticMaintenanceEnabled));
+    private BlockingSegment<K, V> toBlockingSegment(final SegmentId segmentId,
+            final Segment<K, V> segment) {
+        final DefaultBlockingSegment<K, V> blockingSegment = blockingSegments
+                .computeIfAbsent(segmentId,
+                        id -> new DefaultBlockingSegment<>(id, segment,
+                                blockingFacade, blockingRetryPolicy,
+                                automaticMaintenanceEnabled));
+        blockingSegment.updateSegment(segment);
+        return blockingSegment;
     }
 
     private static OperationStatus resultForState(

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexAsyncMaintenanceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -377,6 +378,7 @@ class SegmentIndexAsyncMaintenanceTest {
             final Segment<K, V> segment) {
         final Object cache = readCache(registry);
         putReadyEntry(cache, segmentId, segment);
+        removeBlockingSegment(registry, segmentId);
     }
 
     @SuppressWarnings("unchecked")
@@ -400,6 +402,19 @@ class SegmentIndexAsyncMaintenanceTest {
         } catch (final ReflectiveOperationException ex) {
             throw new IllegalStateException(
                     "Unable to read registry cache for test", ex);
+        }
+    }
+
+    private static void removeBlockingSegment(final Object registry,
+            final SegmentId segmentId) {
+        try {
+            final Field field = registry.getClass()
+                    .getDeclaredField("blockingSegments");
+            field.setAccessible(true);
+            ((Map<?, ?>) field.get(registry)).remove(segmentId);
+        } catch (final ReflectiveOperationException ex) {
+            throw new IllegalStateException(
+                    "Unable to update blocking segment cache for test", ex);
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionRetryTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
@@ -200,6 +201,7 @@ class SegmentIndexSessionRetryTest {
             final Segment<K, V> segment) {
         final Object cache = readCache(registry);
         putReadyEntry(cache, segmentId, segment);
+        removeBlockingSegment(registry, segmentId);
     }
 
     @SuppressWarnings("unchecked")
@@ -223,6 +225,19 @@ class SegmentIndexSessionRetryTest {
         } catch (final ReflectiveOperationException ex) {
             throw new IllegalStateException(
                     "Unable to read registry cache for test", ex);
+        }
+    }
+
+    private static void removeBlockingSegment(final Object registry,
+            final SegmentId segmentId) {
+        try {
+            final Field field = registry.getClass()
+                    .getDeclaredField("blockingSegments");
+            field.setAccessible(true);
+            ((Map<?, ?>) field.get(registry)).remove(segmentId);
+        } catch (final ReflectiveOperationException ex) {
+            throw new IllegalStateException(
+                    "Unable to update blocking segment cache for test", ex);
         }
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SessionOperationGateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SessionOperationGateTest.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,6 +11,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,8 +33,8 @@ class SessionOperationGateTest {
                     () -> {
                         gate.beginOperation();
                         try {
-                        taskStarted.countDown();
-                        await(releaseTask);
+                            taskStarted.countDown();
+                            await(releaseTask);
                         } finally {
                             gate.endOperation();
                         }
@@ -53,6 +56,136 @@ class SessionOperationGateTest {
     }
 
     @Test
+    void awaitOperationDrain_waitsForAllTrackedSyncTasksToFinish()
+            throws Exception {
+        final SessionOperationGate gate = SessionOperationGate.create();
+        final CountDownLatch tasksStarted = new CountDownLatch(2);
+        final CountDownLatch releaseTasks = new CountDownLatch(1);
+        final ExecutorService trackedExecutor = Executors.newFixedThreadPool(2);
+        final ExecutorService waiterExecutor = Executors
+                .newSingleThreadExecutor();
+        try {
+            final Future<?> firstTask = submitTrackedTask(gate,
+                    trackedExecutor, tasksStarted, releaseTasks);
+            final Future<?> secondTask = submitTrackedTask(gate,
+                    trackedExecutor, tasksStarted, releaseTasks);
+            assertTrue(tasksStarted.await(1, TimeUnit.SECONDS));
+
+            final Future<?> awaitTask = waiterExecutor
+                    .submit(gate::awaitOperationDrain);
+            assertThrows(TimeoutException.class,
+                    () -> awaitTask.get(100, TimeUnit.MILLISECONDS));
+
+            releaseTasks.countDown();
+            firstTask.get(1, TimeUnit.SECONDS);
+            secondTask.get(1, TimeUnit.SECONDS);
+            awaitTask.get(1, TimeUnit.SECONDS);
+        } finally {
+            trackedExecutor.shutdownNow();
+            waiterExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void awaitOperationDrain_waitsForOutermostNestedOperation()
+            throws Exception {
+        final SessionOperationGate gate = SessionOperationGate.create();
+        final CountDownLatch nestedOperationStarted = new CountDownLatch(1);
+        final CountDownLatch releaseInnerOperation = new CountDownLatch(1);
+        final CountDownLatch innerOperationFinished = new CountDownLatch(1);
+        final CountDownLatch releaseOuterOperation = new CountDownLatch(1);
+        final ExecutorService trackedExecutor = Executors
+                .newSingleThreadExecutor();
+        final ExecutorService waiterExecutor = Executors
+                .newSingleThreadExecutor();
+        try {
+            final Future<?> trackedTask = trackedExecutor.submit(() -> {
+                gate.beginOperation();
+                try {
+                    gate.beginOperation();
+                    try {
+                        nestedOperationStarted.countDown();
+                        await(releaseInnerOperation);
+                    } finally {
+                        gate.endOperation();
+                    }
+                    innerOperationFinished.countDown();
+                    await(releaseOuterOperation);
+                } finally {
+                    gate.endOperation();
+                }
+            });
+            assertTrue(nestedOperationStarted.await(1, TimeUnit.SECONDS));
+
+            final Future<?> awaitTask = waiterExecutor
+                    .submit(gate::awaitOperationDrain);
+            releaseInnerOperation.countDown();
+            assertTrue(innerOperationFinished.await(1, TimeUnit.SECONDS));
+            assertThrows(TimeoutException.class,
+                    () -> awaitTask.get(100, TimeUnit.MILLISECONDS));
+
+            releaseOuterOperation.countDown();
+            trackedTask.get(1, TimeUnit.SECONDS);
+            awaitTask.get(1, TimeUnit.SECONDS);
+        } finally {
+            trackedExecutor.shutdownNow();
+            waiterExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void endOperation_throwsWhenNoTrackedOperationIsActive() {
+        final SessionOperationGate gate = SessionOperationGate.create();
+
+        final IllegalStateException thrown = assertThrows(
+                IllegalStateException.class, gate::endOperation);
+
+        assertEquals("No tracked index operation is active.",
+                thrown.getMessage());
+    }
+
+    @Test
+    void awaitOperationDrain_restoresInterruptAndThrows() throws Exception {
+        final SessionOperationGate gate = SessionOperationGate.create();
+        final CountDownLatch waiterStarted = new CountDownLatch(1);
+        final AtomicReference<Thread> waiterThread = new AtomicReference<>();
+        final AtomicBoolean interruptedAfterFailure = new AtomicBoolean();
+        final ExecutorService waiterExecutor = Executors
+                .newSingleThreadExecutor();
+        gate.beginOperation();
+        try {
+            final Future<IllegalStateException> awaitTask = waiterExecutor
+                    .submit(() -> {
+                        waiterThread.set(Thread.currentThread());
+                        waiterStarted.countDown();
+                        try {
+                            gate.awaitOperationDrain();
+                            return null;
+                        } catch (final IllegalStateException e) {
+                            interruptedAfterFailure
+                                    .set(Thread.currentThread().isInterrupted());
+                            return e;
+                        }
+                    });
+            assertTrue(waiterStarted.await(1, TimeUnit.SECONDS));
+
+            waiterThread.get().interrupt();
+            final IllegalStateException thrown = assertInstanceOf(
+                    IllegalStateException.class,
+                    awaitTask.get(1, TimeUnit.SECONDS));
+
+            assertEquals(
+                    "Interrupted while waiting for tracked operations to finish.",
+                    thrown.getMessage());
+            assertInstanceOf(InterruptedException.class, thrown.getCause());
+            assertTrue(interruptedAfterFailure.get());
+        } finally {
+            gate.endOperation();
+            waiterExecutor.shutdownNow();
+        }
+    }
+
+    @Test
     void awaitOperationDrain_throwsWhenCalledFromTrackedSyncOperation() {
         final SessionOperationGate gate = SessionOperationGate
                 .create();
@@ -62,7 +195,7 @@ class SessionOperationGateTest {
                 () -> {
                     gate.beginOperation();
                     try {
-                    gate.awaitOperationDrain();
+                        gate.awaitOperationDrain();
                     } finally {
                         gate.endOperation();
                     }
@@ -70,6 +203,22 @@ class SessionOperationGateTest {
 
         assertEquals("close() must not be called from an index operation.",
                 thrown.getMessage());
+    }
+
+    private static Future<?> submitTrackedTask(
+            final SessionOperationGate gate,
+            final ExecutorService trackedExecutor,
+            final CountDownLatch tasksStarted,
+            final CountDownLatch releaseTasks) {
+        return trackedExecutor.submit(() -> {
+            gate.beginOperation();
+            try {
+                tasksStarted.countDown();
+                await(releaseTasks);
+            } finally {
+                gate.endOperation();
+            }
+        });
     }
 
     private static void await(final CountDownLatch latch) {

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
@@ -1,20 +1,23 @@
 package org.hestiastore.index.segmentregistry;
 
-import org.hestiastore.index.BusyRetryPolicy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hestiastore.index.BusyRetryPolicy;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentRuntimeLimits;
+import org.hestiastore.index.segment.SegmentState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +30,7 @@ class DefaultBlockingSegmentTest {
     private static final SegmentId SEGMENT_ID = SegmentId.of(7);
 
     @Mock
-    private SegmentRegistry<Integer, String> segmentRegistry;
+    private BlockingSegmentRegistryAdapter<Integer, String> segmentRegistry;
 
     @Mock
     private Segment<Integer, String> segment;
@@ -44,26 +47,19 @@ class DefaultBlockingSegmentTest {
 
     @Test
     void getRetriesBusyStatusUntilSuccessful() {
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
         when(segment.get(11)).thenReturn(OperationResult.busy())
                 .thenReturn(OperationResult.ok("value"));
 
         assertEquals("value", handle.get(11));
-        verify(segmentRegistry, times(2)).loadSegment(SEGMENT_ID);
         verify(segment, times(2)).get(11);
+        verifyNoInteractions(segmentRegistry);
     }
 
     @Test
     void putRetriesClosedStatusUntilSegmentReloads() {
         final Segment<Integer, String> reloadedSegment = mockSegment();
-        final BlockingSegment<Integer, String> firstHandle = mockBlockingSegment();
-        final BlockingSegment<Integer, String> secondHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(firstHandle)
-                .thenReturn(secondHandle);
-        when(firstHandle.getSegment()).thenReturn(segment);
-        when(secondHandle.getSegment()).thenReturn(reloadedSegment);
+        when(segmentRegistry.loadSegment(SEGMENT_ID))
+                .thenReturn(reloadedSegment);
         when(segment.put(1, "one")).thenReturn(OperationResult.closed());
         when(reloadedSegment.put(1, "one")).thenReturn(OperationResult.ok());
 
@@ -71,29 +67,24 @@ class DefaultBlockingSegmentTest {
 
         verify(segment).put(1, "one");
         verify(reloadedSegment).put(1, "one");
+        verify(segmentRegistry).loadSegment(SEGMENT_ID);
     }
 
     @Test
     void putRetriesWriteCacheFullStatusWhenMaintenanceEnabled() {
         handle = newHandle(true);
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
         when(segment.put(1, "one"))
                 .thenReturn(OperationResult.writeCacheFull())
                 .thenReturn(OperationResult.ok());
 
         handle.put(1, "one");
 
-        verify(segmentRegistry, times(2)).loadSegment(SEGMENT_ID);
         verify(segment, times(2)).put(1, "one");
+        verifyNoInteractions(segmentRegistry);
     }
 
     @Test
     void putThrowsImmediatelyWhenWriteCacheFullStatusReturnedAndMaintenanceDisabled() {
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
         when(segment.put(1, "one")).thenReturn(OperationResult.writeCacheFull());
 
         final IndexException exception = assertThrows(IndexException.class,
@@ -102,16 +93,13 @@ class DefaultBlockingSegmentTest {
         assertEquals(
                 "Write cache is full for segment 'segment-00007' and automatic maintenance is disabled.",
                 exception.getMessage());
-        verify(segmentRegistry).loadSegment(SEGMENT_ID);
         verify(segment).put(1, "one");
+        verifyNoInteractions(segmentRegistry);
     }
 
     @Test
     void putTimesOutWhenWriteCacheFullStatusPersistsAndMaintenanceEnabled() {
         handle = newHandle(new BusyRetryPolicy(1, 5), true);
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
         when(segment.put(1, "one"))
                 .thenReturn(OperationResult.writeCacheFull());
 
@@ -121,27 +109,51 @@ class DefaultBlockingSegmentTest {
         assertTrue(exception.getMessage().contains("timed out"));
         assertFalse(exception.getMessage().contains(
                 "automatic maintenance is disabled"));
+        verifyNoInteractions(segmentRegistry);
     }
 
     @Test
     void compactThrowsOnErrorStatus() {
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
         when(segment.compact()).thenReturn(OperationResult.error());
 
         assertThrows(IndexException.class, () -> handle.compact());
+        verifyNoInteractions(segmentRegistry);
     }
 
     @Test
     void updateRuntimeLimitsDelegatesToLoadedSegment() {
-        final BlockingSegment<Integer, String> segmentHandle = mockBlockingSegment();
-        when(segmentRegistry.loadSegment(SEGMENT_ID)).thenReturn(segmentHandle);
-        when(segmentHandle.getSegment()).thenReturn(segment);
+        when(segment.getState()).thenReturn(SegmentState.READY);
 
         handle.getRuntime().updateRuntimeLimits(runtimeLimits);
 
         verify(segment).applyRuntimeLimits(runtimeLimits);
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void tryGetReloadsClosedSegmentBeforeOperation() {
+        final Segment<Integer, String> reloadedSegment = mockSegment();
+        when(segment.getState()).thenReturn(SegmentState.CLOSED);
+        when(segmentRegistry.loadSegment(SEGMENT_ID))
+                .thenReturn(reloadedSegment);
+        when(reloadedSegment.get(11)).thenReturn(OperationResult.ok("value"));
+
+        final OperationResult<String> result = handle.tryGet(11);
+
+        assertEquals("value", result.getValue());
+        verify(segmentRegistry).loadSegment(SEGMENT_ID);
+    }
+
+    @Test
+    void updateSegmentDoesNotReplaceLiveGeneration() {
+        final Segment<Integer, String> staleSegment = mockSegment();
+        when(segment.getState()).thenReturn(SegmentState.READY);
+
+        ((DefaultBlockingSegment<Integer, String>) handle)
+                .updateSegment(staleSegment);
+
+        assertSame(segment, handle.getSegment());
+        verifyNoInteractions(segmentRegistry);
     }
 
     private BlockingSegment<Integer, String> newHandle(
@@ -153,14 +165,9 @@ class DefaultBlockingSegmentTest {
     private BlockingSegment<Integer, String> newHandle(
             final BusyRetryPolicy retryPolicy,
             final boolean automaticMaintenanceEnabled) {
-        return new DefaultBlockingSegment<>(SEGMENT_ID,
-                () -> segmentRegistry.loadSegment(SEGMENT_ID).getSegment(),
+        return new DefaultBlockingSegment<>(SEGMENT_ID, segment,
+                segmentRegistry,
                 retryPolicy, automaticMaintenanceEnabled);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <K, V> BlockingSegment<K, V> mockBlockingSegment() {
-        return mock(BlockingSegment.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryEntryTest.java
@@ -1,8 +1,17 @@
 package org.hestiastore.index.segmentregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segment.Segment;
@@ -49,5 +58,37 @@ class SegmentRegistryEntryTest {
         final IndexException failure = new IndexException("boom");
         assertThrows(IndexException.class, () -> entry.fail(failure));
         assertThrows(IndexException.class, entry::finishUnload);
+    }
+
+    @Test
+    void readyValueDoesNotWaitForEntryLock() {
+        final SegmentRegistryEntry<Integer, String> entry = new SegmentRegistryEntry<>(
+                7L);
+        entry.finishLoad(segment);
+        final ReentrantLock lock = readLock(entry);
+        final ExecutorService caller = Executors.newSingleThreadExecutor();
+        lock.lock();
+        try {
+            final Future<Segment<Integer, String>> cacheHit = caller
+                    .submit(() -> entry.waitWhileLoading(8L));
+
+            assertSame(segment,
+                    assertDoesNotThrow(() -> cacheHit.get(250,
+                            TimeUnit.MILLISECONDS)));
+        } finally {
+            lock.unlock();
+            caller.shutdownNow();
+        }
+    }
+
+    private static ReentrantLock readLock(final SegmentRegistryEntry<?, ?> entry) {
+        try {
+            final Field field = SegmentRegistryEntry.class
+                    .getDeclaredField("lock");
+            field.setAccessible(true);
+            return (ReentrantLock) field.get(entry);
+        } catch (final ReflectiveOperationException ex) {
+            throw new IllegalStateException("Unable to read entry lock", ex);
+        }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/SegmentRegistryImplTest.java
@@ -88,6 +88,35 @@ class SegmentRegistryImplTest {
     }
 
     @Test
+    void blockingPointOperationUsesSingleRegistryLookup() {
+        final Segment<Integer, String> created = registry.tryCreateSegment()
+                .getValue();
+        assertSame(OperationStatus.OK, created.put(1, "one").getStatus());
+        final SegmentRegistryCacheStats before = registry.metricsSnapshot();
+
+        final String value = registry.loadSegment(created.getId()).get(1);
+
+        final SegmentRegistryCacheStats after = registry.metricsSnapshot();
+        assertEquals("one", value);
+        assertEquals(before.hitCount() + 1L, after.hitCount());
+    }
+
+    @Test
+    void blockingHandleRefreshesAfterSegmentCloses() {
+        final BlockingSegment<Integer, String> handle = registry
+                .createSegment();
+        final Segment<Integer, String> first = handle.getSegment();
+        closeAndAssertClosed(first);
+
+        final BlockingSegment<Integer, String> reloaded = registry
+                .loadSegment(handle.getId());
+
+        assertSame(handle, reloaded);
+        assertNotSame(first, reloaded.getSegment());
+        assertSame(SegmentState.READY, reloaded.getRuntime().getState());
+    }
+
+    @Test
     void registryStartupTransitionsGateToReady() {
         final SegmentRegistryStateMachine gate = readGate(registry);
         assertSame(SegmentRegistryState.READY, gate.getState());


### PR DESCRIPTION
Closes #322

## Summary

- add a safely published lock-free READY fast path for SegmentRegistry entries
- reuse the segment already loaded for a point operation instead of repeating the registry lookup in the blocking wrapper
- replace SessionOperationGate's per-operation monitor and unconditional `notifyAll()` with atomic tracking and bounded close-side drain polling
- preserve registry eviction/close protection, operation nesting, interruption, and session close ordering
- add deterministic concurrency coverage and raw before/after JMH evidence

## Root cause

READY registry hits entered `SegmentRegistryEntry` locking, and `DefaultBlockingSegment` invoked the loader again for the same operation. Separately, every foreground session operation synchronized on `SessionOperationGate` for both admission and completion, with `notifyAll()` executed even when no close drain was waiting.

## Benchmark results

- Registry optimization: mean throughput moved from 2.625M to 3.411M ops/s (+29.9%); short-run confidence intervals overlap, so this is directional rather than a precise expected gain.
- Registry stack samples: both targeted registry-entry waiting paths fell to 0%.
- Session gate: mean throughput moved from 3.176M to 3.072M ops/s (-3.3%) with heavily overlapping confidence intervals, so no regression or improvement is established.
- Session stack samples: all SessionOperationGate blocked frames and the hot-path `Object.notifyAll()` frame disappeared.
- The canonical smoke profile was noisy in both directions and is not used to claim a throughput change.

Detailed reports and raw JMH JSON are included under `benchmarks/results/`.

## Validation

- focused session, registry, eviction, and retry tests
- `mvn -pl benchmarks -DskipTests=false test`
- `mvn clean verify`