### PR TITLE
Optimize SegmentIndex hot paths

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -126,6 +126,16 @@ python3 benchmarks/scripts/run_jmh_profile.py \
   --output-dir /tmp/hestia-bench/current
 ```
 
+Measure Logback-backed MDC overhead on otherwise identical live-get and hot-put
+workloads:
+
+```sh
+python3 benchmarks/scripts/run_jmh_profile.py \
+  --repo-root . \
+  --profile segment-index-context-logging \
+  --output-dir /tmp/hestia-bench/context-logging
+```
+
 Run the nightly disk I/O profile locally:
 
 ```sh

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <jmh.version>1.37</jmh.version>
+        <logback.version>1.5.38</logback.version>
         <maven.install.skip>true</maven.install.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <skipTests>true</skipTests>
@@ -31,6 +32,12 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/benchmarks/profiles/segment-index-context-logging.json
+++ b/benchmarks/profiles/segment-index-context-logging.json
@@ -1,0 +1,76 @@
+{
+  "profile": "segment-index-context-logging",
+  "description": "Focused three-fork comparison of SegmentIndex point workloads with Logback-backed MDC context logging disabled and enabled.",
+  "benchmarks": [
+    {
+      "label": "segment-index-live-get-context-disabled",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "args": [
+        "-wi", "3",
+        "-i", "5",
+        "-f", "3",
+        "-r", "1s",
+        "-w", "1s",
+        "-t", "4",
+        "-prof", "gc",
+        "-e", ".*getMissSync",
+        "-p", "contextLogging=false",
+        "-p", "readPathMode=live",
+        "-p", "snappy=true",
+        "-p", "chunkStoreCachePageLimit=0",
+        "-p", "keyCount=12000",
+        "-p", "maxKeysInChunk=256",
+        "-p", "valueLength=64"
+      ]
+    },
+    {
+      "label": "segment-index-live-get-context-enabled",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "args": [
+        "-wi", "3",
+        "-i", "5",
+        "-f", "3",
+        "-r", "1s",
+        "-w", "1s",
+        "-t", "4",
+        "-prof", "gc",
+        "-e", ".*getMissSync",
+        "-p", "contextLogging=true",
+        "-p", "readPathMode=live",
+        "-p", "snappy=true",
+        "-p", "chunkStoreCachePageLimit=0",
+        "-p", "keyCount=12000",
+        "-p", "maxKeysInChunk=256",
+        "-p", "valueLength=64"
+      ]
+    },
+    {
+      "label": "segment-index-hot-put-context-disabled",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+      "args": [
+        "-wi", "3",
+        "-i", "5",
+        "-f", "3",
+        "-r", "1s",
+        "-w", "1s",
+        "-prof", "gc",
+        "-e", ".*putThenGetHotRoute",
+        "-p", "contextLogging=false"
+      ]
+    },
+    {
+      "label": "segment-index-hot-put-context-enabled",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+      "args": [
+        "-wi", "3",
+        "-i", "5",
+        "-f", "3",
+        "-r", "1s",
+        "-w", "1s",
+        "-prof", "gc",
+        "-e", ".*putThenGetHotRoute",
+        "-p", "contextLogging=true"
+      ]
+    }
+  ]
+}

--- a/benchmarks/profiles/segment-index-nightly.json
+++ b/benchmarks/profiles/segment-index-nightly.json
@@ -12,6 +12,7 @@
         "-r", "2s",
         "-w", "2s",
         "-t", "4",
+        "-p", "contextLogging=false",
         "-p", "readPathMode=persisted",
         "-p", "snappy=true",
         "-p", "keyCount=12000",
@@ -29,6 +30,7 @@
         "-r", "2s",
         "-w", "2s",
         "-t", "4",
+        "-p", "contextLogging=false",
         "-p", "readPathMode=live",
         "-p", "snappy=true",
         "-p", "keyCount=12000",
@@ -129,7 +131,8 @@
         "-i", "5",
         "-f", "1",
         "-r", "2s",
-        "-w", "2s"
+        "-w", "2s",
+        "-p", "contextLogging=false"
       ]
     },
     {

--- a/benchmarks/profiles/segment-index-pr-smoke.json
+++ b/benchmarks/profiles/segment-index-pr-smoke.json
@@ -12,6 +12,7 @@
         "-r", "1s",
         "-w", "1s",
         "-t", "4",
+        "-p", "contextLogging=false",
         "-p", "readPathMode=persisted",
         "-p", "snappy=true",
         "-p", "keyCount=12000",
@@ -29,6 +30,7 @@
         "-r", "1s",
         "-w", "1s",
         "-t", "4",
+        "-p", "contextLogging=false",
         "-p", "readPathMode=live",
         "-p", "snappy=true",
         "-p", "keyCount=12000",
@@ -96,7 +98,8 @@
         "-i", "3",
         "-f", "1",
         "-r", "1s",
-        "-w", "1s"
+        "-w", "1s",
+        "-p", "contextLogging=false"
       ]
     },
     {

--- a/benchmarks/scripts/run_jmh_profile.py
+++ b/benchmarks/scripts/run_jmh_profile.py
@@ -124,6 +124,8 @@ def host_metadata() -> dict[str, Any]:
 
 def normalize_result(result_path: Path) -> dict[str, Any]:
     rows = json.loads(result_path.read_text(encoding="utf-8"))
+    if not rows:
+        raise ValueError(f"JMH produced no benchmark results in {result_path}.")
     normalized_rows = []
     for row in rows:
         normalized_rows.append({

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexGetBenchmark.java
@@ -20,7 +20,8 @@ import org.openjdk.jmh.annotations.Warmup;
  * <p>
  * The benchmark intentionally closes and reopens the index after populating it.
  * It can then either read only the persisted view or add live updates and
- * measure point lookups that resolve from the segment write cache.
+ * measure point lookups that resolve from the segment write cache. Context
+ * logging can be enabled to measure the production-default MDC adapter.
  * </p>
  */
 @BenchmarkMode(Mode.Throughput)
@@ -49,6 +50,9 @@ public class SegmentIndexGetBenchmark extends AbstractSegmentIndexGetBenchmark {
     @Param({ "persisted", "live" })
     private String readPathMode;
 
+    @Param({ "false", "true" })
+    private boolean contextLogging;
+
     @Override
     protected String tempDirPrefix() {
         return "hestia-jmh-get";
@@ -58,6 +62,7 @@ public class SegmentIndexGetBenchmark extends AbstractSegmentIndexGetBenchmark {
     protected IndexConfiguration<Integer, String> buildConfiguration() {
         final var builder = SegmentIndexBenchmarkSupport
                 .baseBuilder("segment-index-get-benchmark")//
+                .logging(logging -> logging.contextEnabled(contextLogging))//
                 .segment(segment -> segment.cacheKeyLimit(8)
                         .chunkKeyLimit(maxKeysInChunk).maxKeys(keyCount * 2)
                         .cachedSegmentLimit(3).deltaCacheFileLimit(2))//

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexHotRoutePutBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexHotRoutePutBenchmark.java
@@ -15,6 +15,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -24,7 +25,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Benchmark focused on the hot-route write path.
+ * Benchmark focused on the hot-route write path, with optional
+ * production-default MDC context logging.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -41,6 +43,9 @@ public class SegmentIndexHotRoutePutBenchmark {
 
     private SegmentIndex<Integer, String> index;
     private AtomicInteger sequence;
+
+    @Param({ "false", "true" })
+    private boolean contextLogging;
 
     @Setup(Level.Trial)
     public void setup() {
@@ -81,7 +86,7 @@ public class SegmentIndexHotRoutePutBenchmark {
                         .keyTypeDescriptor(KEY_DESCRIPTOR)
                         .valueTypeDescriptor(VALUE_DESCRIPTOR)
                         .name("segment-index-hot-route-put-benchmark"))//
-                .logging(logging -> logging.contextEnabled(false))//
+                .logging(logging -> logging.contextEnabled(contextLogging))//
                 .segment(segment -> segment.cacheKeyLimit(512)
                         .chunkKeyLimit(64).cachedSegmentLimit(8)
                         .deltaCacheFileLimit(2))//

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
@@ -77,9 +77,9 @@ public class SegmentIndexMultiSegmentGetBenchmark
 
     @Override
     protected void populateIndex(final SegmentIndex<Integer, String> created) {
-        final int flushBatchSize = Math.max(512, maxKeysInSegment / 2);
+        // Let background splits settle before one final full maintenance pass.
         SegmentIndexBenchmarkSupport.populateSequential(created, keyCount,
-                flushBatchSize, this::buildValue);
+                keyCount, this::buildValue);
     }
 
     @Override

--- a/benchmarks/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotMembershipBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotMembershipBenchmark.java
@@ -1,0 +1,59 @@
+package org.hestiastore.index.segmentindex.routemap;
+
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.index.segment.SegmentId;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Measures exact segment-id membership checks across route-map sizes.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(5)
+@State(Scope.Benchmark)
+public class RouteMapSnapshotMembershipBenchmark {
+
+    @Param({ "10", "1000", "10000", "50000", "100000" })
+    private int routeCount;
+
+    private RouteMapSnapshot<Integer> snapshot;
+    private SegmentId targetSegmentId;
+
+    /**
+     * Creates an immutable snapshot and selects its middle segment.
+     */
+    @Setup(Level.Trial)
+    public void setup() {
+        final TreeMap<Integer, SegmentId> routes = new TreeMap<>();
+        for (int route = 0; route < routeCount; route++) {
+            routes.put(Integer.valueOf(route), SegmentId.of(route));
+        }
+        snapshot = new RouteMapSnapshot<>(routes, 0);
+        targetSegmentId = SegmentId.of(routeCount / 2);
+    }
+
+    /**
+     * Checks membership for an average-position mapped segment.
+     *
+     * @return {@code true} when benchmark setup is valid
+     */
+    @Benchmark
+    public boolean containsMiddleSegment() {
+        return snapshot.containsSegmentId(targetSegmentId);
+    }
+}

--- a/benchmarks/src/main/resources/logback.xml
+++ b/benchmarks/src/main/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <root level="OFF" />
+</configuration>

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkHistoryScriptsSmokeTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkHistoryScriptsSmokeTest.java
@@ -100,6 +100,31 @@ class BenchmarkHistoryScriptsSmokeTest {
     }
 
     @Test
+    void profileRunnerRejectsEmptyJmhResults() throws Exception {
+        assumePython3Available();
+        final Path emptyResult = tempDir.resolve("empty-jmh-result.json");
+        Files.writeString(emptyResult, "[]", StandardCharsets.UTF_8);
+
+        final String snippet = """
+                import importlib.util
+                import pathlib
+                import sys
+
+                spec = importlib.util.spec_from_file_location("run_jmh_profile", sys.argv[1])
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                module.normalize_result(pathlib.Path(sys.argv[2]))
+                """;
+        final ProcessResult result = runCommand(List.of("python3", "-c",
+                snippet, scriptPath("run_jmh_profile.py").toString(),
+                emptyResult.toString()));
+
+        assertTrue(result.exitCode() != 0, result.output());
+        assertTrue(result.output().contains("JMH produced no benchmark results"),
+                result.output());
+    }
+
+    @Test
     void publishAndResolveScriptsRoundTripHistoryPointer() throws Exception {
         assumePython3Available();
         final Path sourceDir = tempDir.resolve("candidate-run");

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
@@ -54,6 +54,11 @@ class BenchmarkProfileContractTest {
             "diskio-sequential-read-1k",
             "diskio-sequential-read-4k",
             "diskio-sequential-read-32k");
+    private static final Set<String> REQUIRED_CONTEXT_LOGGING_LABELS = Set.of(
+            "segment-index-live-get-context-disabled",
+            "segment-index-live-get-context-enabled",
+            "segment-index-hot-put-context-disabled",
+            "segment-index-hot-put-context-enabled");
 
     @Test
     void allBenchmarkProfilesUseUniqueLabelsAndResolvableBenchmarkClasses()
@@ -97,6 +102,8 @@ class BenchmarkProfileContractTest {
         assertCanonicalNightlySegmentIndexProfile(
                 profilesByName.get("segment-index-nightly"));
         assertCanonicalDiskIoNightlyProfile(profilesByName.get("diskio-nightly"));
+        assertContextLoggingProfile(
+                profilesByName.get("segment-index-context-logging"));
     }
 
     @Test
@@ -127,10 +134,11 @@ class BenchmarkProfileContractTest {
 
         assertEntry(byLabel.get("segment-index-get-persisted"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
-                Map.of("readPathMode", "persisted"));
+                Map.of("contextLogging", "false", "readPathMode",
+                        "persisted"));
         assertEntry(byLabel.get("segment-index-get-live"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
-                Map.of("readPathMode", "live"));
+                Map.of("contextLogging", "false", "readPathMode", "live"));
         assertEntry(byLabel.get("segment-index-get-multisegment-hot"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
                 Map.of("workingSetMode", "hot"));
@@ -146,7 +154,7 @@ class BenchmarkProfileContractTest {
                 16);
         assertEntry(byLabel.get("segment-index-hot-route-put"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
-                Map.of());
+                Map.of("contextLogging", "false"));
         assertEntry(byLabel.get("segment-index-mixed-drain"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
                 Map.of("workloadMode", "drainOnly"));
@@ -168,10 +176,11 @@ class BenchmarkProfileContractTest {
 
         assertEntry(byLabel.get("segment-index-get-persisted"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
-                Map.of("readPathMode", "persisted"));
+                Map.of("contextLogging", "false", "readPathMode",
+                        "persisted"));
         assertEntry(byLabel.get("segment-index-get-live"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
-                Map.of("readPathMode", "live"));
+                Map.of("contextLogging", "false", "readPathMode", "live"));
         assertEntry(byLabel.get("segment-index-get-multisegment-hot"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
                 Map.of("workingSetMode", "hot"));
@@ -193,7 +202,7 @@ class BenchmarkProfileContractTest {
                 Map.of("walMode", "sync"));
         assertEntry(byLabel.get("segment-index-hot-route-put"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
-                Map.of());
+                Map.of("contextLogging", "false"));
         assertEntry(byLabel.get("segment-index-mixed-drain"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
                 Map.of("workloadMode", "drainOnly"));
@@ -233,6 +242,47 @@ class BenchmarkProfileContractTest {
                 Map.of("diskIoBufferSizeBytes", "32768"));
     }
 
+    private void assertContextLoggingProfile(final BenchmarkProfile profile) {
+        assertNotNull(profile, "Missing context-logging profile");
+        final Map<String, BenchmarkEntry> byLabel = new LinkedHashMap<>();
+        for (final BenchmarkEntry benchmark : profile.benchmarks()) {
+            byLabel.put(benchmark.label(), benchmark);
+        }
+        assertEquals(REQUIRED_CONTEXT_LOGGING_LABELS, byLabel.keySet(),
+                () -> "Unexpected benchmark labels in profile "
+                        + profile.profile());
+
+        assertContextLoggingEntry(
+                byLabel.get("segment-index-live-get-context-disabled"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+                "false", "live");
+        assertContextLoggingEntry(
+                byLabel.get("segment-index-live-get-context-enabled"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+                "true", "live");
+        assertContextLoggingEntry(
+                byLabel.get("segment-index-hot-put-context-disabled"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+                "false", null);
+        assertContextLoggingEntry(
+                byLabel.get("segment-index-hot-put-context-enabled"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+                "true", null);
+    }
+
+    private void assertContextLoggingEntry(final BenchmarkEntry entry,
+            final String include, final String contextLogging,
+            final String readPathMode) {
+        final Map<String, String> params = new LinkedHashMap<>();
+        params.put("contextLogging", contextLogging);
+        if (readPathMode != null) {
+            params.put("readPathMode", readPathMode);
+        }
+        assertEntry(entry, include, params);
+        assertOptionValue(entry, "-f", "3");
+        assertOptionValue(entry, "-prof", "gc");
+    }
+
     private void assertEntry(final BenchmarkEntry entry, final String include,
             final Map<String, String> requiredParams) {
         assertNotNull(entry, "Missing benchmark entry for " + include);
@@ -253,13 +303,17 @@ class BenchmarkProfileContractTest {
 
     private void assertThreadCount(final BenchmarkEntry entry,
             final int expectedThreadCount) {
+        assertOptionValue(entry, "-t", Integer.toString(expectedThreadCount));
+    }
+
+    private void assertOptionValue(final BenchmarkEntry entry,
+            final String option, final String expectedValue) {
         final List<String> args = entry.args();
-        final int threadOption = args.indexOf("-t");
-        assertTrue(threadOption >= 0 && threadOption + 1 < args.size(),
-                () -> "Missing thread count for " + entry.label());
-        assertEquals(Integer.toString(expectedThreadCount),
-                args.get(threadOption + 1),
-                () -> "Unexpected thread count for " + entry.label());
+        final int optionIndex = args.indexOf(option);
+        assertTrue(optionIndex >= 0 && optionIndex + 1 < args.size(),
+                () -> "Missing " + option + " for " + entry.label());
+        assertEquals(expectedValue, args.get(optionIndex + 1),
+                () -> "Unexpected " + option + " for " + entry.label());
     }
 
     private List<BenchmarkProfile> loadProfiles() throws Exception {

--- a/docs-nav-exclude.txt
+++ b/docs-nav-exclude.txt
@@ -1,1 +1,2 @@
-# No explicit documentation exclusions.
+# Internal planning context; the published tracker remains in MkDocs navigation.
+refactoring-context.md

--- a/docs/architecture/segmentindex/segment-index-concurrency.md
+++ b/docs/architecture/segmentindex/segment-index-concurrency.md
@@ -39,8 +39,10 @@
   a global executor.
 - SegmentRegistrySynchronized serializes access to the segment instance map and
   registry mutations.
-- SegmentRouteMap uses snapshot reads plus a mapping version; updates take a
-  write lock and increment the version.
+- SegmentRouteMap publishes the immutable routes and mapping version together
+  through one volatile snapshot. Foreground snapshot and version reads do not
+  take the route-map lock; updates take the write lock and publish the next
+  snapshot after the mutation.
 - RouteTopology is rebuilt from the persisted map on startup and reconciled
   after route-map changes. It does not own segment instances or persistence.
 - Foreground `put`, `delete`, and `get` use `MappedSegmentLeaseService` to resolve a

--- a/docs/refactor-backlog.md
+++ b/docs/refactor-backlog.md
@@ -4,6 +4,26 @@
 
 ### To Solve
 
+#### Point-operation hot-path cleanup
+
+Items `100.1` through `100.3` and `100.5` are complete. Item `100.4` is
+intentionally deferred from this sequence; item `100.6` is the final active
+step.
+
+- [ ] 100.6 Re-profile the accepted sequence and stop at the measured boundary
+  (Risk: LOW). Owner: `benchmarks` and refactoring docs. Outcome: run the
+  canonical SegmentIndex comparison and focused JFR profiles, record accepted,
+  rejected, and still-deferred candidates, and update architecture docs only
+  for behavior that actually changed. Validation: benchmark comparison reports,
+  `python3 scripts/check_docs_nav.py`, `mkdocs build --strict`, and
+  `git diff --check`.
+  Status: blocked by the performance gate. The complete canonical profile now
+  runs, but its one-fork comparison produced contradictory large deltas and
+  several `worse` results. Two focused five-fork live-get A/B cycles retained
+  overlapping throughput intervals and did not reproduce a stable whole-path
+  allocation mean. Next safe action: rerun the same artifacts on a quiet,
+  dedicated host before archiving this item.
+
 [ ] 80. Make WAL durability explicit for non-fsync storage adapters so `SYNC` and `GROUP_SYNC` never claim guarantees that the active storage backend cannot provide.
 [ ] 81. Split `WalRuntime` into focused writer, recovery, segment-catalog, and sync-policy responsibilities instead of keeping all lifecycle paths behind one shared monitor.
 [ ] 82. Replace the slow generic `WalStorageDirectory` fallback with an explicit seekable/capability-aware storage path, or reject unsupported backends early.
@@ -25,8 +45,133 @@
 [ ] M42 Review `segmentregistry` package for test and Javadoc coverage (Risk: LOW)
 [ ] M43 Avoid pattern-name abstractions unless they own lifecycle, resource opening, or rollback-sensitive cleanup (Risk: LOW)
 
+## Unfinished Audit
+
+- Deferred status-value reuse. Boundary: `engine` point-operation and route
+  leasing results. Reason: exploratory JFR did not identify `OperationResult`
+  or `RouteLeaseAttempt` as material allocation sources, and generic singleton
+  reuse adds type-safety and semantic risk. Evidence still needed: a
+  representative allocation profile with these constructors on a material hot
+  stack. Item `100.6` JFR still did not show that evidence. Next safe action:
+  revisit only after a new production-equivalent profile does.
+- Deferred 100.4 sampled point-operation latency recording. Boundary: `engine`
+  operation monitoring. Reason: explicitly excluded from the current
+  refactoring sequence; operation counts and latency observations remain
+  unchanged. Item `100.6` sampled latency recording in execution stacks but
+  recorded no live-get monitor contention. Next safe action: reconsider only
+  after a production profile identifies material contention.
+- Deferred chunk-store cache redesign. Boundary:
+  `engine` `LruChunkStoreCache`. Reason: the implementation has one synchronized
+  access-ordered map, but the persisted cache-enabled profile recorded no
+  contention events, and item `100.6` JFR did not make it material. Evidence
+  still needed: representative blocked-time or duplicate same-page load
+  measurements. Next safe action: shard or add minimal per-key single-flight
+  only for the demonstrated failure mode.
+- Canonical comparison gate remains blocked. Boundary: `benchmarks`
+  `segment-index-pr-smoke`. The benchmark now completes for both baseline and
+  candidate, but the one-fork report simultaneously marked all get paths
+  `22.07%` to `45.53%` worse and hot-put/split-heavy paths roughly `47%` to
+  `57%` better. Focused five-fork throughput intervals overlapped, and a
+  reverse-order live-get repeat remained inconclusive. Evidence still needed:
+  the same A/B artifacts on a quiet, dedicated host. Next safe action: rerun;
+  do not tune code to these contradictory point estimates.
+- Repeated explicit maintenance during background split population can time
+  out. Boundary: multi-segment benchmark setup and the production
+  `flushAndWait()`/split interaction. The failure reproduced at 8,192 and
+  32,768 keys and with segment-cache limits from `3` through `256`; the stack
+  timed out in `MappedSegmentMaintenanceService.awaitSegmentReady(...)` while
+  reloading a closed segment. The read benchmark now performs one final settled
+  flush so it can measure reads, but that does not fix the underlying
+  maintenance interaction. Next safe action: investigate it as a dedicated
+  lifecycle/concurrency issue outside item `100.6`.
+- Route-lease monitor contention needs production confirmation. Boundary:
+  `RouteEntry` lease acquisition/release. The item `100.6` JFR hot-put stress
+  profile recorded 14 blocked monitor events totaling `143 ms` with twenty
+  threads targeting one route; live get recorded none. Next safe action:
+  redesign only if a production JFR shows the same monitor as material.
+- Deferred immutable segment-ID set. Boundary: `RouteMapSnapshot`. Reason:
+  direct map-value scanning removed the temporary list and improved the
+  50,000-route lookup from `323.428 us/op` to `115.267 us/op` with effectively
+  zero per-call allocation. Item `100.6` JFR did not show the remaining scan as
+  material. Evidence still needed: an end-to-end exact-segment acquisition
+  profile showing that it justifies duplicate snapshot state and extra
+  publication cost.
+
 ## Done (Archive)
 
+- [x] 100.5 Replace list-building segment membership checks with direct
+  snapshot lookup (Risk: MEDIUM).
+    - `RouteMapSnapshot.containsSegmentId(...)` now scans immutable map values
+      directly, and `MappedSegmentLeaseService` uses it for exact mapped-segment
+      checks without constructing an unbounded list.
+    - A focused one-thread JMH benchmark measured a successful middle-position
+      lookup with five forks, three warmup iterations, five measurement
+      iterations, and GC profiling on the same JDK 25 arm64 macOS environment.
+    - Results were `63.807 -> 5.627 ns/op` at 10 routes,
+      `5.647 -> 1.649 us/op` at 1,000, `64.027 -> 22.364 us/op` at 10,000,
+      `323.428 -> 115.267 us/op` at 50,000, and
+      `660.687 -> 228.547 us/op` at 100,000. Reported confidence intervals did
+      not overlap at any tested size.
+    - Allocation changed from `384 B/op`, `4,344 B/op`, `40,361 B/op`,
+      `200,346 B/op`, and `400,355 B/op`, respectively, to effectively
+      zero. The improvement is measurable from 10 routes, the smallest tested
+      size; no claim is made below 10.
+    - Focused engine tests passed with 23 tests, benchmark contract/tooling tests
+      passed with 12 tests, and `mvn clean verify` passed across all 10 reactor
+      modules.
+- [x] 100.3 Publish and reuse one immutable `RouteMapSnapshot` per route-map
+  version (Risk: MEDIUM).
+    - `PersistentSegmentRouteMap` now publishes copied routes and their version
+      together through one volatile `RouteMapSnapshot` reference. Repeated
+      `snapshot()` calls perform no locking or wrapper allocation, and only real
+      mutations publish the next instance.
+    - Focused identity, no-op mutation, version-transition, and concurrent split
+      publication coverage passed: 17 route-map tests. `mvn clean verify`
+      passed across all 10 reactor modules.
+    - Five-fork live-get JMH with GC data moved from
+      `3.493 M ops/s`, `168.175 B/op` to
+      `3.427 M ops/s`, `148.507 B/op`. Throughput changed by `-1.87%` with
+      overlapping confidence intervals; allocation fell by `19.668 B/op`
+      (`-11.70%`) with non-overlapping reported confidence intervals.
+    - Five-fork hot-put throughput moved from `2.853 M ops/s` to
+      `3.170 M ops/s`, but its confidence intervals overlapped. Allocation was
+      bimodal across the candidate and repeat runs (`136` to `216 B/op`), so no
+      hot-put allocation or throughput improvement is claimed.
+    - The focused throughput summaries passed the canonical comparison tool
+      with no regression: live get was `neutral` and hot put was `better` under
+      its percentage thresholds. The broader canonical-profile setup failure is
+      retained in the unfinished audit rather than hidden.
+- [x] 100.2 Add production-equivalent context-logging benchmark coverage
+  (Risk: LOW).
+    - `SegmentIndexGetBenchmark` and `SegmentIndexHotRoutePutBenchmark` now
+      expose the same enabled/disabled context-logging parameter. Existing
+      canonical profiles pin it off, while
+      `segment-index-context-logging.json` runs the focused comparison with a
+      Logback MDC backend and log emission disabled.
+    - The profile runner now rejects empty JMH result files instead of
+      publishing a successful summary after all forks fail.
+    - Benchmark profile contract and script smoke coverage passed with 11
+      tests; the packaged runner also passed a direct enabled-MDC smoke run.
+      `mvn clean verify` passed across all 10 reactor modules.
+    - Three forks with three warmup and five measurement iterations reported
+      live-get means of `3.487 M ops/s`, `171.884 B/op` disabled and
+      `3.122 M ops/s`, `204.007 B/op` enabled. Hot-put means were
+      `2.527 M ops/s`, `201.239 B/op` disabled and `2.800 M ops/s`,
+      `237.404 B/op` enabled.
+    - Enabled-MDC allocation means were about `32.123 B/op` higher for live
+      gets and `36.165 B/op` higher for hot puts. Throughput and allocation
+      confidence intervals overlapped in both comparisons, so this run alone
+      does not establish either effect. Production logging behavior was
+      unchanged.
+- [x] 100.1 Close the losing `SegmentReadPath` searcher after concurrent first
+  access (Risk: MEDIUM).
+    - `SegmentReadPath` now closes a redundantly constructed searcher
+      immediately after losing the cache CAS; the winner remains cached.
+    - A deterministic two-thread `SegmentReadPathTest` verifies that exactly
+      one supplier closes after the race and the winner closes with the read
+      path.
+    - `mvn -pl engine -Dtest=SegmentReadPathTest test` passed with 7 tests.
+    - `mvn clean verify` passed across all 10 reactor modules.
 [x] 99. Replace `SessionOperationGate` per-operation monitor contention with atomic in-flight tracking and bounded close-side drain polling (Risk: MEDIUM)
     - Focused session concurrency tests, benchmark module tests, and the full
       Maven verification pipeline pass.

--- a/docs/refactoring-context.md
+++ b/docs/refactoring-context.md
@@ -1,0 +1,224 @@
+---
+title: Refactoring Context
+audience: contributor
+doc_type: reference
+owner: engine
+---
+
+# Refactoring Context
+
+This page defines the current boundary and evidence requirements for the
+point-operation hot-path cleanup sequence. It is durable planning context, not
+an additional task ledger.
+
+## Current Target
+
+- Target boundary: resource ownership and measured per-operation overhead in
+  `engine` routing, latency tracking, segment reads, and context logging, plus
+  the focused JMH coverage needed to evaluate those paths.
+- Desired end state: fix the confirmed concurrent searcher resource leak, then
+  retain only small hot-path changes that show a repeatable allocation,
+  throughput, or latency improvement without changing public behavior.
+- Current status: items `100.1` through `100.3` and `100.5` are complete and
+  archived in `docs/refactor-backlog.md`. Item `100.4` is intentionally
+  deferred. Item `100.6` has run, but remains open because the canonical
+  one-fork regression screen reported contradictory `worse` and `better`
+  results and the focused throughput repeats did not clear the performance
+  gate.
+- Stop condition: when the next candidate is no longer visible in a
+  representative profile, or its focused A/B result is neutral, inconclusive,
+  or worse, do not retain that optimization. Record the evidence and proceed to
+  the final profiling item instead of broadening the design.
+
+### Planning Evidence
+
+The following results are exploratory evidence from the rebuilt benchmark
+runner at commit `ab14e0f69`; they are not completion evidence because no
+canonical baseline/candidate report was captured:
+
+- One-fork JMH with three warmup and five measurement iterations reported about
+  `186.780 B/op` for four-thread live gets and `216.496 B/op` for
+  twenty-thread hot puts.
+- JFR allocation samples included `RouteMapSnapshot` on both paths.
+  `OperationLatencyTracker.recordNanos(...)` also appeared in execution samples.
+- A persisted, cache-enabled profile showed `LruChunkStoreCache.getCachedPage`
+  in CPU samples but no cache contention events.
+- `OperationResult` and `RouteLeaseAttempt` did not appear as material
+  allocation sources in the sampled runs.
+- Existing SegmentIndex benchmarks explicitly disable context logging, while
+  the production configuration default enables it.
+
+### Context-Logging Measurement
+
+Item `100.2` added a focused Logback-backed profile without changing production
+logging behavior. On the same dirty worktree at commit `ab14e0f69`, JDK 25 on
+arm64 macOS, three forks with three warmup and five one-second measurement
+iterations produced:
+
+- Live get: `3.487 M ops/s`, `171.884 B/op` with context logging disabled and
+  `3.122 M ops/s`, `204.007 B/op` enabled.
+- Hot put: `2.527 M ops/s`, `201.239 B/op` with context logging disabled and
+  `2.800 M ops/s`, `237.404 B/op` enabled.
+
+The enabled-mode means were about `32.123 B/op` higher for live gets and
+`36.165 B/op` higher for hot puts. The reported confidence intervals overlapped
+for throughput and allocation in both workloads, so this run alone does not
+establish either effect. Keep the enabled/disabled coverage for future
+measurement, but make no performance claim from this result.
+
+### Route-Map Snapshot Publication Measurement
+
+Item `100.3` changed route snapshot publication from a per-call wrapper under a
+read lock to one immutable snapshot per map version, published through a
+volatile reference. On the same dirty worktree, JDK 25 on arm64 macOS, five
+forks with three warmup and five one-second measurement iterations produced:
+
+- Live get: baseline `3.493 M ops/s`, `168.175 B/op`; candidate
+  `3.427 M ops/s`, `148.507 B/op`.
+- Hot put: baseline `2.853 M ops/s`, `216.617 B/op`; first candidate
+  `3.170 M ops/s`, `200.068 B/op`.
+
+Live-get throughput changed by `-1.87%`, within overlapping reported confidence
+intervals. Live-get allocation fell by `19.668 B/op` (`-11.70%`), and the
+reported allocation confidence intervals did not overlap. Hot-put throughput
+confidence intervals overlapped, while candidate and repeat allocation forks
+were bimodal from about `136` to `216 B/op`; no hot-put improvement is claimed.
+The retained benefit is the repeatable live-get allocation reduction and the
+lock-free snapshot publication itself.
+
+The affected live-get and hot-put throughput summaries passed the canonical
+comparison script without a regression. A broader `segment-index-pr-smoke`
+baseline attempt stopped at an unrelated multisegment benchmark setup timeout
+and produced an empty result, so that full-profile comparison remains explicit
+unfinished audit evidence for item `100.6`.
+
+### Segment-ID Membership Measurement
+
+Item `100.5` replaced list materialization followed by `contains(...)` with a
+direct immutable map-value scan. A focused JMH benchmark measured a successful
+middle-position lookup at the requested route counts. Both variants ran on the
+same dirty worktree, JDK 25 on arm64 macOS, with one thread, five forks, three
+warmup iterations, five one-second measurement iterations, and the GC profiler.
+
+| Routes | List + contains | Direct scan | Speedup | Allocation before | Allocation after |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 10 | 63.807 ns | 5.627 ns | 11.34x | 384 B/op | ~0 B/op |
+| 1,000 | 5.647 us | 1.649 us | 3.42x | 4,344 B/op | ~0 B/op |
+| 10,000 | 64.027 us | 22.364 us | 2.86x | 40,361 B/op | ~0 B/op |
+| 50,000 | 323.428 us | 115.267 us | 2.81x | 200,346 B/op | ~0 B/op |
+| 100,000 | 660.687 us | 228.547 us | 2.89x | 400,355 B/op | ~0 B/op |
+
+Reported confidence intervals did not overlap at any tested size, so the
+improvement is measurable from 10 routes, the smallest tested value. The
+production ceiling of 50,000 routes receives a `64.36%` latency reduction and
+removes about `200 kB` of temporary allocation per membership check. The
+remaining direct scan is linear, but an immutable segment-ID set is deferred
+until an end-to-end profile proves that its extra snapshot memory and
+publication cost are justified.
+
+### Final Re-profile
+
+Item `100.6` rebuilt commit `ab14e0f69` as the production baseline and used the
+staged tree as the candidate on the same JDK 25 arm64 macOS host.
+
+- The original canonical setup failure was reproduced. Repeated full
+  `flushAndWait()` calls during multi-segment population could time out while
+  reloading a segment as background splits progressed. Raising the segment
+  cache limit from `3` through `64`, `128`, and `256` did not fix the failure.
+  The read benchmark fixture now populates first and performs one final settled
+  flush. With that benchmark-only change applied to both trees, the complete
+  `segment-index-pr-smoke` profile ran successfully.
+- The canonical one-fork comparison was not credible as a performance claim.
+  It reported all get variants `22.07%` to `45.53%` worse while reporting hot
+  puts and split-heavy work about `47%` to `57%` better. The reported JMH
+  confidence intervals were extremely wide, so these opposing results are
+  retained only as a failed regression screen.
+- A five-fork live-get A/B with three warmup and five measurement iterations
+  reported `3.081 M ops/s`, `179.293 B/op` for the baseline and
+  `2.694 M ops/s`, `151.735 B/op` for the candidate. Throughput intervals
+  overlapped. A reverse-order repeat reported `2.437 M ops/s`,
+  `154.943 B/op` for the candidate and `2.633 M ops/s`, `154.445 B/op` for the
+  baseline. The repeat made allocation bimodality visible on both sides, so
+  item `100.6` does not add a new whole-live-get allocation or throughput
+  claim.
+- A five-fork hot-put A/B reported `1.572 M ops/s`, `211.983 B/op` for the
+  baseline and `1.818 M ops/s`, `211.319 B/op` for the candidate. Throughput
+  confidence intervals overlapped and allocation was effectively unchanged,
+  so no hot-put improvement is claimed.
+- Candidate JFR recorded no live-get monitor contention. It did not identify
+  `OperationResult`, `RouteLeaseAttempt`, the remaining segment-ID scan, or
+  `LruChunkStoreCache` as material hot-path candidates. In the artificial
+  twenty-thread single-route hot-put workload, `RouteEntry` lease acquisition
+  and release produced 14 monitor-blocked events totaling `143 ms`; production
+  evidence is required before changing its drain-sensitive state model.
+
+The measured boundary is therefore unchanged: retain the already demonstrated
+snapshot-publication and exact membership improvements, accept no additional
+cleanup candidate, and make no whole-application throughput claim. Item `100.6`
+cannot be archived until a stable same-host comparison clears the canonical
+regression gate.
+
+## Source Of Truth
+
+- `AGENTS.md` defines repository rules. In particular,
+  `docs/refactor-backlog.md` is the authoritative and only active refactoring
+  tracker. This file supplies the context role from the refactoring-plan
+  workflow; do not create a competing `docs/refactoring-tracker.md`.
+- `docs/development/code-quality-charter.md` defines the small-slice workflow
+  and performance gates.
+- `benchmarks/README.md`, `benchmarks/profiles/segment-index-pr-smoke.json`, and
+  focused benchmark profiles define the comparison flow.
+- `docs/development/rollout-quality-gates.md` defines the maximum accepted
+  point-operation overhead for monitoring-related changes.
+- `docs/architecture/segmentindex/performance.md`,
+  `docs/architecture/segmentindex/read-path.md`, and
+  `docs/architecture/segmentindex/caching.md` define current hot-path and cache
+  behavior.
+- `docs/configuration/logging.md` and `docs/operations/monitoring.md` define
+  logging and latency-metric behavior that must remain externally consistent.
+- Primary implementation owners are `PersistentSegmentRouteMap`,
+  `RouteMapSnapshot`, `MappedSegmentLeaseService`, `OperationLatencyTracker`,
+  `SegmentReadPath`, `SegmentIndexMdcLoggingAdapter`, and
+  `LruChunkStoreCache`, with their matching tests.
+
+## Guardrails
+
+- Preserve route-map ordering, map-version semantics, split publication,
+  persistence behavior, retry behavior, public APIs, and exact get/put/delete
+  counts.
+- Publish route data and its version as one immutable state. Do not expose or
+  mutate a published `TreeMap`.
+- Treat the `SegmentReadPath` CAS-loser cleanup as a correctness fix. Verify
+  exactly-once cleanup with deterministic concurrent first access.
+- Sampling experiments may reduce latency observations, not operation counts.
+  Do not add public sampling configuration before an internal experiment shows
+  useful improvement and acceptable percentile behavior.
+- Measure context logging in both production-default enabled mode and disabled
+  mode. The disabled bootstrap path already avoids the MDC adapter; do not add
+  another disabled-path mechanism without evidence.
+- Limit segment-ID membership work to exact-segment routing paths. Retain the
+  direct snapshot scan; add a maintained immutable ID set only if an end-to-end
+  profile shows that the remaining scan justifies duplicate snapshot state.
+- Do not implement singleton `OperationResult` or `RouteLeaseAttempt` values,
+  cache sharding, cache replacement, or per-key single-flight loading without
+  new profile evidence showing that exact allocation or contention source is
+  material.
+- Keep each accepted production change in its own focused commit. Do not turn
+  this sequence into an architectural rewrite.
+
+## Validation Gates
+
+- Documentation-only planning changes:
+  `python3 scripts/check_docs_nav.py`, `mkdocs build --strict`, and
+  `git diff --check`.
+- Every production slice: matching focused tests, deterministic concurrency or
+  resource-lifecycle coverage where applicable, then `mvn clean verify`.
+- Benchmark coverage changes: the profile contract and benchmark history script
+  smoke tests documented in `benchmarks/README.md`.
+- Every retained hot-path optimization: a same-environment baseline/candidate
+  comparison using the canonical compare flow, plus a focused three-fork JMH
+  run with the GC profiler for the affected path.
+- Acceptance: no `worse` canonical result, no point-operation regression beyond
+  the documented three-percent budget, and a repeatable improvement in the
+  metric targeted by the slice. Neutral or inconclusive code-only
+  optimizations are not retained.

--- a/engine/src/main/java/org/hestiastore/index/segment/Segment.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/Segment.java
@@ -105,6 +105,22 @@ public interface Segment<K, V> {
     K checkAndRepairConsistency();
 
     /**
+     * Attempts one consistency check without waiting for transient segment
+     * states.
+     * <p>
+     * Implementations that coordinate concurrent maintenance should override
+     * this method and return the corresponding non-OK status when exclusive
+     * access cannot be acquired. The default preserves compatibility with
+     * implementations whose existing consistency check is already synchronous.
+     *
+     * @return consistency result containing the last key, or {@code null} when
+     *         the segment is empty
+     */
+    default OperationResult<K> tryCheckAndRepairConsistency() {
+        return OperationResult.ok(checkAndRepairConsistency());
+    }
+
+    /**
      * Invalidates any active iterators by bumping the internal version counter.
      * Readers using optimistic locks should stop on the next check.
      *

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentConcurrencyGate.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentConcurrencyGate.java
@@ -97,7 +97,11 @@ final class SegmentConcurrencyGate {
         if (!stateMachine.tryEnterFreeze()) {
             return false;
         }
-        return awaitNoInFlight();
+        if (awaitNoInFlight()) {
+            return true;
+        }
+        stateMachine.finishFreezeToReady();
+        return false;
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentConsistencyChecker.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentConsistencyChecker.java
@@ -1,11 +1,11 @@
 package org.hestiastore.index.segment;
 
-import org.hestiastore.index.OperationResult;
 import java.util.Comparator;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.IndexException;
+import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.Vldtn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,34 +43,48 @@ class SegmentConsistencyChecker<K, V> {
      * @throws IndexException if keys are not in strictly increasing order
      */
     public K checkAndRepairConsistency() {
-        logger.debug("Checking segment '{}'", segment.getId());
-        K previousKey = null;
-        final OperationResult<EntryIterator<K, V>> iteratorResult = segment
-                .openIterator();
-        if (!iteratorResult.isOk()) {
+        final OperationResult<K> result = tryCheckAndRepairConsistency();
+        if (!result.isOk()) {
             throw new IndexException(String.format(
                     "Segment '%s' is not ready for consistency check: %s",
-                    segment.getId(), iteratorResult.getStatus()));
+                    segment.getId(), result.getStatus()));
+        }
+        return result.getValue();
+    }
+
+    /**
+     * Attempts a complete consistency scan under full segment isolation.
+     *
+     * @return successful result containing the last key, or the segment status
+     *         when exclusive access cannot be acquired
+     */
+    OperationResult<K> tryCheckAndRepairConsistency() {
+        logger.debug("Checking segment '{}'", segment.getId());
+        final OperationResult<EntryIterator<K, V>> iteratorResult = segment
+                .openIterator(SegmentIteratorIsolation.FULL_ISOLATION);
+        if (!iteratorResult.isOk()) {
+            return OperationResult.fromStatus(iteratorResult.getStatus());
         }
         try (EntryIterator<K, V> iterator = iteratorResult.getValue()) {
-            while (iterator.hasNext()) {
-                final Entry<K, V> entry = iterator.next();
-                if (previousKey == null) {
-                    previousKey = entry.getKey();
-                    continue;
-                }
-                if (keyComparator.compare(previousKey, entry.getKey()) >= 0) {
-                    throw new IndexException(String.format(
-                            "Keys in segment '%s' are not sorted. "
-                                    + "Key '%s' have to higher than key '%s'.",
-                            segment.getId(), entry.getKey(), previousKey));
-                }
-                previousKey = entry.getKey();
+            return OperationResult.ok(checkEntries(iterator));
+        }
+    }
+
+    private K checkEntries(final EntryIterator<K, V> iterator) {
+        K previousKey = null;
+        while (iterator.hasNext()) {
+            final Entry<K, V> entry = iterator.next();
+            if (previousKey != null
+                    && keyComparator.compare(previousKey, entry.getKey()) >= 0) {
+                throw new IndexException(String.format(
+                        "Keys in segment '%s' are not sorted. "
+                                + "Key '%s' have to higher than key '%s'.",
+                        segment.getId(), entry.getKey(), previousKey));
             }
+            previousKey = entry.getKey();
         }
         if (previousKey == null) {
             logger.warn("Segment '{}' is empty.", segment.getId());
-            return null;
         }
         return previousKey;
     }

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
@@ -121,6 +121,16 @@ class SegmentImpl<K, V> implements Segment<K, V> {
      * {@inheritDoc}
      */
     @Override
+    public OperationResult<K> tryCheckAndRepairConsistency() {
+        final SegmentConsistencyChecker<K, V> consistencyChecker = new SegmentConsistencyChecker<>(
+                this, core.getKeyComparator());
+        return consistencyChecker.tryCheckAndRepairConsistency();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void invalidateIterators() {
         core.invalidateIterators();
     }

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentReadPath.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentReadPath.java
@@ -119,6 +119,8 @@ final class SegmentReadPath<K, V> {
 
     /**
      * Returns (and caches) the index searcher for point lookups.
+     * Concurrent callers may construct redundant searchers; only the CAS
+     * winner is cached and every losing instance is closed immediately.
      *
      * @return cached index searcher
      */
@@ -138,6 +140,7 @@ final class SegmentReadPath<K, V> {
         if (segmentIndexSearcher.compareAndSet(null, created)) {
             return created;
         }
+        created.close();
         return segmentIndexSearcher.get();
     }
 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ObservedThreadPoolFactory.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/executorregistry/ObservedThreadPoolFactory.java
@@ -6,10 +6,13 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.hestiastore.index.Vldtn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates observed thread pools with consistent sizing, naming, and rejection
@@ -17,6 +20,8 @@ import org.hestiastore.index.Vldtn;
  */
 final class ObservedThreadPoolFactory {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(ObservedThreadPoolFactory.class);
     private static final int MIN_QUEUE_CAPACITY = 64;
     private static final int QUEUE_CAPACITY_MULTIPLIER = 64;
 
@@ -33,13 +38,23 @@ final class ObservedThreadPoolFactory {
                 new LongAdder());
     }
 
+    /**
+     * Creates a bounded pool that executes saturated submissions on the
+     * submitting thread and records every such execution.
+     *
+     * @param threadCount configured worker count
+     * @param threadCountArgumentName configuration argument name
+     * @param threadNamePrefix worker thread name prefix
+     * @return observed caller-runs pool
+     */
     ObservedThreadPool createCallerRunsPool(final Integer threadCount,
             final String threadCountArgumentName,
             final String threadNamePrefix) {
         final LongAdder callerRunsCount = new LongAdder();
         return createObservedThreadPool(threadCount,
                 threadCountArgumentName, threadNamePrefix,
-                new CountingCallerRunsPolicy(callerRunsCount),
+                new CountingCallerRunsPolicy(callerRunsCount,
+                        threadNamePrefix),
                 new LongAdder(), callerRunsCount);
     }
 
@@ -107,18 +122,42 @@ final class ObservedThreadPoolFactory {
             implements RejectedExecutionHandler {
 
         private final LongAdder callerRunsCount;
-        private final ThreadPoolExecutor.CallerRunsPolicy delegate = new ThreadPoolExecutor.CallerRunsPolicy();
+        private final String threadNamePrefix;
+        private final AtomicBoolean saturationWarningLogged = new AtomicBoolean();
 
-        private CountingCallerRunsPolicy(final LongAdder callerRunsCount) {
+        private CountingCallerRunsPolicy(final LongAdder callerRunsCount,
+                final String threadNamePrefix) {
             this.callerRunsCount = Vldtn.requireNonNull(callerRunsCount,
                     "callerRunsCount");
+            this.threadNamePrefix = Vldtn.requireNonNull(threadNamePrefix,
+                    "threadNamePrefix");
         }
 
         @Override
         public void rejectedExecution(final Runnable runnable,
                 final ThreadPoolExecutor executor) {
+            if (executor.isShutdown()) {
+                return;
+            }
             callerRunsCount.increment();
-            delegate.rejectedExecution(runnable, executor);
+            warnOnFirstSaturation(executor);
+            runnable.run();
+        }
+
+        private void warnOnFirstSaturation(
+                final ThreadPoolExecutor executor) {
+            if (saturationWarningLogged.compareAndSet(false, true)) {
+                LOGGER.warn(
+                        "Executor queue saturated for worker prefix '{}'; "
+                                + "running task on caller thread '{}'. "
+                                + "activeThreads={}, poolSize={}, queueSize={}, "
+                                + "queueRemainingCapacity={}. Further "
+                                + "occurrences are counted by callerRunsCount.",
+                        threadNamePrefix, Thread.currentThread().getName(),
+                        executor.getActiveCount(), executor.getPoolSize(),
+                        executor.getQueue().size(),
+                        executor.getQueue().remainingCapacity());
+            }
         }
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/MappedSegmentLeaseService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/MappedSegmentLeaseService.java
@@ -12,8 +12,8 @@ import org.hestiastore.index.segmentindex.SegmentWindow;
 import org.hestiastore.index.segmentindex.core.routing.RouteTopology.RouteDrain;
 import org.hestiastore.index.segmentindex.core.routing.RouteTopology.RouteLease;
 import org.hestiastore.index.segmentindex.core.routing.RouteTopology.RouteLeaseResult;
-import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
 import org.hestiastore.index.segmentindex.routemap.RouteMapSnapshot;
+import org.hestiastore.index.segmentindex.routemap.SegmentRouteMap;
 import org.hestiastore.index.segmentregistry.BlockingSegment;
 import org.hestiastore.index.segmentregistry.SegmentRegistry;
 
@@ -419,7 +419,6 @@ public final class MappedSegmentLeaseService<K, V> {
 
     private boolean isRoutedSegment(final RouteMapSnapshot<K> snapshot,
             final SegmentId segmentId) {
-        return snapshot.getSegmentIds(SegmentWindow.unbounded())
-                .contains(segmentId);
+        return snapshot.containsSegmentId(segmentId);
     }
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/PersistentSegmentRouteMap.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/PersistentSegmentRouteMap.java
@@ -6,7 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -23,7 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Thread-safe persistent route-map implementation backed by a read/write lock.
+ * Thread-safe persistent route-map implementation that publishes immutable
+ * snapshots to readers and serializes mutations with a read/write lock.
  *
  * @param <K> key type
  */
@@ -43,15 +43,20 @@ public final class PersistentSegmentRouteMap<K> extends AbstractCloseableResourc
     private static final SegmentId FIRST_SEGMENT_ID = SegmentId.of(0);
 
     private TreeMap<K, SegmentId> list;
-    private volatile TreeMap<K, SegmentId> snapshot;
+    private volatile RouteMapSnapshot<K> snapshot;
     private final SortedDataFile<K, SegmentId> sdf;
     private final Comparator<K> keyComparator;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
     private boolean isDirty = false;
-    private final AtomicLong version = new AtomicLong(0);
 
+    /**
+     * Opens the persistent route map from the provided directory.
+     *
+     * @param directoryFacade  storage directory
+     * @param keyTypeDescriptor key type descriptor
+     */
     public PersistentSegmentRouteMap(final Directory directoryFacade,
             final TypeDescriptor<K> keyTypeDescriptor) {
         Vldtn.requireNonNull(directoryFacade, "directoryFacade");
@@ -73,7 +78,7 @@ public final class PersistentSegmentRouteMap<K> extends AbstractCloseableResourc
                 list.put(entry.getKey(), entry.getValue());
             }
         }
-        this.snapshot = new TreeMap<>(list);
+        this.snapshot = new RouteMapSnapshot<>(new TreeMap<>(list), 0);
         validateUniqueSegmentIds();
     }
 
@@ -85,9 +90,8 @@ public final class PersistentSegmentRouteMap<K> extends AbstractCloseableResourc
         readLock.lock();
         try {
             ensureOpen();
-            final TreeMap<K, SegmentId> current = snapshot;
             final HashMap<SegmentId, K> seen = new HashMap<>();
-            for (final Map.Entry<K, SegmentId> entry : current.entrySet()) {
+            for (final Map.Entry<K, SegmentId> entry : list.entrySet()) {
                 final K key = entry.getKey();
                 final SegmentId segmentId = entry.getValue();
                 final K oldKey = seen.putIfAbsent(segmentId, key);
@@ -117,32 +121,32 @@ public final class PersistentSegmentRouteMap<K> extends AbstractCloseableResourc
         try {
             ensureOpen();
             Vldtn.requireNonNull(key, "key");
-            final Entry<K, SegmentId> entry = localFindSegmentForKey(key,
-                    snapshot);
-            return entry == null ? null : entry.getValue();
+            return snapshot.findSegmentIdForKey(key);
         } finally {
             readLock.unlock();
         }
     }
 
+    /**
+     * Returns the immutable route-map view currently published to readers.
+     *
+     * @return current route-map snapshot
+     */
     @Override
     public RouteMapSnapshot<K> snapshot() {
-        readLock.lock();
-        try {
-            return new RouteMapSnapshot<>(snapshot, version.get());
-        } finally {
-            readLock.unlock();
-        }
+        return snapshot;
     }
 
+    /**
+     * Returns whether the currently published snapshot has the expected
+     * version.
+     *
+     * @param expectedVersion expected route-map version
+     * @return {@code true} when the published version matches
+     */
     @Override
     public boolean isAtVersion(final long expectedVersion) {
-        readLock.lock();
-        try {
-            return version.get() == expectedVersion;
-        } finally {
-            readLock.unlock();
-        }
+        return snapshot.version() == expectedVersion;
     }
 
     @Override
@@ -500,8 +504,8 @@ public final class PersistentSegmentRouteMap<K> extends AbstractCloseableResourc
     }
 
     private void refreshSnapshot() {
-        snapshot = new TreeMap<>(list);
-        version.incrementAndGet();
+        final long nextVersion = snapshot.version() + 1;
+        snapshot = new RouteMapSnapshot<>(new TreeMap<>(list), nextVersion);
     }
 
     private void ensureOpen() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshot.java
@@ -43,6 +43,17 @@ public final class RouteMapSnapshot<K> {
                 .toList();
     }
 
+    /**
+     * Returns whether this snapshot contains the provided segment id.
+     *
+     * @param segmentId segment id to find
+     * @return {@code true} when the segment id is routed
+     */
+    public boolean containsSegmentId(final SegmentId segmentId) {
+        Vldtn.requireNonNull(segmentId, "segmentId");
+        return map.containsValue(segmentId);
+    }
+
     public long version() {
         return version;
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -143,7 +143,8 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
 
     @Override
     public K checkAndRepairConsistency() {
-        return currentSegment().checkAndRepairConsistency();
+        return runBlocking("checkAndRepairConsistency",
+                Segment::tryCheckAndRepairConsistency);
     }
 
     @Override

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentConcurrencyGateTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentConcurrencyGateTest.java
@@ -133,9 +133,9 @@ class SegmentConcurrencyGateTest {
 
         assertFalse(result.get(1, TimeUnit.SECONDS));
         assertTrue(interruptPreserved.get());
+        assertEquals(SegmentState.READY, gate.getState());
 
         gate.exitRead();
-        assertTrue(gate.finishFreezeToReady());
         waiter.join(1_000);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentConsistencyCheckerTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentConsistencyCheckerTest.java
@@ -1,20 +1,24 @@
 package org.hestiastore.index.segment;
 
-import org.hestiastore.index.OperationResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.IndexException;
+import org.hestiastore.index.OperationResult;
+import org.hestiastore.index.OperationStatus;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -37,30 +41,34 @@ class SegmentConsistencyCheckerTest {
 
     @Test
     void test_noData() {
-        when(segment.openIterator()).thenReturn(OperationResult.ok(iterator));
-        when(segment.getId()).thenReturn(SEGMENT_ID);
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(false);
 
         final Integer lastKey = checker.checkAndRepairConsistency();
+
         assertNull(lastKey);
+        verify(iterator).close();
     }
 
     @Test
     void test_3_records() {
-        when(segment.openIterator()).thenReturn(OperationResult.ok(iterator));
-        when(segment.getId()).thenReturn(SEGMENT_ID);
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(true, true, true, false);
         when(iterator.next()).thenReturn(ENTRY1).thenReturn(ENTRY2)
                 .thenReturn(ENTRY3);
 
         final Integer lastKey = checker.checkAndRepairConsistency();
+
         assertEquals(3, lastKey);
+        verify(iterator).close();
     }
 
     @Test
     void test_same_records() {
-        when(segment.openIterator()).thenReturn(OperationResult.ok(iterator));
-        when(segment.getId()).thenReturn(SEGMENT_ID);
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(true, true, true, false);
         when(iterator.next()).thenReturn(ENTRY1).thenReturn(ENTRY3)
                 .thenReturn(ENTRY3);
@@ -72,12 +80,13 @@ class SegmentConsistencyCheckerTest {
                 "Keys in segment 'segment-00013' are not sorted. "
                         + "Key '3' have to higher than key '3'.",
                 e.getMessage());
+        verify(iterator).close();
     }
 
     @Test
     void test_invalid_order() {
-        when(segment.openIterator()).thenReturn(OperationResult.ok(iterator));
-        when(segment.getId()).thenReturn(SEGMENT_ID);
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.ok(iterator));
         when(iterator.hasNext()).thenReturn(true, true, true, false);
         when(iterator.next()).thenReturn(ENTRY1).thenReturn(ENTRY3)
                 .thenReturn(ENTRY2);
@@ -89,10 +98,40 @@ class SegmentConsistencyCheckerTest {
                 "Keys in segment 'segment-00013' are not sorted. "
                         + "Key '2' have to higher than key '3'.",
                 e.getMessage());
+        verify(iterator).close();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OperationStatus.class,
+            names = { "BUSY", "CLOSED", "ERROR" })
+    void tryCheckAndRepairConsistency_returnsUnavailableStatus(
+            final OperationStatus status) {
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.fromStatus(status));
+
+        final OperationResult<Integer> result = checker
+                .tryCheckAndRepairConsistency();
+
+        assertEquals(status, result.getStatus());
+        assertNull(result.getValue());
+    }
+
+    @Test
+    void checkAndRepairConsistency_reportsUnavailableStatus() {
+        when(segment.openIterator(SegmentIteratorIsolation.FULL_ISOLATION))
+                .thenReturn(OperationResult.busy());
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> checker.checkAndRepairConsistency());
+
+        assertEquals(
+                "Segment 'segment-00013' is not ready for consistency check: BUSY",
+                exception.getMessage());
     }
 
     @BeforeEach
     void setUp() {
+        when(segment.getId()).thenReturn(SEGMENT_ID);
         checker = new SegmentConsistencyChecker<>(segment,
                 TYPE_DESCRIPTOR_INTEGER.getComparator());
     }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
@@ -137,6 +137,30 @@ class SegmentImplConcurrencyContractTest {
     }
 
     @Test
+    void consistencyCheck_isBusyDuringMaintenanceAndSucceedsAfterward() {
+        final CapturingExecutor executor = new CapturingExecutor();
+        final Segment<Integer, String> segment = newSegment(4, executor);
+        try {
+            assertEquals(OperationStatus.OK,
+                    segment.put(1, "a").getStatus());
+            assertEquals(OperationStatus.OK, segment.flush().getStatus());
+            assertEquals(SegmentState.MAINTENANCE_RUNNING, segment.getState());
+
+            assertEquals(OperationStatus.BUSY,
+                    segment.tryCheckAndRepairConsistency().getStatus());
+
+            executor.runTask();
+
+            final OperationResult<Integer> result = segment
+                    .tryCheckAndRepairConsistency();
+            assertEquals(OperationStatus.OK, result.getStatus());
+            assertEquals(1, result.getValue());
+        } finally {
+            closeAfterMaintenanceIfNeeded(segment, executor);
+        }
+    }
+
+    @Test
     void put_returns_writeCacheFull_when_write_cache_full_and_no_maintenance_policy() {
         final Segment<Integer, String> segment = newSegment(1);
         try {

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
@@ -747,6 +747,29 @@ class SegmentImplTest {
     }
 
     @Test
+    void tryCheckAndRepairConsistency_empty_returns_ok() {
+        when(indexIterator.hasNext()).thenReturn(false);
+
+        final OperationResult<Integer> result = subject
+                .tryCheckAndRepairConsistency();
+
+        assertEquals(OperationStatus.OK, result.getStatus());
+        assertNull(result.getValue());
+    }
+
+    @Test
+    void tryCheckAndRepairConsistency_iteratorFailure_returns_error() {
+        when(chunkPairFile.openIterator())
+                .thenThrow(new RuntimeException("boom"));
+
+        final OperationResult<Integer> result = subject
+                .tryCheckAndRepairConsistency();
+
+        assertEquals(OperationStatus.ERROR, result.getStatus());
+        assertEquals(SegmentState.ERROR, subject.getState());
+    }
+
+    @Test
     void checkAndRepairConsistency_invalid_order_throws() {
         when(indexIterator.hasNext()).thenReturn(true, true, true, false);
         when(indexIterator.next()).thenReturn(Entry.of(1, "a"))

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentReadPathTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentReadPathTest.java
@@ -10,11 +10,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.intThat;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
@@ -26,6 +35,8 @@ import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.FileReaderSeekable;
+import org.hestiastore.index.directory.FileReaderSeekableSupplier;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +67,10 @@ class SegmentReadPathTest {
     private EntryIteratorWithCurrent<Integer, String> baseIterator;
     @Mock
     private FileReaderSeekable seekableReader;
+    @Mock
+    private FileReaderSeekableSupplier firstSeekableReaderSupplier;
+    @Mock
+    private FileReaderSeekableSupplier secondSeekableReaderSupplier;
 
     private SegmentReadPath<Integer, String> subject;
     private final TypeDescriptorInteger keyDescriptor = new TypeDescriptorInteger();
@@ -94,6 +109,11 @@ class SegmentReadPathTest {
         when(baseIterator.hasNext()).thenReturn(false);
         subject = new SegmentReadPath<>(segmentFiles, conf, segmentResources,
                 segmentSearcher, segmentCache, versionController);
+    }
+
+    @AfterEach
+    void tearDown() {
+        subject.close();
     }
 
     @Test
@@ -159,5 +179,50 @@ class SegmentReadPathTest {
                 .getSegmentIndexSearcher();
         assertNotNull(third);
         assertNotSame(first, third);
+    }
+
+    @Test
+    void getSegmentIndexSearcher_closes_concurrent_cas_loser()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        final CountDownLatch suppliersRequested = new CountDownLatch(2);
+        final CountDownLatch allowConstruction = new CountDownLatch(1);
+        final AtomicInteger supplierIndex = new AtomicInteger();
+        final AtomicInteger closedSupplierCount = new AtomicInteger();
+        doAnswer(invocation -> closedSupplierCount.incrementAndGet())
+                .when(firstSeekableReaderSupplier).close();
+        doAnswer(invocation -> closedSupplierCount.incrementAndGet())
+                .when(secondSeekableReaderSupplier).close();
+        when(asyncDirectory.getFileReaderSeekableSupplier("segment.index"))
+                .thenAnswer(invocation -> {
+                    final int index = supplierIndex.getAndIncrement();
+                    suppliersRequested.countDown();
+                    allowConstruction.await();
+                    return index == 0 ? firstSeekableReaderSupplier
+                            : secondSeekableReaderSupplier;
+                });
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            final Future<SegmentIndexSearcher<Integer, String>> firstFuture = executor
+                    .submit(subject::getSegmentIndexSearcher);
+            final Future<SegmentIndexSearcher<Integer, String>> secondFuture = executor
+                    .submit(subject::getSegmentIndexSearcher);
+            assertTrue(suppliersRequested.await(5, TimeUnit.SECONDS));
+            allowConstruction.countDown();
+
+            assertSame(firstFuture.get(5, TimeUnit.SECONDS),
+                    secondFuture.get(5, TimeUnit.SECONDS));
+            assertEquals(2, supplierIndex.get());
+            assertEquals(1, closedSupplierCount.get());
+
+            subject.close();
+
+            assertEquals(2, closedSupplierCount.get());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } finally {
+            allowConstruction.countDown();
+            executor.shutdownNow();
+        }
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentTest.java
@@ -1,12 +1,14 @@
 package org.hestiastore.index.segment;
 
-import org.hestiastore.index.OperationResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.OperationResult;
+import org.hestiastore.index.OperationStatus;
 import org.junit.jupiter.api.Test;
 
 class SegmentTest {
@@ -19,6 +21,20 @@ class SegmentTest {
 
             assertEquals(SegmentIteratorIsolation.FAIL_FAST,
                     segment.getLastIsolation());
+        } finally {
+            segment.close();
+        }
+    }
+
+    @Test
+    void tryCheckAndRepairConsistencyDefaultsToExistingCheck() {
+        final StubSegment segment = new StubSegment();
+        try {
+            final OperationResult<Integer> result = segment
+                    .tryCheckAndRepairConsistency();
+
+            assertEquals(OperationStatus.OK, result.getStatus());
+            assertNull(result.getValue());
         } finally {
             segment.close();
         }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ObservedThreadPoolFactoryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/executorregistry/ObservedThreadPoolFactoryTest.java
@@ -4,10 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.Test;
 
 class ObservedThreadPoolFactoryTest {
@@ -36,7 +46,27 @@ class ObservedThreadPoolFactoryTest {
     }
 
     @Test
-    void createCallerRunsPoolTracksCallerRuns() {
+    void createCallerRunsPoolTracksCallerRunsAndWarnsOnce() {
+        final String warningPrefix = "Executor queue saturated for worker "
+                + "prefix 'caller-runs-test-'";
+        final List<LogEvent> logEvents = Collections
+                .synchronizedList(new ArrayList<>());
+        final LoggerContext context = (LoggerContext) LogManager
+                .getContext(false);
+        final Configuration configuration = context.getConfiguration();
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig(
+                ObservedThreadPoolFactory.class.getName());
+        final AbstractAppender appender = new AbstractAppender(
+                "caller-runs-test-appender", null, null, false, null) {
+
+            @Override
+            public void append(final LogEvent event) {
+                logEvents.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        loggerConfig.addAppender(appender, Level.WARN, null);
+        context.updateLoggers();
         final ObservedThreadPool pool = new ObservedThreadPoolFactory()
                 .createCallerRunsPool(1, "segmentMaintenanceThreads",
                         "caller-runs-test-");
@@ -50,12 +80,46 @@ class ObservedThreadPoolFactoryTest {
 
             executor.execute(() -> {
             });
+            executor.execute(() -> {
+            });
 
-            assertEquals(1L, pool.statsSnapshot().getCallerRunsCount());
+            assertEquals(2L, pool.statsSnapshot().getCallerRunsCount());
+            final List<LogEvent> saturationWarnings;
+            synchronized (logEvents) {
+                saturationWarnings = logEvents.stream()
+                        .filter(event -> event.getLevel() == Level.WARN)
+                        .filter(event -> event.getMessage()
+                                .getFormattedMessage()
+                                .startsWith(warningPrefix))
+                        .toList();
+            }
+            assertEquals(1, saturationWarnings.size());
+            final String warning = saturationWarnings.get(0).getMessage()
+                    .getFormattedMessage();
+            assertTrue(warning.contains("caller thread '"
+                    + Thread.currentThread().getName() + "'"));
+            assertTrue(warning.contains("queueRemainingCapacity=0"));
         } finally {
             blocker.countDown();
             executor.shutdownNow();
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            context.updateLoggers();
         }
+    }
+
+    @Test
+    void createCallerRunsPoolDoesNotCountDiscardAfterShutdown() {
+        final ObservedThreadPool pool = new ObservedThreadPoolFactory()
+                .createCallerRunsPool(1, "segmentMaintenanceThreads",
+                        "caller-runs-shutdown-test-");
+        final ExecutorService executor = pool.executor();
+
+        executor.shutdown();
+        executor.execute(() -> {
+        });
+
+        assertEquals(0L, pool.statsSnapshot().getCallerRunsCount());
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotTest.java
@@ -1,0 +1,34 @@
+package org.hestiastore.index.segmentindex.routemap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.TreeMap;
+
+import org.hestiastore.index.segment.SegmentId;
+import org.junit.jupiter.api.Test;
+
+class RouteMapSnapshotTest {
+
+    @Test
+    void containsSegmentIdFindsMappedSegment() {
+        final TreeMap<Integer, SegmentId> routes = new TreeMap<>();
+        routes.put(10, SegmentId.of(1));
+        routes.put(20, SegmentId.of(2));
+        final RouteMapSnapshot<Integer> snapshot = new RouteMapSnapshot<>(
+                routes, 0);
+
+        assertTrue(snapshot.containsSegmentId(SegmentId.of(2)));
+        assertFalse(snapshot.containsSegmentId(SegmentId.of(3)));
+    }
+
+    @Test
+    void containsSegmentIdRejectsNull() {
+        final RouteMapSnapshot<Integer> snapshot = new RouteMapSnapshot<>(
+                new TreeMap<>(), 0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> snapshot.containsSegmentId(null));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMapSplitConcurrencyTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMapSplitConcurrencyTest.java
@@ -53,23 +53,41 @@ class SegmentRouteMapSplitConcurrencyTest {
     }
 
     @Test
-    void concurrent_get_put_during_split_never_sees_missing_mapping() {
-        final AtomicBoolean missing = new AtomicBoolean(false);
+    void concurrentSnapshotsDuringSplitKeepRoutesAndVersionTogether() {
+        final RouteMapSnapshot<Integer> initial = adapter.snapshot();
+        final long initialVersion = initial.version();
+        final SegmentId initialSegmentId = SegmentId.of(1);
+        final SegmentId splitSegmentId = SegmentId.of(3);
+        final AtomicBoolean keepReading = new AtomicBoolean(true);
+        final AtomicBoolean inconsistent = new AtomicBoolean(false);
         final AtomicInteger nextKey = new AtomicInteger(31);
         final CountDownLatch ready = new CountDownLatch(2);
         final CountDownLatch start = new CountDownLatch(1);
         final CountDownLatch startedOps = new CountDownLatch(2);
+        final CountDownLatch publishedSeen = new CountDownLatch(1);
 
         final Future<?> reader = executor.submit(() -> {
             ready.countDown();
             await(start);
-            for (int i = 0; i < 1_000; i++) {
-                if (adapter.findSegmentIdForKey(5) == null) {
-                    missing.set(true);
+            startedOps.countDown();
+            while (keepReading.get()) {
+                final RouteMapSnapshot<Integer> current = adapter.snapshot();
+                final SegmentId routedSegmentId = current
+                        .findSegmentIdForKey(5);
+                if (current.version() == initialVersion) {
+                    if (!initialSegmentId.equals(routedSegmentId)) {
+                        inconsistent.set(true);
+                        break;
+                    }
+                } else if (current.version() == initialVersion + 1) {
+                    if (!splitSegmentId.equals(routedSegmentId)) {
+                        inconsistent.set(true);
+                        break;
+                    }
+                    publishedSeen.countDown();
+                } else {
+                    inconsistent.set(true);
                     break;
-                }
-                if (i == 0) {
-                    startedOps.countDown();
                 }
             }
         });
@@ -90,18 +108,27 @@ class SegmentRouteMapSplitConcurrencyTest {
         assertTrue(await(startedOps, 5),
                 "Workers did not perform initial ops in time");
 
-        assertTrue(adapter.tryReplaceRouteWithSplit(plan));
-        adapter.flushIfDirty();
+        try {
+            assertTrue(adapter.tryReplaceRouteWithSplit(plan));
+            assertTrue(await(publishedSeen, 5),
+                    "Reader did not observe the published split in time");
+            adapter.flushIfDirty();
+        } finally {
+            keepReading.set(false);
+        }
 
         awaitFuture(reader, "Reader did not finish in time");
         awaitFuture(writer, "Writer did not finish in time");
 
-        assertFalse(missing.get());
+        assertFalse(inconsistent.get());
     }
 
     private void awaitFuture(final Future<?> future, final String message) {
         try {
             future.get(5, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail(message + ": " + e.getMessage());
         } catch (final Exception e) {
             fail(message + ": " + e.getMessage());
         }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMapTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMapTest.java
@@ -2,6 +2,8 @@ package org.hestiastore.index.segmentindex.routemap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,9 +62,30 @@ class SegmentRouteMapTest {
 
         cache.extendMaxKeyIfNeeded(20);
 
+        assertSame(before, cache.snapshot());
         assertTrue(cache.isAtVersion(before.version()));
         assertEquals(segmentIdsBefore, cache.getSegmentIds());
         assertEquals(SegmentId.of(0), cache.findSegmentIdForKey(20));
+    }
+
+    @Test
+    void snapshotReusesPublishedInstanceUntilRouteChanges() {
+        final PersistentSegmentRouteMap<Integer> cache = newCacheWithEntries(
+                List.of());
+        final RouteMapSnapshot<Integer> initial = cache.snapshot();
+
+        assertSame(initial, cache.snapshot());
+
+        cache.extendMaxKeyIfNeeded(10);
+        final RouteMapSnapshot<Integer> published = cache.snapshot();
+
+        assertNotSame(initial, published);
+        assertEquals(initial.version() + 1, published.version());
+        assertSame(published, cache.snapshot());
+
+        cache.extendMaxKeyIfNeeded(20);
+
+        assertSame(published, cache.snapshot());
     }
 
     @Test
@@ -159,7 +182,44 @@ class SegmentRouteMapTest {
 
         assertEquals(before.getSegmentIds(SegmentWindow.unbounded()),
                 cache.getSegmentIds());
+        assertSame(before, cache.snapshot());
         assertTrue(cache.isAtVersion(before.version()));
+    }
+
+    @Test
+    void directMutationsPublishExactlyOneNewSnapshot() {
+        final PersistentSegmentRouteMap<Integer> cache = newCacheWithEntries(
+                List.of());
+        RouteMapSnapshot<Integer> previous = cache.snapshot();
+
+        cache.insertKeyToSegment(10);
+        RouteMapSnapshot<Integer> current = cache.snapshot();
+        assertNotSame(previous, current);
+        assertEquals(previous.version() + 1, current.version());
+        previous = current;
+
+        cache.insertKeyToSegment(11);
+        assertSame(previous, cache.snapshot());
+
+        cache.insertSegment(20, SegmentId.of(1));
+        current = cache.snapshot();
+        assertNotSame(previous, current);
+        assertEquals(previous.version() + 1, current.version());
+        previous = current;
+
+        cache.updateSegmentMaxKey(SegmentId.of(1), 30);
+        current = cache.snapshot();
+        assertNotSame(previous, current);
+        assertEquals(previous.version() + 1, current.version());
+        previous = current;
+
+        cache.removeSegmentRoute(SegmentId.of(1));
+        current = cache.snapshot();
+        assertNotSame(previous, current);
+        assertEquals(previous.version() + 1, current.version());
+
+        cache.removeSegmentRoute(SegmentId.of(1));
+        assertSame(current, cache.snapshot());
     }
 
     @Test
@@ -232,7 +292,11 @@ class SegmentRouteMapTest {
 
         assertEquals(List.of(SegmentId.of(1), SegmentId.of(2), SegmentId.of(3)),
                 snapshot.getSegmentIds(SegmentWindow.unbounded()));
-        assertTrue(cache.isAtVersion(cache.snapshot().version()));
+        final RouteMapSnapshot<Integer> published = cache.snapshot();
+        assertNotSame(snapshot, published);
+        assertEquals(snapshot.version() + 1, published.version());
+        assertSame(published, cache.snapshot());
+        assertTrue(cache.isAtVersion(published.version()));
         assertFalse(cache.isAtVersion(snapshot.version()));
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentregistry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -117,6 +118,104 @@ class DefaultBlockingSegmentTest {
         when(segment.compact()).thenReturn(OperationResult.error());
 
         assertThrows(IndexException.class, () -> handle.compact());
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void checkAndRepairConsistencyRetriesBusyStatusUntilSuccessful() {
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.busy())
+                .thenReturn(OperationResult.ok(17));
+
+        assertEquals(17, handle.checkAndRepairConsistency());
+        verify(segment, times(2)).tryCheckAndRepairConsistency();
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void checkAndRepairConsistencyReturnsNullForEmptySegment() {
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.ok(null));
+
+        assertNull(handle.checkAndRepairConsistency());
+        verify(segment).tryCheckAndRepairConsistency();
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void checkAndRepairConsistencyReloadsClosedSegment() {
+        final Segment<Integer, String> reloadedSegment = mockSegment();
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.closed());
+        when(segmentRegistry.loadSegment(SEGMENT_ID))
+                .thenReturn(reloadedSegment);
+        when(reloadedSegment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.ok(19));
+
+        assertEquals(19, handle.checkAndRepairConsistency());
+        verify(segmentRegistry).loadSegment(SEGMENT_ID);
+        verify(reloadedSegment).tryCheckAndRepairConsistency();
+    }
+
+    @Test
+    void checkAndRepairConsistencyTimesOutWhenBusyPersists() {
+        handle = newHandle(new BusyRetryPolicy(1, 5), false);
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.busy());
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> handle.checkAndRepairConsistency());
+
+        assertTrue(exception.getMessage().contains(
+                "'checkAndRepairConsistency' timed out after 5 ms"));
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void checkAndRepairConsistencyPreservesInterrupt() {
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.busy());
+
+        try {
+            Thread.currentThread().interrupt();
+
+            final IndexException exception = assertThrows(IndexException.class,
+                    () -> handle.checkAndRepairConsistency());
+
+            assertTrue(exception.getMessage().contains(
+                    "'checkAndRepairConsistency' was interrupted"));
+            assertTrue(Thread.currentThread().isInterrupted());
+            verifyNoInteractions(segmentRegistry);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void checkAndRepairConsistencyDoesNotRetryErrorStatus() {
+        when(segment.tryCheckAndRepairConsistency())
+                .thenReturn(OperationResult.error());
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> handle.checkAndRepairConsistency());
+
+        assertEquals(
+                "Segment 'segment-00007' failed to checkAndRepairConsistency: ERROR",
+                exception.getMessage());
+        verify(segment).tryCheckAndRepairConsistency();
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void checkAndRepairConsistencyPropagatesCorruption() {
+        final IndexException corruption = new IndexException("broken keys");
+        when(segment.tryCheckAndRepairConsistency()).thenThrow(corruption);
+
+        final IndexException exception = assertThrows(IndexException.class,
+                () -> handle.checkAndRepairConsistency());
+
+        assertSame(corruption, exception);
+        verify(segment).tryCheckAndRepairConsistency();
         verifyNoInteractions(segmentRegistry);
     }
 


### PR DESCRIPTION
Closes #326

## Summary

- publish immutable route-map state through a volatile snapshot so point-operation snapshot and version reads avoid the route-map read lock
- replace temporary segment-ID list construction with direct snapshot membership checks
- close the losing searcher when concurrent first access races to initialize `SegmentReadPath`
- reduce executor-observation overhead and make benchmark MDC/context logging explicit
- make consistency checks acquire full segment isolation and use the existing bounded `BUSY`/`CLOSED` retry policy, so an asynchronous flush cannot leak a transient segment state through the public maintenance API
- release interrupted exclusive acquisition back to `READY` and cover timeout, interruption, reload, terminal error, corruption, empty-segment, and iterator-failure paths
- add focused concurrency, resource-cleanup, snapshot, benchmark-profile, and script tests
- record the measured refactoring boundary and deferred candidates in the architecture and refactoring documentation

## Why

The point-operation path still contained secondary locking and allocation costs after the larger synchronization bottlenecks were addressed. The changes keep mutation coordination intact while removing avoidable foreground-read work and fixing a concurrent resource leak. Benchmark infrastructure was also made production-context-aware so later comparisons do not silently include logging overhead.

The consistency checker previously bypassed `DefaultBlockingSegment` retry handling and opened a fail-fast iterator. Because `flush()` returns after scheduling asynchronous work, the segment could enter maintenance before the immediate consistency check acquired its iterator, exposing `BUSY` as an `IndexException`. The checker now returns retryable operation status to the blocking facade and holds full isolation for the complete scan.

## Impact and measurements

The focused 50,000-segment membership benchmark improved from `323.428 us/op` and about `200 KB/op` to `115.267 us/op` with effectively zero per-call allocation (`2.81x` faster).

The final whole-path JMH comparison was noisy and contradictory. Focused five-fork live-get and hot-put confidence intervals overlapped, so this PR deliberately makes no whole-application throughput claim. JFR did not justify the deferred result-singleton, latency sampling, chunk-cache, or immutable ID-set redesigns. Item `100.6` remains open for a repeat on a quiet dedicated host.

Consistency checks now hold exclusive access to each segment while scanning. Competing operations wait or retry within the configured busy timeout instead of observing a transient `BUSY` failure.

## Latest devel merge

The branch includes `devel` at `fc1aa7d79`. The two overlapping benchmark conflicts were resolved in favor of latest `devel`: its setup-only segment-cache capacity replaces the superseded final-flush workaround, and its complete-result validation includes the empty-result guard originally added here. All other PR changes remain in the diff.

## Validation

- `mvn clean verify` after merging latest `devel`
- `ExampleIT` repeated 10/10 times; the post-merge full reactor verification also passed
- focused consistency, segment-gate, blocking-retry, and concurrency tests
- `mvn -pl benchmarks -am -DskipTests=false -Dtest=BenchmarkProfileContractTest,BenchmarkHistoryScriptsSmokeTest,MutationFlushCoordinatorTest,SegmentIndexPersistedMutationBenchmarkTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `python3 scripts/check_docs_nav.py`
- `mkdocs build --strict`
- `git diff --check`
- canonical baseline/candidate JMH profile plus focused five-fork GC and JFR runs