### PR TITLE
Stabilize canonical SegmentIndex benchmarks

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -163,40 +163,46 @@ jobs:
 
     - name: Detect fallback baseline compatibility
       id: fallback-compat
-      if: steps.stored-baseline.outputs.baseline_summary == ''
       shell: bash
       run: |
         set -euo pipefail
 
         PROFILE_PATH="benchmarks/profiles/${{ steps.refs.outputs.profile }}.json"
         CAN_RUN="true"
-
-        if ! git cat-file -e "${{ steps.refs.outputs.fallback_baseline_ref }}:${PROFILE_PATH}" 2>/dev/null; then
-          CAN_RUN="false"
-        fi
-        if [ "${CAN_RUN}" = "true" ]; then
-          while IFS= read -r BENCHMARK_CLASS_PATH; do
-            if ! git cat-file -e "${{ steps.refs.outputs.fallback_baseline_ref }}:${BENCHMARK_CLASS_PATH}" 2>/dev/null; then
-              CAN_RUN="false"
-              break
-            fi
-          done < <(python3 - <<'PY'
+        mapfile -t BENCHMARK_SOURCE_PATHS < <(python3 - <<'PY'
         import json
         from pathlib import Path
 
         profile_path = Path("benchmarks/profiles/${{ steps.refs.outputs.profile }}.json")
         profile = json.loads(profile_path.read_text(encoding="utf-8"))
-        paths = []
+        paths = list(profile.get("supportSources", []))
         for benchmark in profile.get("benchmarks", []):
             include = benchmark.get("include")
-            if not include:
-                continue
-            relative = "benchmarks/src/main/java/" + include.replace(".", "/") + ".java"
-            paths.append(relative)
+            if include:
+                paths.append(
+                    "benchmarks/src/main/java/" + include.replace(".", "/") + ".java"
+                )
         for path in sorted(set(paths)):
             print(path)
         PY
-          )
+        )
+
+        if ! git cat-file -e "${{ steps.refs.outputs.fallback_baseline_ref }}:${PROFILE_PATH}" 2>/dev/null; then
+          CAN_RUN="false"
+        fi
+        if [ "${CAN_RUN}" = "true" ]; then
+          for BENCHMARK_CLASS_PATH in "${BENCHMARK_SOURCE_PATHS[@]}"; do
+            if ! git cat-file -e "${{ steps.refs.outputs.fallback_baseline_ref }}:${BENCHMARK_CLASS_PATH}" 2>/dev/null; then
+              CAN_RUN="false"
+              break
+            fi
+          done
+        fi
+        if [ "${CAN_RUN}" = "true" ] && ! git diff --quiet \
+          "${{ steps.refs.outputs.fallback_baseline_ref }}" \
+          "${{ steps.refs.outputs.candidate_ref }}" -- \
+          "${PROFILE_PATH}" "${BENCHMARK_SOURCE_PATHS[@]}"; then
+          CAN_RUN="false"
         fi
 
         echo "can_run=${CAN_RUN}" >> "${GITHUB_OUTPUT}"
@@ -231,7 +237,8 @@ jobs:
         set -euo pipefail
 
         BASELINE_SUMMARY=""
-        if python3 benchmarks/scripts/resolve_jmh_history_baseline.py \
+        if [ "${{ steps.fallback-compat.outputs.can_run }}" = "true" ] && \
+          python3 benchmarks/scripts/resolve_jmh_history_baseline.py \
           --history-dir "${{ steps.history.outputs.history_dir }}" \
           --profile "${{ steps.refs.outputs.profile }}" \
           --profile-spec "${GITHUB_WORKSPACE}/benchmarks/profiles/${{ steps.refs.outputs.profile }}.json" \
@@ -249,7 +256,8 @@ jobs:
         set -euo pipefail
 
         PREVIOUS_PR_SUMMARY=""
-        if python3 benchmarks/scripts/resolve_jmh_history_baseline.py \
+        if [ "${{ steps.fallback-compat.outputs.can_run }}" = "true" ] && \
+          python3 benchmarks/scripts/resolve_jmh_history_baseline.py \
           --history-dir "${{ steps.history.outputs.history_dir }}" \
           --profile "${{ steps.refs.outputs.profile }}" \
           --profile-spec "${GITHUB_WORKSPACE}/benchmarks/profiles/${{ steps.refs.outputs.profile }}.json" \

--- a/benchmarks/profiles/segment-index-nightly.json
+++ b/benchmarks/profiles/segment-index-nightly.json
@@ -1,10 +1,20 @@
 {
   "profile": "segment-index-nightly",
   "description": "Longer canonical SegmentIndex benchmark set for trend tracking on main/nightly runs.",
+  "supportSources": [
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/AbstractSegmentIndexGetBenchmark.java",
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinator.java",
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java"
+  ],
   "benchmarks": [
     {
       "label": "segment-index-get-persisted",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 4,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -22,6 +32,11 @@
     {
       "label": "segment-index-get-live",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 4,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -39,6 +54,11 @@
     {
       "label": "segment-index-get-multisegment-hot",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -57,6 +77,11 @@
     {
       "label": "segment-index-get-multisegment-cold",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -75,6 +100,11 @@
     {
       "label": "segment-index-persisted-mutation",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.deleteSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.putSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -92,6 +122,11 @@
     {
       "label": "segment-index-persisted-mutation-concurrent",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.deleteSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.putSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -109,6 +144,12 @@
     {
       "label": "segment-index-lifecycle",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexLifecycleBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexLifecycleBenchmark.openAndCheckAndRepairConsistency",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexLifecycleBenchmark.openAndCompact",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexLifecycleBenchmark.openExisting"
+      ],
+      "expectedResultCount": 3,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -124,6 +165,11 @@
     {
       "label": "segment-index-hot-route-put",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark.putHotRoute",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark.putThenGetHotRoute"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -135,6 +181,10 @@
     {
       "label": "segment-index-mixed-drain",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark.partitionedIngestMixed"
+      ],
+      "expectedResultCount": 1,
       "args": [
         "-wi", "2",
         "-i", "5",
@@ -148,6 +198,10 @@
     {
       "label": "segment-index-mixed-split-heavy",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark.partitionedIngestMixed"
+      ],
+      "expectedResultCount": 1,
       "args": [
         "-wi", "2",
         "-i", "5",

--- a/benchmarks/profiles/segment-index-pr-smoke.json
+++ b/benchmarks/profiles/segment-index-pr-smoke.json
@@ -1,10 +1,20 @@
 {
   "profile": "segment-index-pr-smoke",
   "description": "Short canonical SegmentIndex benchmark set for per-change comparison.",
+  "supportSources": [
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/AbstractSegmentIndexGetBenchmark.java",
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinator.java",
+    "benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java"
+  ],
   "benchmarks": [
     {
       "label": "segment-index-get-persisted",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 4,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -22,6 +32,11 @@
     {
       "label": "segment-index-get-live",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 4,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -39,6 +54,11 @@
     {
       "label": "segment-index-get-multisegment-hot",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getHitSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark.getMissSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -57,6 +77,11 @@
     {
       "label": "segment-index-persisted-mutation",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.deleteSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.putSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -74,6 +99,11 @@
     {
       "label": "segment-index-persisted-mutation-concurrent",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.deleteSync",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.putSync"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -91,6 +121,11 @@
     {
       "label": "segment-index-hot-route-put",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark.putHotRoute",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexHotRoutePutBenchmark.putThenGetHotRoute"
+      ],
+      "expectedResultCount": 2,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -102,6 +137,10 @@
     {
       "label": "segment-index-mixed-drain",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark.partitionedIngestMixed"
+      ],
+      "expectedResultCount": 1,
       "args": [
         "-wi", "1",
         "-i", "3",
@@ -115,6 +154,10 @@
     {
       "label": "segment-index-mixed-split-heavy",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexMixedDrainBenchmark.partitionedIngestMixed"
+      ],
+      "expectedResultCount": 1,
       "args": [
         "-wi", "1",
         "-i", "3",

--- a/benchmarks/scripts/resolve_jmh_history_baseline.py
+++ b/benchmarks/scripts/resolve_jmh_history_baseline.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -20,6 +21,10 @@ def parse_args() -> argparse.Namespace:
 
 def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def profile_fingerprint(profile_spec_path: Path) -> str:
+    return hashlib.sha256(profile_spec_path.read_bytes()).hexdigest()
 
 
 def load_expected_benchmark_labels(profile_spec_path: Path) -> list[str] | None:
@@ -72,6 +77,10 @@ def main() -> int:
         if expected_labels is None:
             return 1
         summary = load_json(summary_path)
+        if summary.get("profileFingerprint") != profile_fingerprint(
+            profile_spec_path
+        ):
+            return 1
         if not has_complete_profile_coverage(summary, expected_labels):
             return 1
     print(summary_path)

--- a/benchmarks/scripts/run_jmh_profile.py
+++ b/benchmarks/scripts/run_jmh_profile.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -122,8 +123,32 @@ def host_metadata() -> dict[str, Any]:
     }
 
 
-def normalize_result(result_path: Path) -> dict[str, Any]:
+def profile_fingerprint(profile_path: Path) -> str:
+    return hashlib.sha256(profile_path.read_bytes()).hexdigest()
+
+
+def normalize_result(
+    result_path: Path,
+    expected_benchmarks: list[str] | None = None,
+    expected_result_count: int | None = None,
+) -> dict[str, Any]:
     rows = json.loads(result_path.read_text(encoding="utf-8"))
+    actual_benchmarks = {row["benchmark"] for row in rows}
+    expected = set(expected_benchmarks or [])
+    if not rows:
+        raise ValueError(f"JMH produced no benchmark results in {result_path}.")
+    if expected_result_count is not None and len(rows) != expected_result_count:
+        raise ValueError(
+            f"JMH produced {len(rows)} benchmark results in {result_path}; "
+            f"expected {expected_result_count}."
+        )
+    if expected and actual_benchmarks != expected:
+        missing = sorted(expected - actual_benchmarks)
+        unexpected = sorted(actual_benchmarks - expected)
+        raise ValueError(
+            f"JMH produced incomplete benchmark results in {result_path}; "
+            f"missing={missing}, unexpected={unexpected}."
+        )
     normalized_rows = []
     for row in rows:
         normalized_rows.append({
@@ -170,6 +195,7 @@ def main() -> int:
     run_summary: dict[str, Any] = {
         "profile": profile["profile"],
         "description": profile.get("description", ""),
+        "profileFingerprint": profile_fingerprint(profile_path),
         "timestampUtc": datetime.now(timezone.utc).isoformat(),
         "repoRoot": str(repo_root),
         "jar": str(jar_path),
@@ -184,7 +210,11 @@ def main() -> int:
         log_path = logs_dir / f"{label}.log"
         cmd = ["java", "-jar", str(jar_path), benchmark["include"], *benchmark["args"], "-rf", "json", "-rff", str(raw_path)]
         run_command(cmd, cwd=repo_root, stdout_path=log_path)
-        normalized = normalize_result(raw_path)
+        normalized = normalize_result(
+            raw_path,
+            benchmark.get("expectedBenchmarks"),
+            benchmark.get("expectedResultCount"),
+        )
         run_summary["benchmarks"].append({
             "label": label,
             "include": benchmark["include"],

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/AbstractSegmentIndexGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/AbstractSegmentIndexGetBenchmark.java
@@ -23,14 +23,15 @@ public abstract class AbstractSegmentIndexGetBenchmark {
     @Setup(Level.Trial)
     public final void setup() throws IOException {
         tempDir = SegmentIndexBenchmarkSupport.createTempDir(tempDirPrefix());
-        final IndexConfiguration<Integer, String> conf = buildConfiguration();
+        final IndexConfiguration<Integer, String> setupConf = buildSetupConfiguration();
 
         try (SegmentIndex<Integer, String> created = SegmentIndex
-                .create(new FsDirectory(tempDir), conf)) {
+                .create(new FsDirectory(tempDir), setupConf)) {
             populateIndex(created);
             afterCreate(created);
         }
 
+        final IndexConfiguration<Integer, String> conf = buildConfiguration();
         index = SegmentIndex.open(new FsDirectory(tempDir), conf);
         configureReadState(index);
     }
@@ -59,6 +60,17 @@ public abstract class AbstractSegmentIndexGetBenchmark {
     }
 
     protected abstract String tempDirPrefix();
+
+    /**
+     * Builds the configuration used while creating persisted benchmark data.
+     * Subclasses may provide additional setup-only capacity without changing
+     * the measured reopen configuration.
+     *
+     * @return setup configuration
+     */
+    protected IndexConfiguration<Integer, String> buildSetupConfiguration() {
+        return buildConfiguration();
+    }
 
     protected abstract IndexConfiguration<Integer, String> buildConfiguration();
 

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinator.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinator.java
@@ -1,0 +1,48 @@
+package org.hestiastore.benchmark.segmentindex;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Coordinates one aggregate periodic flush across concurrent benchmark
+ * writers.
+ */
+final class MutationFlushCoordinator {
+
+    private final AtomicInteger pendingMutations = new AtomicInteger();
+    private final AtomicBoolean flushInProgress = new AtomicBoolean();
+
+    /**
+     * Records one mutation and claims the flush gate when the aggregate
+     * threshold has been reached.
+     *
+     * @param flushBatchSize aggregate mutation count between flushes
+     * @return true when the caller owns the flush gate
+     */
+    boolean recordAndTryStartFlush(final int flushBatchSize) {
+        final int pending = pendingMutations.incrementAndGet();
+        if (pending < flushBatchSize
+                || !flushInProgress.compareAndSet(false, true)) {
+            return false;
+        }
+        if (pendingMutations.getAndSet(0) >= flushBatchSize) {
+            return true;
+        }
+        flushInProgress.set(false);
+        return false;
+    }
+
+    /**
+     * Releases the flush gate after the owning caller completes its flush.
+     */
+    void finishFlush() {
+        flushInProgress.set(false);
+    }
+
+    /**
+     * Clears mutations retained for the next periodic flush.
+     */
+    void reset() {
+        pendingMutations.set(0);
+    }
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
@@ -51,12 +51,22 @@ public class SegmentIndexMultiSegmentGetBenchmark
     }
 
     @Override
+    protected IndexConfiguration<Integer, String> buildSetupConfiguration() {
+        return buildConfiguration(Math.max(maxSegmentsInCache, keyCount));
+    }
+
+    @Override
     protected IndexConfiguration<Integer, String> buildConfiguration() {
+        return buildConfiguration(maxSegmentsInCache);
+    }
+
+    private IndexConfiguration<Integer, String> buildConfiguration(
+            final int cachedSegmentLimit) {
         final var builder = SegmentIndexBenchmarkSupport
                 .baseBuilder("segment-index-multi-segment-get-benchmark")//
                 .segment(segment -> segment.cacheKeyLimit(32)
                         .chunkKeyLimit(64).maxKeys(maxKeysInSegment)
-                        .cachedSegmentLimit(maxSegmentsInCache)
+                        .cachedSegmentLimit(cachedSegmentLimit)
                         .deltaCacheFileLimit(2))//
                 .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(256)
                         .maintenanceWriteCacheKeyLimit(512)
@@ -77,9 +87,8 @@ public class SegmentIndexMultiSegmentGetBenchmark
 
     @Override
     protected void populateIndex(final SegmentIndex<Integer, String> created) {
-        final int flushBatchSize = Math.max(512, maxKeysInSegment / 2);
         SegmentIndexBenchmarkSupport.populateSequential(created, keyCount,
-                flushBatchSize, this::buildValue);
+                keyCount, this::buildValue);
     }
 
     @Override
@@ -88,7 +97,6 @@ public class SegmentIndexMultiSegmentGetBenchmark
                 () -> created.runtimeMonitoring().snapshot()
                         .segments().count() > 1, 15_000L,
                 "Expected persisted multi-segment benchmark layout.");
-        created.maintenance().flushAndWait();
     }
 
     @Override

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmark.java
@@ -53,6 +53,7 @@ public class SegmentIndexPersistedMutationBenchmark {
 
     private File tempDir;
     private SegmentIndex<Integer, String> index;
+    private MutationFlushCoordinator flushCoordinator;
 
     /**
      * Creates the persisted benchmark index and its stable seed data.
@@ -65,6 +66,7 @@ public class SegmentIndexPersistedMutationBenchmark {
                 .createTempDir("hestia-jmh-mutation");
         index = SegmentIndex.create(new FsDirectory(tempDir),
                 buildConfiguration(resolveWal()));
+        flushCoordinator = new MutationFlushCoordinator();
         seedStableBase(index);
     }
 
@@ -75,6 +77,7 @@ public class SegmentIndexPersistedMutationBenchmark {
     public void flushAfterIteration() {
         if (index != null) {
             index.maintenance().flushAndWait();
+            flushCoordinator.reset();
         }
     }
 
@@ -87,6 +90,7 @@ public class SegmentIndexPersistedMutationBenchmark {
             index.close();
             index = null;
         }
+        flushCoordinator = null;
         if (tempDir != null) {
             SegmentIndexBenchmarkSupport.deleteRecursively(tempDir);
             tempDir = null;
@@ -102,7 +106,7 @@ public class SegmentIndexPersistedMutationBenchmark {
     public void putSync(final MutationCursor cursor) {
         final int key = cursor.nextPutKey(seededKeyCount);
         index.put(Integer.valueOf(key), buildValue("put-", key, 'p'));
-        flushIfNeeded(cursor);
+        flushIfNeeded();
     }
 
     /**
@@ -113,21 +117,23 @@ public class SegmentIndexPersistedMutationBenchmark {
     @Benchmark
     public void deleteSync(final MutationCursor cursor) {
         index.delete(Integer.valueOf(cursor.nextDeleteKey(seededKeyCount)));
-        flushIfNeeded(cursor);
+        flushIfNeeded();
     }
 
     private IndexConfiguration<Integer, String> buildConfiguration(
             final IndexWalConfiguration wal) {
         final int maxKeysBeforeSplit = Math.max(65_536, seededKeyCount * 8);
+        final int writeCacheKeyLimit = Math.max(8_192, flushBatchSize * 32);
         final var builder = SegmentIndexBenchmarkSupport
                 .baseBuilder("segment-index-persisted-mutation-benchmark")//
                 .wal(walBuilder -> walBuilder.configuration(wal))//
                 .segment(segment -> segment.cacheKeyLimit(32)
                         .chunkKeyLimit(128).maxKeys(maxKeysBeforeSplit)
                         .cachedSegmentLimit(8).deltaCacheFileLimit(2))//
-                .writePath(writePath -> writePath.segmentWriteCacheKeyLimit(512)
-                        .maintenanceWriteCacheKeyLimit(1024)
-                        .indexBufferedWriteKeyLimit(8192)
+                .writePath(writePath -> writePath
+                        .segmentWriteCacheKeyLimit(writeCacheKeyLimit)
+                        .maintenanceWriteCacheKeyLimit(writeCacheKeyLimit * 2)
+                        .indexBufferedWriteKeyLimit(writeCacheKeyLimit * 4)
                         .segmentSplitKeyThreshold(maxKeysBeforeSplit))//
                 .bloomFilter(bloomFilter -> bloomFilter
                         .indexSizeBytes(Math.max(16_384, seededKeyCount / 2))
@@ -167,9 +173,14 @@ public class SegmentIndexPersistedMutationBenchmark {
         seedingIndex.maintenance().compactAndWait();
     }
 
-    private void flushIfNeeded(final MutationCursor cursor) {
-        if (cursor.shouldFlush(flushBatchSize)) {
+    private void flushIfNeeded() {
+        if (!flushCoordinator.recordAndTryStartFlush(flushBatchSize)) {
+            return;
+        }
+        try {
             index.maintenance().flushAndWait();
+        } finally {
+            flushCoordinator.finishFlush();
         }
     }
 
@@ -180,7 +191,7 @@ public class SegmentIndexPersistedMutationBenchmark {
     }
 
     /**
-     * Thread-local key selection and flush scheduling for concurrent writers.
+     * Thread-local key selection for concurrent writers.
      */
     @State(Scope.Thread)
     public static class MutationCursor {
@@ -189,11 +200,9 @@ public class SegmentIndexPersistedMutationBenchmark {
         private int threadCount;
         private int putOffset;
         private int deleteKey;
-        private int mutationsUntilFlush;
-        private boolean firstFlush;
 
         /**
-         * Resets the cursor and staggers the first flush across writers.
+         * Resets the cursor for this writer's disjoint key partitions.
          *
          * @param threadParams JMH thread metadata
          */
@@ -203,8 +212,6 @@ public class SegmentIndexPersistedMutationBenchmark {
             threadCount = threadParams.getThreadCount();
             putOffset = threadIndex;
             deleteKey = threadIndex;
-            mutationsUntilFlush = 0;
-            firstFlush = true;
         }
 
         /**
@@ -234,23 +241,5 @@ public class SegmentIndexPersistedMutationBenchmark {
             return key;
         }
 
-        /**
-         * Staggers per-writer flushes to preserve the configured aggregate flush
-         * cadence under multiple JMH threads.
-         *
-         * @param flushBatchSize aggregate mutation count between flushes
-         * @return true when this writer should request a flush
-         */
-        boolean shouldFlush(final int flushBatchSize) {
-            if (mutationsUntilFlush == 0) {
-                mutationsUntilFlush = firstFlush
-                        ? Math.max(1, (threadIndex + 1) * flushBatchSize
-                                / threadCount)
-                        : flushBatchSize;
-                firstFlush = false;
-            }
-            mutationsUntilFlush--;
-            return mutationsUntilFlush == 0;
-        }
     }
 }

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkHistoryScriptsSmokeTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkHistoryScriptsSmokeTest.java
@@ -9,8 +9,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
+import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,6 +219,116 @@ class BenchmarkHistoryScriptsSmokeTest {
                 "--channel", "main");
 
         assertEquals(1, resolveResult.exitCode(), resolveResult.output());
+    }
+
+    @Test
+    void resolveScriptRequiresMatchingProfileFingerprint() throws Exception {
+        assumePython3Available();
+        final Path sourceDir = tempDir.resolve("candidate-run-fingerprint");
+        final Path historyDir = tempDir.resolve("perf-artifacts-fingerprint");
+        final Path profileSpec = tempDir.resolve("fingerprint-profile.json");
+        Files.createDirectories(sourceDir.resolve("raw"));
+        Files.createDirectories(sourceDir.resolve("logs"));
+        Files.writeString(profileSpec, """
+                {
+                  "profile": "segment-index-pr-smoke",
+                  "benchmarks": [
+                    { "label": "segment-index-get-live" },
+                    { "label": "segment-index-mixed-drain" }
+                  ]
+                }
+                """, StandardCharsets.UTF_8);
+        final Map<String, Object> summary = new LinkedHashMap<>(
+                candidateSummaryModel());
+        summary.put("profileFingerprint", sha256(profileSpec));
+        writeSummary(sourceDir.resolve("summary.json"), summary);
+        Files.writeString(sourceDir.resolve("raw/sample.json"), "{}",
+                StandardCharsets.UTF_8);
+        Files.writeString(sourceDir.resolve("logs/sample.log"), "ok\n",
+                StandardCharsets.UTF_8);
+
+        final ProcessResult publishResult = runPythonScript(
+                "publish_jmh_history.py",
+                "--source-dir", sourceDir.toString(),
+                "--history-dir", historyDir.toString(),
+                "--channel", "main",
+                "--run-suffix", "fingerprint");
+        assertEquals(0, publishResult.exitCode(), publishResult.output());
+
+        final ProcessResult matchingResult = runPythonScript(
+                "resolve_jmh_history_baseline.py",
+                "--history-dir", historyDir.toString(),
+                "--profile", PROFILE,
+                "--profile-spec", profileSpec.toString(),
+                "--channel", "main");
+        assertEquals(0, matchingResult.exitCode(), matchingResult.output());
+
+        Files.writeString(profileSpec, "\n", StandardCharsets.UTF_8,
+                StandardOpenOption.APPEND);
+        final ProcessResult changedResult = runPythonScript(
+                "resolve_jmh_history_baseline.py",
+                "--history-dir", historyDir.toString(),
+                "--profile", PROFILE,
+                "--profile-spec", profileSpec.toString(),
+                "--channel", "main");
+        assertEquals(1, changedResult.exitCode(), changedResult.output());
+    }
+
+    @Test
+    void runProfileScriptRejectsEmptyJmhResults() throws Exception {
+        assumePython3Available();
+        final Path rawResult = tempDir.resolve("empty-jmh.json");
+        Files.writeString(rawResult, "[]", StandardCharsets.UTF_8);
+
+        final ProcessResult result = runCommand(List.of(
+                "python3",
+                "-c",
+                "import sys; from pathlib import Path; "
+                        + "sys.path.insert(0, sys.argv[1]); "
+                        + "from run_jmh_profile import normalize_result; "
+                        + "normalize_result(Path(sys.argv[2]))",
+                scriptPath("run_jmh_profile.py").getParent().toString(),
+                rawResult.toString()));
+
+        assertEquals(1, result.exitCode(), result.output());
+        assertTrue(result.output().contains("no benchmark results"));
+    }
+
+    @Test
+    void runProfileScriptRejectsPartialParameterResults() throws Exception {
+        assumePython3Available();
+        final Path rawResult = tempDir.resolve("partial-jmh.json");
+        Files.writeString(rawResult, """
+                [
+                  {
+                    "benchmark": "example.Benchmark.first",
+                    "mode": "thrpt",
+                    "threads": 1,
+                    "primaryMetric": {
+                      "score": 1.0,
+                      "scoreUnit": "ops/s"
+                    },
+                    "secondaryMetrics": {}
+                  }
+                ]
+                """, StandardCharsets.UTF_8);
+
+        final ProcessResult result = runCommand(List.of(
+                "python3",
+                "-c",
+                "import sys; from pathlib import Path; "
+                        + "sys.path.insert(0, sys.argv[1]); "
+                        + "from run_jmh_profile import normalize_result; "
+                        + "normalize_result(Path(sys.argv[2]), "
+                        + "sys.argv[4:], int(sys.argv[3]))",
+                scriptPath("run_jmh_profile.py").getParent().toString(),
+                rawResult.toString(),
+                "2",
+                "example.Benchmark.first"));
+
+        assertEquals(1, result.exitCode(), result.output());
+        assertTrue(result.output().contains(
+                "produced 1 benchmark results"));
     }
 
     @Test
@@ -570,6 +683,11 @@ class BenchmarkHistoryScriptsSmokeTest {
         path.getParent().toFile().mkdirs();
         Files.writeString(path, value, StandardCharsets.UTF_8);
         Files.setLastModifiedTime(path, FileTime.fromMillis(modifiedMillis));
+    }
+
+    private String sha256(final Path path) throws Exception {
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(path)));
     }
 
     private Map<String, Object> baselineSummaryModel() {

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
@@ -117,6 +117,7 @@ class BenchmarkProfileContractTest {
     private void assertCanonicalPrSegmentIndexProfile(
             final BenchmarkProfile profile) {
         assertNotNull(profile, "Missing canonical segment-index profile");
+        assertCanonicalProfileMetadata(profile);
         final Map<String, BenchmarkEntry> byLabel = new LinkedHashMap<>();
         for (final BenchmarkEntry benchmark : profile.benchmarks()) {
             byLabel.put(benchmark.label(), benchmark);
@@ -158,6 +159,7 @@ class BenchmarkProfileContractTest {
     private void assertCanonicalNightlySegmentIndexProfile(
             final BenchmarkProfile profile) {
         assertNotNull(profile, "Missing canonical segment-index profile");
+        assertCanonicalProfileMetadata(profile);
         final Map<String, BenchmarkEntry> byLabel = new LinkedHashMap<>();
         for (final BenchmarkEntry benchmark : profile.benchmarks()) {
             byLabel.put(benchmark.label(), benchmark);
@@ -251,6 +253,43 @@ class BenchmarkProfileContractTest {
         }
     }
 
+    private void assertCanonicalProfileMetadata(
+            final BenchmarkProfile profile) {
+        assertNotNull(profile.supportSources(),
+                () -> "Missing support sources for " + profile.profile());
+        assertFalse(profile.supportSources().isEmpty(),
+                () -> "Empty support sources for " + profile.profile());
+        for (final String supportSource : profile.supportSources()) {
+            assertTrue(Files.isRegularFile(repoRoot().resolve(supportSource)),
+                    () -> "Missing benchmark support source "
+                            + supportSource);
+        }
+        for (final BenchmarkEntry benchmark : profile.benchmarks()) {
+            assertNotNull(benchmark.expectedBenchmarks(),
+                    () -> "Missing expected benchmark methods for "
+                            + benchmark.label());
+            assertFalse(benchmark.expectedBenchmarks().isEmpty(),
+                    () -> "Empty expected benchmark methods for "
+                            + benchmark.label());
+            assertEquals(benchmark.expectedBenchmarks().size(),
+                    new LinkedHashSet<>(benchmark.expectedBenchmarks()).size(),
+                    () -> "Duplicate expected benchmark methods for "
+                            + benchmark.label());
+            assertTrue(benchmark.expectedResultCount() >= benchmark
+                    .expectedBenchmarks().size(),
+                    () -> "Invalid expected result count for "
+                            + benchmark.label());
+            for (final String expectedBenchmark : benchmark
+                    .expectedBenchmarks()) {
+                assertTrue(
+                        expectedBenchmark.startsWith(benchmark.include() + "."),
+                        () -> "Unexpected benchmark method "
+                                + expectedBenchmark + " for "
+                                + benchmark.label());
+            }
+        }
+    }
+
     private void assertThreadCount(final BenchmarkEntry entry,
             final int expectedThreadCount) {
         final List<String> args = entry.args();
@@ -326,6 +365,11 @@ class BenchmarkProfileContractTest {
         return current.resolve("benchmarks").resolve("src/main/java");
     }
 
+    private Path repoRoot() {
+        final Path sourceRoot = sourceRoot();
+        return sourceRoot.getParent().getParent().getParent().getParent();
+    }
+
     private String readUtf8(final Path path) {
         try {
             return Files.readString(path, StandardCharsets.UTF_8);
@@ -335,9 +379,12 @@ class BenchmarkProfileContractTest {
     }
 
     record BenchmarkProfile(String profile, String description,
+            List<String> supportSources,
             List<BenchmarkEntry> benchmarks) {
     }
 
-    record BenchmarkEntry(String label, String include, List<String> args) {
+    record BenchmarkEntry(String label, String include,
+            List<String> expectedBenchmarks, int expectedResultCount,
+            List<String> args) {
     }
 }

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinatorTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/segmentindex/MutationFlushCoordinatorTest.java
@@ -1,0 +1,38 @@
+package org.hestiastore.benchmark.segmentindex;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MutationFlushCoordinatorTest {
+
+    @Test
+    void startsOneFlushAtAggregateThreshold() {
+        final MutationFlushCoordinator coordinator = new MutationFlushCoordinator();
+
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+        assertTrue(coordinator.recordAndTryStartFlush(3));
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+
+        coordinator.finishFlush();
+        assertTrue(coordinator.recordAndTryStartFlush(3));
+        coordinator.finishFlush();
+        assertFalse(coordinator.recordAndTryStartFlush(3));
+    }
+
+    @Test
+    void resetClearsPendingMutations() {
+        final MutationFlushCoordinator coordinator = new MutationFlushCoordinator();
+
+        assertFalse(coordinator.recordAndTryStartFlush(2));
+        coordinator.reset();
+
+        assertFalse(coordinator.recordAndTryStartFlush(2));
+        assertTrue(coordinator.recordAndTryStartFlush(2));
+        coordinator.finishFlush();
+    }
+}

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmarkTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/segmentindex/SegmentIndexPersistedMutationBenchmarkTest.java
@@ -1,8 +1,6 @@
 package org.hestiastore.benchmark.segmentindex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark.MutationCursor;
 import org.junit.jupiter.api.Test;
@@ -11,7 +9,7 @@ import org.openjdk.jmh.infra.ThreadParams;
 class SegmentIndexPersistedMutationBenchmarkTest {
 
     @Test
-    void mutationCursorPartitionsKeysAndStaggersFlushes() {
+    void mutationCursorPartitionsKeys() {
         final MutationCursor cursor = new MutationCursor();
         cursor.setup(threadParams(3, 16));
 
@@ -20,14 +18,6 @@ class SegmentIndexPersistedMutationBenchmarkTest {
         assertEquals(3, cursor.nextDeleteKey(35));
         assertEquals(19, cursor.nextDeleteKey(35));
         assertEquals(3, cursor.nextDeleteKey(35));
-        assertFalse(cursor.shouldFlush(16));
-        assertFalse(cursor.shouldFlush(16));
-        assertFalse(cursor.shouldFlush(16));
-        assertTrue(cursor.shouldFlush(16));
-        for (int i = 0; i < 15; i++) {
-            assertFalse(cursor.shouldFlush(16));
-        }
-        assertTrue(cursor.shouldFlush(16));
     }
 
     private static ThreadParams threadParams(final int threadIndex,


### PR DESCRIPTION
## Summary

- stabilize multi-segment fixture creation by separating setup-only cache capacity from the measured reopen configuration and removing redundant setup flushes
- coordinate persisted-mutation flush cadence across concurrent writers and provide enough benchmark write-buffer headroom while a flush completes
- reject empty, method-partial, and parameter-partial JMH JSON; fingerprint profile definitions before accepting stored history
- bootstrap instead of comparing against an incompatible fallback when canonical profile or benchmark-support sources change

## Why this is a prerequisite

The existing `devel` history is not a valid comparison baseline: JMH can return exit code 0 after a trial setup failure, and the old runner accepted empty or partial JSON. The stored canonical summary is missing rows for the multi-segment get and concurrent mutation labels. This PR intentionally creates a new benchmark-definition boundary; the first `devel` run after merge should publish the replacement canonical baseline before the SegmentRegistry/SessionOperationGate optimization PR is rebased.

Supports #326.

## Verification

- `mvn -pl benchmarks -DskipTests=false test` — 16 tests passed
- `mvn clean verify` — all 10 modules passed; engine 1,990 unit tests and 42 integration tests passed
- exact Java 21 `segment-index-get-multisegment-hot` smoke parameters — 3 consecutive complete two-row runs after the final fixture bound
- exact Java 21 `segment-index-persisted-mutation-concurrent` smoke parameters — complete delete/put run
- Java 21 `segment-index-pr-smoke` — all 8 canonical labels completed, including a second complete concurrent mutation run; final method/row-count validation accepted every raw result

No before/after throughput claim is made here because the historical baseline is incomplete and therefore unusable.