### PR TITLE
Add UTF-8 string descriptors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.0.6 (Unreleased)
 
+### Added
+
+- Added strict UTF-8 string descriptors for emoji and multilingual keys and
+  values: `TypeDescriptorTinyUtf8String` for payloads up to 255 encoded bytes
+  and `TypeDescriptorUtf8String` for larger payloads.
+
 ### Changed
 
 - Key encoding now uses a single-pass API (`TypeEncoder#encode(T, byte[])`) across read and write paths, including Bloom filter lookup, WAL encoding, and type writers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ range scans, and operational simplicity inside a single application process.
 
 - Pure Java embedding with no native dependency requirement
 - In-memory or filesystem-backed directories
+- Strict UTF-8 keys and values for emoji and multilingual text
 - Custom key and value type descriptors
 - Bloom-filter assisted negative lookups
 - Segment-based storage with ordered scans
@@ -108,6 +109,11 @@ try (SegmentIndex<String, String> index = SegmentIndex.create(directory, conf)) 
     System.out.println(index.get("hello"));
 }
 ```
+
+String indexes use the compact ISO-8859-1 descriptor by default for on-disk
+compatibility. To store emoji or multilingual text, explicitly select one of
+the [UTF-8 string descriptors](configuration/data-types.md#utf-8-string-descriptors)
+when creating the index.
 
 For the next step after this example, go to [Quick Start](how-to-use/quick-start.md).
 

--- a/docs/configuration/data-types.md
+++ b/docs/configuration/data-types.md
@@ -1,21 +1,111 @@
-# Data types
+# Data Types
 
 HestiaStore supports a variety of data types for storing keys and values in a binary-efficient and consistent manner. Each data type is associated with a `TypeDescriptor`, which handles serialization, deserialization, comparison, and hashing logic.
 
 Below is a list of the supported data types and their characteristics.
 
-| Java Class           | TypeDescriptor Class              | Max Length (Bytes) | Notes |
-|----------------------|-----------------------------------|---------------------|-------|
+| Java Class           | TypeDescriptor Class              | Maximum Payload Bytes | Notes |
+|----------------------|-----------------------------------|-----------------------|-------|
 | `java.lang.Byte`     | `TypeDescriptorByte`              | 1                   | Two's complement representation |
 | `java.lang.Integer`  | `TypeDescriptorInteger`           | 4                   | Big-endian encoding |
 | `java.lang.Long`     | `TypeDescriptorLong`              | 8                   | Big-endian encoding |
 | `java.lang.Float`    | `TypeDescriptorFloat`             | 4                   | IEEE 754 format |
 | `java.lang.Double`   | `TypeDescriptorDouble`            | 8                   | IEEE 754 format |
-| `java.lang.String`   | `TypeDescriptorShortString`       | 128                 | UTF-8 encoding, prefixed with 1-byte length, it's default string type descriptor |
-| `java.lang.String`   | `TypeDescriptorString`            | 2 GB                | UTF-8 encoding, prefixed with 4-byte length |
+| `java.lang.String`   | `TypeDescriptorShortString`       | 127                 | ISO-8859-1, one-byte length; default string descriptor |
+| `java.lang.String`   | `TypeDescriptorString`            | JVM array limit     | ISO-8859-1, four-byte signed length |
+| `java.lang.String`   | `TypeDescriptorTinyUtf8String`    | 255                 | Strict UTF-8, one-byte unsigned length |
+| `java.lang.String`   | `TypeDescriptorUtf8String`        | 2,147,483,642       | Strict UTF-8, canonical unsigned LEB128 length |
 | `org.hestiastore.index.datatype.ByteArray` | `TypeDescriptorByteArray`   | n                   | Raw bytes, length determined by actual data |
-| `org.hestiastore.index.datatype.NullValue` | `TypeDescriptorNullValue`   | 0                   | Usefulll when value is not needed. Doesn't occupy any space. |
+| `org.hestiastore.index.datatype.NullValue` | `TypeDescriptorNull`   | 0                   | Useful when a value is not needed; occupies no payload space |
 | `org.hestiastore.index.datatype.CompositeValue` | `TypeDescriptorCompositeValue`   | n                   | Represents multiple values.  |
+
+## UTF-8 String Descriptors
+
+Both UTF-8 descriptors use standard UTF-8 and store the encoded payload byte
+length. The limit does not count Java UTF-16 code units, Unicode code points,
+or displayed grapheme clusters.
+
+`TypeDescriptorTinyUtf8String` stores:
+
+```text
+[one-byte unsigned payload length][UTF-8 payload]
+```
+
+Its payload can contain 0 through 255 bytes. For example, it can hold 255 ASCII
+characters or 63 four-byte emoji, but not 64 four-byte emoji.
+
+`TypeDescriptorUtf8String` stores:
+
+```text
+[canonical unsigned LEB128 payload length][UTF-8 payload]
+```
+
+The prefix size is:
+
+| Payload Length | Prefix Bytes |
+|----------------|--------------|
+| 0–127 | 1 |
+| 128–16,383 | 2 |
+| 16,384–2,097,151 | 3 |
+| 2,097,152–268,435,455 | 4 |
+| 268,435,456–2,147,483,642 | 5 |
+
+The general descriptor's maximum preserves the `TypeWriter` contract that the
+total prefix and payload byte count fits in a non-negative Java `int`. Actual
+usable values can be lower because a payload must also fit in a JVM byte array
+and available heap.
+
+Both descriptors:
+
+- reject unpaired Java UTF-16 surrogates during encoding
+- reject malformed, truncated, overlong, or surrogate UTF-8 byte sequences
+  during decoding
+- preserve the original string without automatic Unicode normalization
+- use Java `String.compareTo` ordering
+
+Application character limits must account for variable-width encoding:
+
+| Application Limit | Worst-Case UTF-8 Payload | Suitable Descriptor |
+|-------------------|---------------------------|---------------------|
+| 128 encoded bytes | 128 bytes | `TypeDescriptorTinyUtf8String` |
+| 128 Unicode code points | 512 bytes | `TypeDescriptorUtf8String` |
+| 64,000 encoded bytes | 64,000 bytes | `TypeDescriptorUtf8String` |
+| 64,000 Unicode code points | 256,000 bytes | `TypeDescriptorUtf8String` |
+
+Displayed characters can contain multiple code points, so a grapheme-count
+limit alone does not provide a strict serialized byte limit.
+
+### Configuration
+
+Wire UTF-8 descriptors explicitly in the identity configuration:
+
+```java
+IndexConfiguration<String, String> configuration = IndexConfiguration
+    .<String, String>builder()
+    .identity(identity -> identity
+        .name("localized-text")
+        .keyClass(String.class)
+        .valueClass(String.class)
+        .keyTypeDescriptor(new TypeDescriptorTinyUtf8String())
+        .valueTypeDescriptor(new TypeDescriptorUtf8String()))
+    .build();
+```
+
+The default registry mapping for `String` remains
+`TypeDescriptorShortString` for on-disk compatibility. Applications can use
+either UTF-8 descriptor without changing that global default by configuring it
+explicitly as shown above.
+
+### Migration from ISO-8859-1
+
+Do not replace `TypeDescriptorShortString` or `TypeDescriptorString` with a
+UTF-8 descriptor when opening an existing index. The formats use different
+payload encodings and different length framing. Create a new index with the
+UTF-8 descriptor and migrate or rebuild the data.
+
+The legacy ISO-8859-1 encoder replaces unsupported characters with `?`.
+Choose a UTF-8 descriptor before accepting emoji or characters outside
+ISO-8859-1 to prevent that data loss.
 
 ## Custom Data Types
 
@@ -30,9 +120,9 @@ To create a new data type:
 1. Implement the `TypeDescriptor<T>` interface. It groups encoder/decoder/reader/writer/comparator contracts for your type.
 2. Optionallly register it using `org.hestiastore.index.segmentindex.configuration.DataTypeDescriptorRegistry.addTypeDescriptor(Class, descriptor)`.
 
-### TypeEncoder Contract (0.0.6+)
+### TypeEncoder Contract
 
-Starting with `0.0.6`, `TypeEncoder` uses a single method:
+`TypeEncoder` uses a single method:
 
 ```java
 EncodedBytes encode(T value, byte[] reusableBuffer)
@@ -64,12 +154,6 @@ public final class TypeDescriptorMyType implements TypeDescriptor<MyType> {
     }
 }
 ```
-
-Migration from older API:
-
-* Remove old `bytesLength(...)`/`toBytes(...)` implementations.
-* Move length validation and write validation directly into `encode(...)`.
-* Return exact written length via `EncodedBytes`.
 
 ### Why Register Your Custom Type Descriptor
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -109,6 +109,13 @@ Supported built-in types are the common compact types such as `Integer`,
 `Long`, `String`, and `Byte`. Custom types must provide a
 `TypeDescriptor` with stable serialization and comparison behavior.
 
+For emoji and multilingual strings, configure
+`TypeDescriptorTinyUtf8String` for payloads up to 255 encoded bytes or
+`TypeDescriptorUtf8String` for larger payloads. The default `String` mapping is
+the legacy ISO-8859-1 descriptor for on-disk compatibility. See
+[Data Types](data-types.md#utf-8-string-descriptors) for configuration, byte
+limits, and migration guidance.
+
 ### Segment sizing and cache behavior
 
 - `segment(...).maxKeys()` controls when segments split.
@@ -215,7 +222,8 @@ recovery for acknowledged writes.
 
 - [Filters](filters.md) for chunk filter setup, provider-backed custom filters,
   and registry wiring
-- [Data Types](data-types.md) for custom serialization and comparator contracts
+- [Data Types](data-types.md) for UTF-8 strings, custom serialization, and
+  comparator contracts
 - [Logging](logging.md) for logger configuration
 - [Monitoring Console](monitoring-console.md) for monitoring-side configuration
 

--- a/docs/development/documentation-guidelines.md
+++ b/docs/development/documentation-guidelines.md
@@ -28,6 +28,9 @@ Use a light Diataxis split:
 - Update docs in the same change when behavior or contracts change.
 - Prefer exact code terminology over vague prose.
 - If code and docs disagree, fix both or clearly mark the page as a proposal.
+- Describe the current code and contracts without version comparisons by
+  default. Keep release history in `CHANGELOG.md`, and add version-specific
+  migration guidance only when the user explicitly requests it.
 - Keep architecture pages as source-of-truth documents, not changelog notes.
 - Do not leave placeholder pages such as "content to be expanded" in published
   navigation.

--- a/docs/how-to-use/quick-start.md
+++ b/docs/how-to-use/quick-start.md
@@ -60,6 +60,39 @@ String value = index.get("hello");
 index.delete("hello");
 ```
 
+## Store emoji and multilingual text
+
+HestiaStore supports strict UTF-8 keys and values through explicit string
+descriptors. Select them when creating the index:
+
+```java
+import org.hestiastore.index.datatype.TypeDescriptorTinyUtf8String;
+import org.hestiastore.index.datatype.TypeDescriptorUtf8String;
+
+IndexConfiguration<String, String> conf = IndexConfiguration
+    .<String, String>builder()
+    .identity(identity -> identity
+        .name("localized-text")
+        .keyClass(String.class)
+        .valueClass(String.class)
+        .keyTypeDescriptor(new TypeDescriptorTinyUtf8String())
+        .valueTypeDescriptor(new TypeDescriptorUtf8String()))
+    .build();
+
+try (SegmentIndex<String, String> index = SegmentIndex.create(directory, conf)) {
+    index.put("objednávka-🙂", "Čeština Ελληνικά Кириллица 日本語 👨‍👩‍👧‍👦");
+}
+```
+
+Use `TypeDescriptorTinyUtf8String` for payloads up to 255 encoded bytes and
+`TypeDescriptorUtf8String` for larger strings. The limits apply to UTF-8 bytes,
+not displayed characters.
+
+The default `String` descriptor remains ISO-8859-1 for on-disk compatibility.
+Choose the UTF-8 descriptors before creating an index that will contain emoji
+or characters outside ISO-8859-1. See [Data Types](../configuration/data-types.md#utf-8-string-descriptors)
+for exact size limits and migration guidance.
+
 ## Iterate entries
 
 Read all entries in ascending key order:
@@ -99,5 +132,6 @@ index.maintenance().compact();
 ## Next steps
 
 - [Configuration](../configuration/index.md) for storage and tuning knobs
+- [Data Types](../configuration/data-types.md) for UTF-8 and custom descriptors
 - [WAL](../operations/wal.md) for local crash recovery
 - [Troubleshooting](troubleshooting.md) for common startup and runtime issues

--- a/engine/src/integration-test/java/org/hestiastore/index/it/Utf8StringDescriptorsIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/Utf8StringDescriptorsIT.java
@@ -1,0 +1,41 @@
+package org.hestiastore.index.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hestiastore.index.datatype.TypeDescriptorTinyUtf8String;
+import org.hestiastore.index.datatype.TypeDescriptorUtf8String;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segmentindex.SegmentIndex;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.junit.jupiter.api.Test;
+
+class Utf8StringDescriptorsIT {
+
+    @Test
+    void persistedConfigurationReopensAndReadsMultilingualEntry() {
+        final Directory directory = new MemDirectory();
+        final IndexConfiguration<String, String> configuration = IndexConfiguration
+                .<String, String>builder()
+                .identity(identity -> identity.name("utf8-index")
+                        .keyClass(String.class).valueClass(String.class)
+                        .keyTypeDescriptor(
+                                new TypeDescriptorTinyUtf8String())
+                        .valueTypeDescriptor(
+                                new TypeDescriptorUtf8String()))
+                .build();
+        final String key = "objednávka-🙂";
+        final String value = "Čeština Ελληνικά Кириллица 日本語 👨‍👩‍👧‍👦";
+
+        try (SegmentIndex<String, String> index = SegmentIndex.create(directory,
+                configuration)) {
+            index.put(key, value);
+            index.maintenance().flush();
+        }
+
+        try (SegmentIndex<String, String> reopened = SegmentIndex
+                .open(directory)) {
+            assertEquals(value, reopened.get(key));
+        }
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorTinyUtf8String.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorTinyUtf8String.java
@@ -1,0 +1,55 @@
+package org.hestiastore.index.datatype;
+
+import java.util.OptionalInt;
+
+/**
+ * Descriptor for strict UTF-8 strings with an unsigned one-byte payload length
+ * and a maximum payload of 255 encoded bytes.
+ *
+ * <p>
+ * The limit applies to UTF-8 payload bytes, not Java UTF-16 code units or
+ * displayed characters.
+ * </p>
+ */
+public final class TypeDescriptorTinyUtf8String
+        extends TypeDescriptorUtf8String {
+
+    private static final int MAX_SERIALIZED_BYTES = 1
+            + UnsignedByteLengthWriter.MAX_PAYLOAD_BYTES;
+
+    /**
+     * Creates a strict UTF-8 string descriptor limited to 255 payload bytes.
+     */
+    public TypeDescriptorTinyUtf8String() {
+    }
+
+    /**
+     * Returns the unsigned-byte length writer.
+     *
+     * @return writer
+     */
+    @Override
+    public TypeWriter<String> getTypeWriter() {
+        return new UnsignedByteLengthWriter<String>(getTypeEncoder());
+    }
+
+    /**
+     * Returns the unsigned-byte length reader.
+     *
+     * @return reader
+     */
+    @Override
+    public TypeReader<String> getTypeReader() {
+        return new UnsignedByteLengthReader<String>(getTypeDecoder());
+    }
+
+    /**
+     * Returns the conservative maximum serialized size including the prefix.
+     *
+     * @return 256 bytes
+     */
+    @Override
+    public OptionalInt getEstimatedAverageSizeInBytes() {
+        return OptionalInt.of(MAX_SERIALIZED_BYTES);
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorUtf8String.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorUtf8String.java
@@ -1,0 +1,112 @@
+package org.hestiastore.index.datatype;
+
+import java.util.Comparator;
+
+/**
+ * Descriptor for strict UTF-8 strings prefixed by their canonical unsigned
+ * LEB128 encoded byte length.
+ *
+ * <p>
+ * The length prefix describes UTF-8 payload bytes, not Java UTF-16 code units
+ * or displayed characters.
+ * </p>
+ */
+public class TypeDescriptorUtf8String implements TypeDescriptor<String> {
+
+    private static final Utf8StringCodec CODEC = Utf8StringCodec.INSTANCE;
+
+    /**
+     * Tombstone value reserved for delete semantics.
+     */
+    public static final String TOMBSTONE_VALUE = "(*&^%$#@!)-1eaa9b2c-3c11-11ee-be56-0242ac120002";
+
+    /**
+     * Creates a general strict UTF-8 string descriptor.
+     */
+    public TypeDescriptorUtf8String() {
+    }
+
+    /**
+     * Returns the strict UTF-8 decoder.
+     *
+     * @return decoder
+     */
+    @Override
+    public TypeDecoder<String> getTypeDecoder() {
+        return CODEC;
+    }
+
+    /**
+     * Returns the strict UTF-8 encoder.
+     *
+     * @return encoder
+     */
+    @Override
+    public TypeEncoder<String> getTypeEncoder() {
+        return CODEC;
+    }
+
+    /**
+     * Returns the unsigned LEB128 length writer.
+     *
+     * @return writer
+     */
+    @Override
+    public TypeWriter<String> getTypeWriter() {
+        return new VarIntLengthWriter<String>(getTypeEncoder());
+    }
+
+    /**
+     * Returns the unsigned LEB128 length reader.
+     *
+     * @return reader
+     */
+    @Override
+    public TypeReader<String> getTypeReader() {
+        return new VarIntLengthReader<String>(getTypeDecoder());
+    }
+
+    /**
+     * Returns natural Java string ordering.
+     *
+     * @return comparator
+     */
+    @Override
+    public Comparator<String> getComparator() {
+        return String::compareTo;
+    }
+
+    /**
+     * Returns the tombstone marker.
+     *
+     * @return tombstone value
+     */
+    @Override
+    public String getTombstone() {
+        return TOMBSTONE_VALUE;
+    }
+
+    /**
+     * Returns whether the object has the same descriptor type.
+     *
+     * @param obj object to compare
+     * @return {@code true} when both objects have the same descriptor type
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        return obj != null && getClass() == obj.getClass();
+    }
+
+    /**
+     * Returns a stable descriptor-type hash code.
+     *
+     * @return hash code
+     */
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/UnsignedByteLengthReader.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/UnsignedByteLengthReader.java
@@ -1,0 +1,42 @@
+package org.hestiastore.index.datatype;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.directory.FileReader;
+
+/**
+ * Reads values stored as {@code [unsigned byte length][payload bytes]}.
+ *
+ * @param <T> decoded value type
+ */
+final class UnsignedByteLengthReader<T> implements TypeReader<T> {
+
+    private final TypeDecoder<T> convertor;
+
+    /**
+     * Creates an unsigned-byte-length reader.
+     *
+     * @param convertor payload decoder
+     */
+    UnsignedByteLengthReader(final TypeDecoder<T> convertor) {
+        this.convertor = Vldtn.requireNonNull(convertor, "convertor");
+    }
+
+    /**
+     * Reads and decodes one value.
+     *
+     * @param reader source reader
+     * @return decoded value, or {@code null} on EOF before a length prefix
+     */
+    @Override
+    public T read(final FileReader reader) {
+        final FileReader validatedReader = Vldtn.requireNonNull(reader,
+                "reader");
+        final int length = validatedReader.read();
+        if (length < 0) {
+            return null;
+        }
+        final byte[] bytes = new byte[length];
+        TypeIo.readFullyRequired(validatedReader, bytes);
+        return convertor.decode(bytes);
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/UnsignedByteLengthWriter.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/UnsignedByteLengthWriter.java
@@ -1,0 +1,53 @@
+package org.hestiastore.index.datatype;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.directory.FileWriter;
+
+/**
+ * Writes values as {@code [unsigned byte length][payload bytes]} while
+ * retaining a reusable payload buffer.
+ *
+ * @param <T> encoded value type
+ */
+final class UnsignedByteLengthWriter<T> implements TypeWriter<T> {
+
+    static final int MAX_PAYLOAD_BYTES = 0xFF;
+
+    private final TypeEncoder<T> convertor;
+    private byte[] payloadBytes;
+
+    /**
+     * Creates an unsigned-byte-length writer.
+     *
+     * @param convertor payload encoder
+     */
+    UnsignedByteLengthWriter(final TypeEncoder<T> convertor) {
+        this.convertor = Vldtn.requireNonNull(convertor, "convertor");
+        this.payloadBytes = new byte[0];
+    }
+
+    /**
+     * Encodes and writes one value.
+     *
+     * @param writer target writer
+     * @param object value to encode
+     * @return total prefix and payload bytes written
+     */
+    @Override
+    public int write(final FileWriter writer, final T object) {
+        final FileWriter validatedWriter = Vldtn.requireNonNull(writer,
+                "writer");
+        final EncodedBytes encodedPayload = convertor.encode(object,
+                payloadBytes);
+        final int payloadLength = encodedPayload.getLength();
+        if (payloadLength > MAX_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException(String.format(
+                    "Encoded payload length '%s' exceeds maximum '%s'.",
+                    payloadLength, MAX_PAYLOAD_BYTES));
+        }
+        payloadBytes = encodedPayload.getBytes();
+        validatedWriter.write((byte) payloadLength);
+        validatedWriter.write(payloadBytes, 0, payloadLength);
+        return 1 + payloadLength;
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/UnsignedLeb128.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/UnsignedLeb128.java
@@ -1,0 +1,89 @@
+package org.hestiastore.index.datatype;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.directory.FileReader;
+import org.hestiastore.index.directory.FileWriter;
+
+/**
+ * Reads and writes canonical unsigned LEB128 values in the non-negative Java
+ * {@code int} range.
+ */
+final class UnsignedLeb128 {
+
+    static final int MAX_ENCODED_BYTES = 5;
+    static final int MAX_FRAME_PAYLOAD_BYTES = Integer.MAX_VALUE
+            - MAX_ENCODED_BYTES;
+
+    private static final int DATA_BITS_PER_BYTE = 7;
+    private static final int DATA_MASK = 0x7F;
+    private static final int CONTINUATION_MASK = 0x80;
+    private static final int MAX_FINAL_BYTE_VALUE = 0x07;
+
+    private UnsignedLeb128() {
+    }
+
+    /**
+     * Writes one non-negative integer in canonical unsigned LEB128 form.
+     *
+     * @param writer target writer
+     * @param value non-negative value
+     * @return encoded byte count
+     */
+    static int write(final FileWriter writer, final int value) {
+        final FileWriter validatedWriter = Vldtn.requireNonNull(writer,
+                "writer");
+        int remaining = Vldtn.requireGreaterThanOrEqualToZero(value, "value");
+        int written = 0;
+        do {
+            int current = remaining & DATA_MASK;
+            remaining >>>= DATA_BITS_PER_BYTE;
+            if (remaining != 0) {
+                current |= CONTINUATION_MASK;
+            }
+            validatedWriter.write((byte) current);
+            written++;
+        } while (remaining != 0);
+        return written;
+    }
+
+    /**
+     * Reads one canonical unsigned LEB128 integer.
+     *
+     * @param reader source reader
+     * @return decoded value, or {@code -1} when EOF occurs before the prefix
+     */
+    static int read(final FileReader reader) {
+        final FileReader validatedReader = Vldtn.requireNonNull(reader,
+                "reader");
+        int value = 0;
+        int shift = 0;
+        for (int index = 0; index < MAX_ENCODED_BYTES; index++) {
+            final int current = validatedReader.read();
+            if (current < 0) {
+                if (index == 0) {
+                    return -1;
+                }
+                throw new IndexException(
+                        "Truncated unsigned LEB128 length prefix.");
+            }
+            final int data = current & DATA_MASK;
+            if (index == MAX_ENCODED_BYTES - 1
+                    && data > MAX_FINAL_BYTE_VALUE) {
+                throw new IndexException(
+                        "Unsigned LEB128 length exceeds the supported integer range.");
+            }
+            value |= data << shift;
+            if ((current & CONTINUATION_MASK) == 0) {
+                if (index > 0 && data == 0) {
+                    throw new IndexException(
+                            "Non-canonical unsigned LEB128 length prefix.");
+                }
+                return value;
+            }
+            shift += DATA_BITS_PER_BYTE;
+        }
+        throw new IndexException(
+                "Unsigned LEB128 length prefix exceeds five bytes.");
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/Utf8StringCodec.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/Utf8StringCodec.java
@@ -1,0 +1,123 @@
+package org.hestiastore.index.datatype;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.Vldtn;
+
+/**
+ * Strict UTF-8 encoder and decoder that rejects malformed input and reuses
+ * caller-provided encoding buffers.
+ */
+@SuppressWarnings("java:S6548")
+final class Utf8StringCodec
+        implements TypeEncoder<String>, TypeDecoder<String> {
+
+    static final Utf8StringCodec INSTANCE = new Utf8StringCodec();
+
+    private static final int MIN_GROWTH_BYTES = 32;
+
+    private Utf8StringCodec() {
+    }
+
+    /**
+     * Encodes a Java string as strict standard UTF-8.
+     *
+     * @param value string to encode
+     * @param reusableBuffer caller-provided reusable buffer
+     * @return encoded payload and effective byte length
+     */
+    @Override
+    public EncodedBytes encode(final String value,
+            final byte[] reusableBuffer) {
+        final String validatedValue = Vldtn.requireNonNull(value, "value");
+        final byte[] validatedBuffer = Vldtn.requireNonNull(reusableBuffer,
+                "reusableBuffer");
+        final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        final CharBuffer input = CharBuffer.wrap(validatedValue);
+        byte[] output = validatedBuffer;
+        int written = 0;
+
+        while (true) {
+            final ByteBuffer destination = ByteBuffer.wrap(output);
+            destination.position(written);
+            final CoderResult result = encoder.encode(input, destination, true);
+            written = destination.position();
+            if (result.isOverflow()) {
+                output = grow(output, written, input.remaining());
+            } else if (result.isError()) {
+                throw encodingException(result);
+            } else {
+                break;
+            }
+        }
+
+        while (true) {
+            final ByteBuffer destination = ByteBuffer.wrap(output);
+            destination.position(written);
+            final CoderResult result = encoder.flush(destination);
+            written = destination.position();
+            if (result.isOverflow()) {
+                output = grow(output, written, 0);
+            } else if (result.isError()) {
+                throw encodingException(result);
+            } else {
+                return new EncodedBytes(output, written);
+            }
+        }
+    }
+
+    /**
+     * Decodes strict standard UTF-8.
+     *
+     * @param source encoded payload
+     * @return decoded Java string
+     */
+    @Override
+    public String decode(final byte[] source) {
+        final byte[] validatedSource = Vldtn.requireNonNull(source, "source");
+        final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        try {
+            return decoder.decode(ByteBuffer.wrap(validatedSource)).toString();
+        } catch (CharacterCodingException e) {
+            throw new IndexException("Invalid UTF-8 payload.", e);
+        }
+    }
+
+    private static byte[] grow(final byte[] current, final int written,
+            final int remainingCharacters) {
+        final long doubledLength = Math.max(MIN_GROWTH_BYTES,
+                (long) current.length * 2);
+        final long estimatedLength = (long) written
+                + Math.max(Character.BYTES * 2, remainingCharacters);
+        final long requiredLength = Math.max(doubledLength, estimatedLength);
+        if (requiredLength > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    "UTF-8 payload exceeds the supported array size.");
+        }
+        return Arrays.copyOf(current, (int) requiredLength);
+    }
+
+    private static IllegalArgumentException encodingException(
+            final CoderResult result) {
+        try {
+            result.throwException();
+        } catch (CharacterCodingException e) {
+            return new IllegalArgumentException(
+                    "String contains malformed UTF-16 input.", e);
+        }
+        return new IllegalArgumentException("Unable to encode string as UTF-8.");
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/VarIntLengthReader.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/VarIntLengthReader.java
@@ -1,0 +1,47 @@
+package org.hestiastore.index.datatype;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.directory.FileReader;
+
+/**
+ * Reads values stored as
+ * {@code [canonical unsigned LEB128 byte length][payload bytes]}.
+ *
+ * @param <T> decoded value type
+ */
+final class VarIntLengthReader<T> implements TypeReader<T> {
+
+    private final TypeDecoder<T> convertor;
+
+    /**
+     * Creates a variable-length reader.
+     *
+     * @param convertor payload decoder
+     */
+    VarIntLengthReader(final TypeDecoder<T> convertor) {
+        this.convertor = Vldtn.requireNonNull(convertor, "convertor");
+    }
+
+    /**
+     * Reads and decodes one value.
+     *
+     * @param reader source reader
+     * @return decoded value, or {@code null} on EOF before a length prefix
+     */
+    @Override
+    public T read(final FileReader reader) {
+        final int length = UnsignedLeb128.read(reader);
+        if (length < 0) {
+            return null;
+        }
+        if (length > UnsignedLeb128.MAX_FRAME_PAYLOAD_BYTES) {
+            throw new IndexException(String.format(
+                    "Encoded payload length '%s' exceeds maximum '%s'.", length,
+                    UnsignedLeb128.MAX_FRAME_PAYLOAD_BYTES));
+        }
+        final byte[] bytes = new byte[length];
+        TypeIo.readFullyRequired(reader, bytes);
+        return convertor.decode(bytes);
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/VarIntLengthWriter.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/VarIntLengthWriter.java
@@ -1,0 +1,52 @@
+package org.hestiastore.index.datatype;
+
+import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.directory.FileWriter;
+
+/**
+ * Writes values as {@code [unsigned LEB128 byte length][payload bytes]} while
+ * retaining a reusable payload buffer.
+ *
+ * @param <T> encoded value type
+ */
+final class VarIntLengthWriter<T> implements TypeWriter<T> {
+
+    private final TypeEncoder<T> convertor;
+    private byte[] payloadBytes;
+
+    /**
+     * Creates a variable-length writer.
+     *
+     * @param convertor payload encoder
+     */
+    VarIntLengthWriter(final TypeEncoder<T> convertor) {
+        this.convertor = Vldtn.requireNonNull(convertor, "convertor");
+        this.payloadBytes = new byte[0];
+    }
+
+    /**
+     * Encodes and writes one value.
+     *
+     * @param writer target writer
+     * @param object value to encode
+     * @return total prefix and payload bytes written
+     */
+    @Override
+    public int write(final FileWriter writer, final T object) {
+        final FileWriter validatedWriter = Vldtn.requireNonNull(writer,
+                "writer");
+        final EncodedBytes encodedPayload = convertor.encode(object,
+                payloadBytes);
+        final int payloadLength = encodedPayload.getLength();
+        if (payloadLength > UnsignedLeb128.MAX_FRAME_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException(String.format(
+                    "Encoded payload length '%s' exceeds maximum '%s'.",
+                    payloadLength, UnsignedLeb128.MAX_FRAME_PAYLOAD_BYTES));
+        }
+        payloadBytes = encodedPayload.getBytes();
+        final int prefixLength = UnsignedLeb128.write(validatedWriter,
+                payloadLength);
+        validatedWriter.write(payloadBytes, 0, payloadLength);
+        return prefixLength + payloadLength;
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorTinyUtf8StringTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorTinyUtf8StringTest.java
@@ -1,0 +1,81 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.directory.MemFileReader;
+import org.junit.jupiter.api.Test;
+
+class TypeDescriptorTinyUtf8StringTest {
+
+    private final TypeDescriptorTinyUtf8String descriptor = new TypeDescriptorTinyUtf8String();
+
+    @Test
+    void writerAndReader_roundTripUnicodeWithinByteLimit() {
+        final String value = "🙂".repeat(63);
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final int written = descriptor.getTypeWriter().write(writer, value);
+        final byte[] frame = writer.toByteArray();
+        final String decoded = descriptor.getTypeReader()
+                .read(new MemFileReader(frame));
+
+        assertEquals(253, written);
+        assertEquals(252, frame[0] & 0xFF);
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void writerAndReader_accept255EncodedBytes() {
+        final String value = "a".repeat(255);
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final int written = descriptor.getTypeWriter().write(writer, value);
+        final String decoded = descriptor.getTypeReader()
+                .read(new MemFileReader(writer.toByteArray()));
+
+        assertEquals(256, written);
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void writerRejects256AsciiBytes() {
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> descriptor.getTypeWriter().write(writer,
+                        "a".repeat(256)));
+
+        assertEquals("Encoded payload length '256' exceeds maximum '255'.",
+                error.getMessage());
+    }
+
+    @Test
+    void writerRejects64EmojiBecauseLimitIsEncodedBytes() {
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> descriptor.getTypeWriter().write(writer,
+                        "🙂".repeat(64)));
+
+        assertEquals("Encoded payload length '256' exceeds maximum '255'.",
+                error.getMessage());
+    }
+
+    @Test
+    void decoderRejectsMalformedUtf8() {
+        final byte[] malformed = new byte[] { (byte) 0xC0, (byte) 0xAF };
+
+        assertThrows(IndexException.class,
+                () -> descriptor.getTypeDecoder().decode(malformed));
+    }
+
+    @Test
+    void estimatedSizeIncludesPrefixAndMaximumPayload() {
+        assertEquals(256,
+                descriptor.getEstimatedAverageSizeInBytes().orElseThrow());
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorUtf8StringTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/TypeDescriptorUtf8StringTest.java
@@ -1,0 +1,86 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.directory.MemFileReader;
+import org.junit.jupiter.api.Test;
+
+class TypeDescriptorUtf8StringTest {
+
+    private final TypeDescriptorUtf8String descriptor = new TypeDescriptorUtf8String();
+
+    @Test
+    void encoderAndDecoder_roundTripMultilingualValue() {
+        final String value = "Ahoj, Καλημέρα, こんにちは, 🙂";
+
+        final byte[] encoded = TestEncoding.toByteArray(
+                descriptor.getTypeEncoder(), value);
+        final String decoded = descriptor.getTypeDecoder().decode(encoded);
+
+        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), encoded);
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void writerAndReader_roundTrip128EmojiCodePoints() {
+        final String value = "🙂".repeat(128);
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final int written = descriptor.getTypeWriter().write(writer, value);
+        final byte[] frame = writer.toByteArray();
+        final String decoded = descriptor.getTypeReader()
+                .read(new MemFileReader(frame));
+
+        assertEquals(514, written);
+        assertArrayEquals(new byte[] { (byte) 0x80, 0x04 },
+                Arrays.copyOf(frame, 2));
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void writerAndReader_roundTrip64000EmojiCodePoints() {
+        final String value = "🙂".repeat(64_000);
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final int written = descriptor.getTypeWriter().write(writer, value);
+        final byte[] frame = writer.toByteArray();
+        final String decoded = descriptor.getTypeReader()
+                .read(new MemFileReader(frame));
+
+        assertEquals(256_003, written);
+        assertArrayEquals(
+                new byte[] { (byte) 0x80, (byte) 0xD0, (byte) 0x0F },
+                Arrays.copyOf(frame, 3));
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void decoderRejectsMalformedUtf8() {
+        final byte[] malformed = new byte[] { (byte) 0xF0, (byte) 0x9F };
+
+        assertThrows(IndexException.class,
+                () -> descriptor.getTypeDecoder().decode(malformed));
+    }
+
+    @Test
+    void descriptorContractsRemainStable() {
+        final TypeDescriptorUtf8String equalDescriptor = new TypeDescriptorUtf8String();
+        final TypeDescriptorTinyUtf8String differentDescriptor = new TypeDescriptorTinyUtf8String();
+
+        assertEquals(0, descriptor.getComparator().compare("same", "same"));
+        assertEquals(TypeDescriptorUtf8String.TOMBSTONE_VALUE,
+                descriptor.getTombstone());
+        assertEquals(descriptor, equalDescriptor);
+        assertEquals(descriptor.hashCode(), equalDescriptor.hashCode());
+        assertNotEquals(descriptor, differentDescriptor);
+        assertFalse(descriptor.getEstimatedAverageSizeInBytes().isPresent());
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/UnsignedByteLengthReaderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/UnsignedByteLengthReaderTest.java
@@ -1,0 +1,77 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.directory.MemFileReader;
+import org.junit.jupiter.api.Test;
+
+class UnsignedByteLengthReaderTest {
+
+    @Test
+    void read_returnsNullOnEofBeforePrefix() {
+        final UnsignedByteLengthReader<String> reader = createReader();
+
+        final String value = reader.read(new MemFileReader(new byte[0]));
+
+        assertNull(value);
+    }
+
+    @Test
+    void read_decodesEmptyPayload() {
+        final UnsignedByteLengthReader<String> reader = createReader();
+
+        final String value = reader
+                .read(new MemFileReader(new byte[] { 0 }));
+
+        assertEquals("", value);
+    }
+
+    @Test
+    void read_treatsPrefixAsUnsignedAt255Boundary() {
+        final UnsignedByteLengthReader<String> reader = createReader();
+        final byte[] frame = new byte[256];
+        frame[0] = (byte) 0xFF;
+        Arrays.fill(frame, 1, frame.length, (byte) 'a');
+
+        final String value = reader.read(new MemFileReader(frame));
+
+        assertEquals("a".repeat(255), value);
+    }
+
+    @Test
+    void read_rejectsTruncatedPayload() {
+        final UnsignedByteLengthReader<String> reader = createReader();
+        final MemFileReader fileReader = new MemFileReader(
+                new byte[] { 3, 'a', 'b' });
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> reader.read(fileReader));
+
+        assertEquals(
+                "Expected '3' bytes but reached EOF after '2' bytes.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsNullReader() {
+        final UnsignedByteLengthReader<String> reader = createReader();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> reader.read(null));
+    }
+
+    @Test
+    void constructorRejectsNullDecoder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new UnsignedByteLengthReader<String>(null));
+    }
+
+    private static UnsignedByteLengthReader<String> createReader() {
+        return new UnsignedByteLengthReader<>(Utf8StringCodec.INSTANCE);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/UnsignedByteLengthWriterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/UnsignedByteLengthWriterTest.java
@@ -1,0 +1,83 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class UnsignedByteLengthWriterTest {
+
+    @Test
+    void write_accepts255ByteBoundary() {
+        final UnsignedByteLengthWriter<String> writer = createWriter();
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final int written = writer.write(fileWriter, "a".repeat(255));
+        final byte[] frame = fileWriter.toByteArray();
+
+        assertEquals(256, written);
+        assertEquals(255, frame[0] & 0xFF);
+        assertEquals(256, frame.length);
+    }
+
+    @Test
+    void write_rejects256BytePayloadWithoutWritingPartialFrame() {
+        final UnsignedByteLengthWriter<String> writer = createWriter();
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> writer.write(fileWriter, "a".repeat(256)));
+
+        assertEquals("Encoded payload length '256' exceeds maximum '255'.",
+                error.getMessage());
+        assertEquals(0, fileWriter.toByteArray().length);
+    }
+
+    @Test
+    void write_writesZeroLengthPrefix() {
+        final UnsignedByteLengthWriter<String> writer = createWriter();
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final int written = writer.write(fileWriter, "");
+
+        assertEquals(1, written);
+        assertEquals(0, fileWriter.toByteArray()[0]);
+    }
+
+    @Test
+    void write_doesNotWriteWhenEncoderFails() {
+        final TypeEncoder<String> failingEncoder = (value,
+                reusableBuffer) -> {
+                    throw new IllegalArgumentException("bad payload");
+                };
+        final UnsignedByteLengthWriter<String> writer = new UnsignedByteLengthWriter<>(
+                failingEncoder);
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> writer.write(fileWriter, "value"));
+
+        assertEquals("bad payload", error.getMessage());
+        assertEquals(0, fileWriter.toByteArray().length);
+    }
+
+    @Test
+    void write_rejectsNullWriterBeforeEncoding() {
+        final UnsignedByteLengthWriter<String> writer = createWriter();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> writer.write(null, "value"));
+    }
+
+    @Test
+    void constructorRejectsNullEncoder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new UnsignedByteLengthWriter<String>(null));
+    }
+
+    private static UnsignedByteLengthWriter<String> createWriter() {
+        return new UnsignedByteLengthWriter<>(Utf8StringCodec.INSTANCE);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/UnsignedLeb128Test.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/UnsignedLeb128Test.java
@@ -1,0 +1,122 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.directory.MemFileReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class UnsignedLeb128Test {
+
+    @ParameterizedTest
+    @CsvSource({ "0, 1", "127, 1", "128, 2", "16383, 2", "16384, 3",
+            "2097151, 3", "2097152, 4", "268435455, 4",
+            "2147483647, 5" })
+    void writeAndRead_roundTripsBoundaryValues(final int value,
+            final int expectedBytes) {
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        final int written = UnsignedLeb128.write(writer, value);
+        final byte[] encoded = writer.toByteArray();
+        final int decoded = UnsignedLeb128
+                .read(new MemFileReader(encoded));
+
+        assertEquals(expectedBytes, written);
+        assertEquals(expectedBytes, encoded.length);
+        assertEquals(value, decoded);
+    }
+
+    @Test
+    void write_usesCanonicalLittleEndianBase128Order() {
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        UnsignedLeb128.write(writer, 16384);
+
+        assertArrayEquals(
+                new byte[] { (byte) 0x80, (byte) 0x80, (byte) 0x01 },
+                writer.toByteArray());
+    }
+
+    @Test
+    void write_rejectsNegativeValue() {
+        final ByteArrayWriter writer = new ByteArrayWriter();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> UnsignedLeb128.write(writer, -1));
+    }
+
+    @Test
+    void write_rejectsNullWriter() {
+        assertThrows(IllegalArgumentException.class,
+                () -> UnsignedLeb128.write(null, 0));
+    }
+
+    @Test
+    void read_returnsNegativeOneOnEofBeforePrefix() {
+        final int value = UnsignedLeb128
+                .read(new MemFileReader(new byte[0]));
+
+        assertEquals(-1, value);
+    }
+
+    @Test
+    void read_rejectsTruncatedPrefix() {
+        final MemFileReader reader = new MemFileReader(
+                new byte[] { (byte) 0x80 });
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> UnsignedLeb128.read(reader));
+
+        assertEquals("Truncated unsigned LEB128 length prefix.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsNonCanonicalPrefix() {
+        final MemFileReader reader = new MemFileReader(
+                new byte[] { (byte) 0x80, 0 });
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> UnsignedLeb128.read(reader));
+
+        assertEquals("Non-canonical unsigned LEB128 length prefix.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsIntegerOverflow() {
+        final byte[] prefix = new byte[] { (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, 0x08 };
+        final MemFileReader reader = new MemFileReader(prefix);
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> UnsignedLeb128.read(reader));
+
+        assertEquals(
+                "Unsigned LEB128 length exceeds the supported integer range.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsPrefixLongerThanFiveBytes() {
+        final byte[] prefix = new byte[] { (byte) 0x80, (byte) 0x80,
+                (byte) 0x80, (byte) 0x80, (byte) 0x80, 0 };
+        final MemFileReader reader = new MemFileReader(prefix);
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> UnsignedLeb128.read(reader));
+
+        assertEquals("Unsigned LEB128 length prefix exceeds five bytes.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsNullReader() {
+        assertThrows(IllegalArgumentException.class,
+                () -> UnsignedLeb128.read(null));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/Utf8StringCodecTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/Utf8StringCodecTest.java
@@ -1,0 +1,105 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.hestiastore.index.IndexException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class Utf8StringCodecTest {
+
+    private static final Utf8StringCodec CODEC = Utf8StringCodec.INSTANCE;
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "plain ASCII", "Příliš žluťoučký kůň",
+            "Кириллица", "漢字", "🙂", "👨‍👩‍👧‍👦", "e\u0301" })
+    void encodeAndDecode_roundTripsStandardUtf8(final String value) {
+        final EncodedBytes encoded = CODEC.encode(value, new byte[0]);
+        final byte[] payload = Arrays.copyOf(encoded.getBytes(),
+                encoded.getLength());
+
+        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), payload);
+        assertEquals(value, CODEC.decode(payload));
+    }
+
+    @Test
+    void encode_reusesSufficientCallerBuffer() {
+        final byte[] reusableBuffer = new byte[32];
+
+        final EncodedBytes encoded = CODEC.encode("🙂", reusableBuffer);
+
+        assertSame(reusableBuffer, encoded.getBytes());
+        assertEquals(4, encoded.getLength());
+        assertArrayEquals("🙂".getBytes(StandardCharsets.UTF_8),
+                Arrays.copyOf(encoded.getBytes(), encoded.getLength()));
+    }
+
+    @Test
+    void encode_growsInsufficientCallerBuffer() {
+        final String value = "漢字🙂";
+
+        final EncodedBytes encoded = CODEC.encode(value, new byte[1]);
+
+        assertEquals(value.getBytes(StandardCharsets.UTF_8).length,
+                encoded.getLength());
+        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8),
+                Arrays.copyOf(encoded.getBytes(), encoded.getLength()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "\uD800", "\uDC00" })
+    void encode_rejectsUnpairedSurrogates(final String malformed) {
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> CODEC.encode(malformed, new byte[0]));
+
+        assertEquals("String contains malformed UTF-16 input.",
+                error.getMessage());
+    }
+
+    @Test
+    void encode_rejectsNullValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CODEC.encode(null, new byte[0]));
+    }
+
+    @Test
+    void encode_rejectsNullReusableBuffer() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CODEC.encode("value", null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("malformedUtf8")
+    void decode_rejectsMalformedUtf8(final byte[] malformed) {
+        final IndexException error = assertThrows(IndexException.class,
+                () -> CODEC.decode(malformed));
+
+        assertEquals("Invalid UTF-8 payload.", error.getMessage());
+    }
+
+    @Test
+    void decode_rejectsNullSource() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CODEC.decode(null));
+    }
+
+    private static Stream<Arguments> malformedUtf8() {
+        return Stream.of(Arguments.of((Object) new byte[] { (byte) 0xC3, 0x28 }),
+                Arguments.of((Object) new byte[] { (byte) 0xF0, (byte) 0x9F }),
+                Arguments.of(
+                        (Object) new byte[] { (byte) 0xC0, (byte) 0xAF }),
+                Arguments.of((Object) new byte[] { (byte) 0xED, (byte) 0xA0,
+                        (byte) 0x80 }));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/VarIntLengthReaderTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/VarIntLengthReaderTest.java
@@ -1,0 +1,99 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.hestiastore.index.IndexException;
+import org.hestiastore.index.directory.MemFileReader;
+import org.junit.jupiter.api.Test;
+
+class VarIntLengthReaderTest {
+
+    @Test
+    void read_returnsNullOnEofBeforePrefix() {
+        final VarIntLengthReader<String> reader = createReader();
+
+        final String value = reader.read(new MemFileReader(new byte[0]));
+
+        assertNull(value);
+    }
+
+    @Test
+    void read_decodesEmptyPayload() {
+        final VarIntLengthReader<String> reader = createReader();
+
+        final String value = reader.read(new MemFileReader(new byte[] { 0 }));
+
+        assertEquals("", value);
+    }
+
+    @Test
+    void read_decodesTwoByteLengthPrefix() {
+        final VarIntLengthReader<String> reader = createReader();
+        final byte[] payload = "a".repeat(128)
+                .getBytes(StandardCharsets.UTF_8);
+        final byte[] frame = new byte[2 + payload.length];
+        frame[0] = (byte) 0x80;
+        frame[1] = 0x01;
+        System.arraycopy(payload, 0, frame, 2, payload.length);
+
+        final String value = reader.read(new MemFileReader(frame));
+
+        assertEquals("a".repeat(128), value);
+    }
+
+    @Test
+    void read_rejectsTruncatedPayload() {
+        final VarIntLengthReader<String> reader = createReader();
+        final MemFileReader fileReader = new MemFileReader(
+                new byte[] { 3, 'a', 'b' });
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> reader.read(fileReader));
+
+        assertEquals(
+                "Expected '3' bytes but reached EOF after '2' bytes.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsNonCanonicalLengthPrefix() {
+        final VarIntLengthReader<String> reader = createReader();
+        final MemFileReader fileReader = new MemFileReader(
+                new byte[] { (byte) 0x80, 0 });
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> reader.read(fileReader));
+
+        assertEquals("Non-canonical unsigned LEB128 length prefix.",
+                error.getMessage());
+    }
+
+    @Test
+    void read_rejectsFrameLengthThatWouldOverflowWrittenByteCount() {
+        final VarIntLengthReader<String> reader = createReader();
+        final byte[] maximumIntegerPrefix = new byte[] { (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x07 };
+        final MemFileReader fileReader = new MemFileReader(maximumIntegerPrefix);
+
+        final IndexException error = assertThrows(IndexException.class,
+                () -> reader.read(fileReader));
+
+        assertEquals(
+                "Encoded payload length '2147483647' exceeds maximum '2147483642'.",
+                error.getMessage());
+    }
+
+    @Test
+    void constructorRejectsNullDecoder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new VarIntLengthReader<String>(null));
+    }
+
+    private static VarIntLengthReader<String> createReader() {
+        return new VarIntLengthReader<>(Utf8StringCodec.INSTANCE);
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/datatype/VarIntLengthWriterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/datatype/VarIntLengthWriterTest.java
@@ -1,0 +1,75 @@
+package org.hestiastore.index.datatype;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class VarIntLengthWriterTest {
+
+    @Test
+    void write_writesTwoBytePrefixFor128BytePayload() {
+        final VarIntLengthWriter<String> writer = new VarIntLengthWriter<>(
+                Utf8StringCodec.INSTANCE);
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+        final String value = "a".repeat(128);
+
+        final int written = writer.write(fileWriter, value);
+        final byte[] bytes = fileWriter.toByteArray();
+
+        assertEquals(130, written);
+        assertArrayEquals(new byte[] { (byte) 0x80, 0x01 },
+                Arrays.copyOf(bytes, 2));
+        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8),
+                Arrays.copyOfRange(bytes, 2, bytes.length));
+    }
+
+    @Test
+    void write_writesCanonicalZeroLengthPrefix() {
+        final VarIntLengthWriter<String> writer = new VarIntLengthWriter<>(
+                Utf8StringCodec.INSTANCE);
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final int written = writer.write(fileWriter, "");
+
+        assertEquals(1, written);
+        assertArrayEquals(new byte[] { 0 }, fileWriter.toByteArray());
+    }
+
+    @Test
+    void write_doesNotWriteWhenEncoderFails() {
+        final TypeEncoder<String> failingEncoder = (value,
+                reusableBuffer) -> {
+                    throw new IllegalArgumentException("bad payload");
+                };
+        final VarIntLengthWriter<String> writer = new VarIntLengthWriter<>(
+                failingEncoder);
+        final ByteArrayWriter fileWriter = new ByteArrayWriter();
+
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> writer.write(fileWriter, "value"));
+
+        assertEquals("bad payload", error.getMessage());
+        assertEquals(0, fileWriter.toByteArray().length);
+    }
+
+    @Test
+    void write_rejectsNullWriterBeforeEncoding() {
+        final VarIntLengthWriter<String> writer = new VarIntLengthWriter<>(
+                Utf8StringCodec.INSTANCE);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> writer.write(null, "value"));
+    }
+
+    @Test
+    void constructorRejectsNullEncoder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new VarIntLengthWriter<String>(null));
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/DataTypeDescriptorRegistryTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/configuration/DataTypeDescriptorRegistryTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.hestiastore.index.datatype.TypeDescriptorTinyUtf8String;
+import org.hestiastore.index.datatype.TypeDescriptorUtf8String;
 import org.junit.jupiter.api.Test;
 
 class DataTypeDescriptorRegistryTest {
@@ -32,6 +34,26 @@ class DataTypeDescriptorRegistryTest {
 
         assertNotNull(ss);
         assertNotNull(ss.getTypeDecoder());
+    }
+
+    @Test
+    void makeInstanceCreatesUtf8StringDescriptors() {
+        final TypeDescriptor<String> general = DataTypeDescriptorRegistry
+                .makeInstance(TypeDescriptorUtf8String.class.getName());
+        final TypeDescriptor<String> tiny = DataTypeDescriptorRegistry
+                .makeInstance(TypeDescriptorTinyUtf8String.class.getName());
+
+        assertEquals(TypeDescriptorUtf8String.class, general.getClass());
+        assertEquals(TypeDescriptorTinyUtf8String.class, tiny.getClass());
+    }
+
+    @Test
+    void defaultStringDescriptorRemainsIso88591ForCompatibility() {
+        final String descriptorClass = DataTypeDescriptorRegistry
+                .getTypeDescriptor(String.class);
+
+        assertEquals(TypeDescriptorShortString.class.getName(),
+                descriptorClass);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add `TypeDescriptorTinyUtf8String` with an unsigned one-byte payload length for up to 255 UTF-8 bytes
- add `TypeDescriptorUtf8String` with a canonical unsigned LEB128 length for larger UTF-8 payloads
- reject malformed UTF-8 and invalid Java surrogate input instead of silently replacing data
- preserve `TypeDescriptorShortString` as the default `String` mapping for on-disk compatibility
- add direct codec, framing, descriptor, registry, and reopen integration coverage
- document emoji and multilingual string configuration, limits, and migration guidance

## Why

The existing string descriptors encode ISO-8859-1 and replace unsupported characters with `?`. Applications need an explicit, space-efficient UTF-8 option for emoji and text from other alphabets without changing the legacy on-disk default.

## Impact

UTF-8 support is opt-in through the key and value type descriptor configuration. Existing indexes keep their persisted descriptors and are not silently migrated. Applications moving existing data to UTF-8 must create a new index and migrate or rebuild it.

## Issue

No linked issue; requested directly.

## Validation

- `mvn clean verify` with Java 17 — all 10 reactor modules passed
- `python3 scripts/check_docs_nav.py`
- `mkdocs build --strict`
- `git diff --check`