### PR TITLE
Add WAL-disabled conditional mutations

### DIFF
--- a/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
+++ b/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
@@ -76,6 +76,34 @@ public class UniqueCache<K, V> {
     }
 
     /**
+     * Stores an entry only when its key is not already present.
+     *
+     * @param entry entry to store
+     * @return true when the entry was added
+     */
+    public boolean putIfAbsent(final Entry<K, V> entry) {
+        Vldtn.requireNonNull(entry, "entry");
+        final K key = Vldtn.requireNonNull(entry.getKey(), "entry.key");
+        final V value = Vldtn.requireNonNull(entry.getValue(), "entry.value");
+        return map.putIfAbsent(key, value) == null;
+    }
+
+    /**
+     * Replaces an entry only when its current value is the observed value.
+     *
+     * @param key key to replace
+     * @param observedValue value previously read from this cache
+     * @param newValue replacement value
+     * @return true when the value was replaced
+     */
+    public boolean replace(final K key, final V observedValue,
+            final V newValue) {
+        return map.replace(Vldtn.requireNonNull(key, "key"),
+                Vldtn.requireNonNull(observedValue, "observedValue"),
+                Vldtn.requireNonNull(newValue, "newValue"));
+    }
+
+    /**
      * Get value for given key or null when there is no such key.
      * 
      * @param key required key

--- a/engine/src/main/java/org/hestiastore/index/segment/Segment.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/Segment.java
@@ -176,6 +176,33 @@ public interface Segment<K, V> {
     OperationResult<Void> put(K key, V value);
 
     /**
+     * Writes directly into the in-memory segment cache only when the key is
+     * logically absent. Tombstones are treated as absence.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return result containing {@code true} when the value was inserted,
+     *         {@code false} when the key was already present, or
+     *         {@link OperationStatus#WRITE_CACHE_FULL} when no immediate write
+     *         capacity is available
+     */
+    OperationResult<Boolean> putIfAbsent(K key, V value);
+
+    /**
+     * Replaces a value only when the current logical value matches the expected
+     * value according to the configured value comparator.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return result containing {@code true} when the value was replaced,
+     *         {@code false} on absence or mismatch, or
+     *         {@link OperationStatus#WRITE_CACHE_FULL} when no immediate write
+     *         capacity is available
+     */
+    OperationResult<Boolean> replace(K key, V expectedValue, V newValue);
+
+    /**
      * Starts a flush of the in-memory write cache into the delta cache. The
      * call returns once flush is accepted.
      *

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCache.java
@@ -111,6 +111,62 @@ final class SegmentCache<K, V> {
     }
 
     /**
+     * Returns the raw value from the active write cache.
+     * <p>
+     * The caller must hold a segment write admission while using the returned
+     * value in a following conditional mutation, so maintenance cannot replace
+     * the active cache between those operations.
+     *
+     * @param key key to read
+     * @return active write-cache value or {@code null}
+     */
+    V getFromWriteCache(final K key) {
+        return writeCache.get(Vldtn.requireNonNull(key, "key"));
+    }
+
+    /**
+     * Replaces the active write-cache value only when it still equals the
+     * previously observed value.
+     *
+     * @param key key to replace
+     * @param observedValue exact value observed in the active write cache
+     * @param newValue replacement value
+     * @return true when the value was replaced
+     */
+    boolean replaceInWriteCache(final K key, final V observedValue,
+            final V newValue) {
+        return writeCache.replace(key, observedValue, newValue);
+    }
+
+    /**
+     * Attempts to insert an entry only when its key is absent from the active
+     * write cache.
+     *
+     * @param entry entry to insert
+     * @return true when the entry was inserted
+     */
+    boolean tryPutIfAbsentToWriteCacheWithoutWaiting(
+            final Entry<K, V> entry) {
+        final Entry<K, V> nonNullEntry = validateEntry(entry);
+        final UniqueCache<K, V> write = writeCache;
+        if (write.get(nonNullEntry.getKey()) != null
+                || !tryReserveWriteSlot()) {
+            return false;
+        }
+        final boolean added;
+        try {
+            added = write.putIfAbsent(nonNullEntry);
+        } catch (final RuntimeException e) {
+            releaseWriteSlots(1);
+            throw e;
+        }
+        if (!added) {
+            releaseWriteSlots(1);
+        }
+        return added;
+    }
+
+    /**
      * Adds an entry into the delta cache portion.
      *
      * @param entry entry to store

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCore.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCore.java
@@ -8,7 +8,9 @@ import java.util.function.Consumer;
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.EntryWriter;
+import org.hestiastore.index.OperationResult;
 import org.hestiastore.index.Vldtn;
+import org.hestiastore.index.datatype.TypeDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,6 +148,95 @@ final class SegmentCore<K, V> {
      */
     boolean tryPutWithoutWaiting(final K key, final V value) {
         return writePath.tryPutWithoutWaiting(key, value);
+    }
+
+    /**
+     * Inserts a value only when the key is logically absent.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return conditional mutation result
+     */
+    OperationResult<Boolean> tryPutIfAbsentWithoutWaiting(final K key,
+            final V value) {
+        final K nonNullKey = Vldtn.requireNonNull(key, "key");
+        final V nonNullValue = requireConditionalValue(value, "value");
+        return tryConditionalPutWithoutWaiting(nonNullKey, null, nonNullValue);
+    }
+
+    /**
+     * Replaces a value only when the current logical value matches the expected
+     * value according to the configured value comparator.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return conditional mutation result
+     */
+    OperationResult<Boolean> tryReplaceWithoutWaiting(final K key,
+            final V expectedValue, final V newValue) {
+        final K nonNullKey = Vldtn.requireNonNull(key, "key");
+        final V nonNullExpected = requireConditionalValue(expectedValue,
+                "expectedValue");
+        final V nonNullValue = requireConditionalValue(newValue, "newValue");
+        return tryConditionalPutWithoutWaiting(nonNullKey, nonNullExpected,
+                nonNullValue);
+    }
+
+    private OperationResult<Boolean> tryConditionalPutWithoutWaiting(
+            final K key, final V expectedValue, final V newValue) {
+        final TypeDescriptor<V> valueDescriptor = segmentFiles
+                .getValueTypeDescriptor();
+        while (true) {
+            final V observedValue = segmentCache.getFromWriteCache(key);
+            if (observedValue != null) {
+                final V logicalValue = valueDescriptor
+                        .isTombstone(observedValue) ? null : observedValue;
+                if (!matchesExpectedValue(valueDescriptor, logicalValue,
+                        expectedValue)) {
+                    return OperationResult.ok(false);
+                }
+                if (segmentCache.replaceInWriteCache(key, observedValue,
+                        newValue)) {
+                    return OperationResult.ok(true);
+                }
+                continue;
+            }
+
+            final V logicalValue = readPath.get(key);
+            if (!matchesExpectedValue(valueDescriptor, logicalValue,
+                    expectedValue)) {
+                return OperationResult.ok(false);
+            }
+            if (segmentCache.tryPutIfAbsentToWriteCacheWithoutWaiting(
+                    Entry.of(key, newValue))) {
+                return OperationResult.ok(true);
+            }
+            if (segmentCache.getFromWriteCache(key) == null) {
+                return OperationResult.writeCacheFull();
+            }
+        }
+    }
+
+    private boolean matchesExpectedValue(
+            final TypeDescriptor<V> valueDescriptor, final V currentValue,
+            final V expectedValue) {
+        if (expectedValue == null) {
+            return currentValue == null;
+        }
+        return currentValue != null && valueDescriptor.getComparator()
+                .compare(currentValue, expectedValue) == 0;
+    }
+
+    private V requireConditionalValue(final V value,
+            final String propertyName) {
+        final V nonNullValue = Vldtn.requireNonNull(value, propertyName);
+        if (segmentFiles.getValueTypeDescriptor()
+                .isTombstone(nonNullValue)) {
+            throw new IllegalArgumentException(String.format(
+                    "Property '%s' must not be a tombstone.", propertyName));
+        }
+        return nonNullValue;
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
@@ -225,6 +225,51 @@ class SegmentImpl<K, V> implements Segment<K, V> {
         return OperationResult.busy();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public OperationResult<Boolean> putIfAbsent(final K key, final V value) {
+        if (!gate.tryEnterWrite()) {
+            return resultForState(gate.getState());
+        }
+        final OperationResult<Boolean> result;
+        try {
+            result = core.tryPutIfAbsentWithoutWaiting(key, value);
+        } finally {
+            gate.exitWrite();
+        }
+        return completeConditionalMutation(result);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OperationResult<Boolean> replace(final K key,
+            final V expectedValue, final V newValue) {
+        if (!gate.tryEnterWrite()) {
+            return resultForState(gate.getState());
+        }
+        final OperationResult<Boolean> result;
+        try {
+            result = core.tryReplaceWithoutWaiting(key, expectedValue,
+                    newValue);
+        } finally {
+            gate.exitWrite();
+        }
+        return completeConditionalMutation(result);
+    }
+
+    private OperationResult<Boolean> completeConditionalMutation(
+            final OperationResult<Boolean> result) {
+        if (result.isOk() && !Boolean.TRUE.equals(result.getValue())) {
+            return result;
+        }
+        scheduleMaintenanceIfNeeded();
+        if (result.getStatus() == OperationStatus.WRITE_CACHE_FULL
+                && gate.getState() != SegmentState.READY) {
+            return OperationResult.busy();
+        }
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import org.hestiastore.index.CloseableResource;
 import org.hestiastore.index.Entry;
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.chunkstore.ChunkFilterProviderResolver;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuning;
@@ -312,6 +313,33 @@ public interface SegmentIndex<K, V> extends CloseableResource {
         Vldtn.requireNonNull(entry, "entry");
         put(entry.getKey(), entry.getValue());
     }
+
+    /**
+     * Inserts a value only when the key is logically absent. A deleted
+     * (tombstoned) key is considered absent.
+     * <p>
+     * This operation is currently supported only when WAL is disabled.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return true when the value was inserted
+     * @throws IndexException when WAL is enabled
+     */
+    boolean putIfAbsent(K key, V value);
+
+    /**
+     * Replaces a value only when its current value matches
+     * {@code expectedValue} according to the configured value comparator.
+     * <p>
+     * This operation is currently supported only when WAL is disabled.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return true when the value was replaced
+     * @throws IndexException when WAL is enabled
+     */
+    boolean replace(K key, V expectedValue, V newValue);
 
     /**
      * Performs a point lookup for the given key.

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/PointOperationCoordinator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/PointOperationCoordinator.java
@@ -1,5 +1,6 @@
 package org.hestiastore.index.segmentindex.core.execution;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.segmentindex.core.routing.MappedSegmentLease;
@@ -19,6 +20,7 @@ public final class PointOperationCoordinator<K, V> {
     private final MappedSegmentLeaseService<K, V> segmentLeaseService;
     private final StorageCoordinator<K, V> storageService;
     private final TypeDescriptor<V> valueTypeDescriptor;
+    private final boolean walEnabled;
 
     /**
      * Creates an operation coordinator from initialized runtime services.
@@ -27,12 +29,14 @@ public final class PointOperationCoordinator<K, V> {
      * @param statsRecorder operation metrics recorder
      * @param segmentLeaseService segment lease service
      * @param storageService storage and WAL service
+     * @param walEnabled whether WAL is enabled for this index
      */
     public PointOperationCoordinator(
             final TypeDescriptor<V> valueTypeDescriptor,
             final IndexOperationStatsRecorder statsRecorder,
             final MappedSegmentLeaseService<K, V> segmentLeaseService,
-            final StorageCoordinator<K, V> storageService) {
+            final StorageCoordinator<K, V> storageService,
+            final boolean walEnabled) {
         this.statsRecorder = Vldtn.requireNonNull(statsRecorder,
                 "statsRecorder");
         this.segmentLeaseService = Vldtn.requireNonNull(segmentLeaseService,
@@ -41,6 +45,7 @@ public final class PointOperationCoordinator<K, V> {
                 "storageService");
         this.valueTypeDescriptor = Vldtn.requireNonNull(valueTypeDescriptor,
                 "valueTypeDescriptor");
+        this.walEnabled = walEnabled;
     }
 
     /**
@@ -60,6 +65,50 @@ public final class PointOperationCoordinator<K, V> {
         writeToSegment(nonNullKey, nonNullValue);
         storageService.recordAppliedWalLsn(walLsn);
         recordWriteLatency(startedNanos);
+    }
+
+    /**
+     * Inserts a value only when its key is logically absent.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return true when the value was inserted
+     * @throws IndexException when WAL is enabled
+     */
+    public boolean putIfAbsent(final K key, final V value) {
+        rejectConditionalMutationWhenWalEnabled();
+        final long startedNanos = startWriteOperation();
+        final K nonNullKey = requireKey(key);
+        final V nonNullValue = requireConditionalValue(value, "value");
+        statsRecorder.recordPutRequest();
+        final boolean changed = putIfAbsentInSegment(nonNullKey,
+                nonNullValue);
+        recordWriteLatency(startedNanos);
+        return changed;
+    }
+
+    /**
+     * Replaces a value only when its current value matches the expected value.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return true when the value was replaced
+     * @throws IndexException when WAL is enabled
+     */
+    public boolean replace(final K key, final V expectedValue,
+            final V newValue) {
+        rejectConditionalMutationWhenWalEnabled();
+        final long startedNanos = startWriteOperation();
+        final K nonNullKey = requireKey(key);
+        final V nonNullExpected = requireConditionalValue(expectedValue,
+                "expectedValue");
+        final V nonNullValue = requireConditionalValue(newValue, "newValue");
+        statsRecorder.recordPutRequest();
+        final boolean changed = replaceInSegment(nonNullKey, nonNullExpected,
+                nonNullValue);
+        recordWriteLatency(startedNanos);
+        return changed;
     }
 
     /**
@@ -124,6 +173,21 @@ public final class PointOperationCoordinator<K, V> {
         }
     }
 
+    private boolean putIfAbsentInSegment(final K key, final V value) {
+        try (MappedSegmentLease<K, V> lease = segmentLeaseService
+                .acquireForWrite(key)) {
+            return lease.segment().putIfAbsent(key, value);
+        }
+    }
+
+    private boolean replaceInSegment(final K key, final V expectedValue,
+            final V newValue) {
+        try (MappedSegmentLease<K, V> lease = segmentLeaseService
+                .acquireForWrite(key)) {
+            return lease.segment().replace(key, expectedValue, newValue);
+        }
+    }
+
     private long startWriteOperation() {
         return System.nanoTime();
     }
@@ -140,12 +204,29 @@ public final class PointOperationCoordinator<K, V> {
         return Vldtn.requireNonNull(value, "value");
     }
 
+    private V requireConditionalValue(final V value,
+            final String propertyName) {
+        final V nonNullValue = Vldtn.requireNonNull(value, propertyName);
+        if (valueTypeDescriptor.isTombstone(nonNullValue)) {
+            throw new IllegalArgumentException(String.format(
+                    "Property '%s' must not be a tombstone.", propertyName));
+        }
+        return nonNullValue;
+    }
+
     private void rejectTombstoneValue(final V value) {
         if (!valueTypeDescriptor.isTombstone(value)) {
             return;
         }
         throw new IllegalArgumentException(String.format(
                 "Can't insert tombstone value '%s' into index", value));
+    }
+
+    private void rejectConditionalMutationWhenWalEnabled() {
+        if (walEnabled) {
+            throw new IndexException(
+                    "Conditional mutations are supported only when WAL is disabled.");
+        }
     }
 
     private V tombstoneValue() {

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexBootstrapOperation.java
@@ -460,7 +460,8 @@ public final class SegmentIndexBootstrapOperation<K, V> {
                 state.getValueTypeDescriptor(),
                 sessionResources.operationStatsRecorder(),
                 state.getRuntimeSegmentLeaseService(),
-                state.getStorageService()));
+                state.getStorageService(),
+                state.getConfiguration().wal().isEnabled()));
     }
 
     private void transferRuntimeCloseOwnership(

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
@@ -61,6 +61,21 @@ final class SegmentIndexMdcLoggingAdapter<K, V>
     }
 
     @Override
+    public boolean putIfAbsent(final K key, final V value) {
+        try (IndexMdcScope ignored = openScope()) {
+            return delegate.putIfAbsent(key, value);
+        }
+    }
+
+    @Override
+    public boolean replace(final K key, final V expectedValue,
+            final V newValue) {
+        try (IndexMdcScope ignored = openScope()) {
+            return delegate.replace(key, expectedValue, newValue);
+        }
+    }
+
+    @Override
     public V get(final K key) {
         try (IndexMdcScope ignored = openScope()) {
             return delegate.get(key);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
@@ -111,6 +111,29 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean putIfAbsent(final K key, final V value) {
+        beginOperationalOperation();
+        try {
+            return operationAccess.putIfAbsent(key, value);
+        } finally {
+            operationGate.endOperation();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean replace(final K key, final V expectedValue,
+            final V newValue) {
+        beginOperationalOperation();
+        try {
+            return operationAccess.replace(key, expectedValue, newValue);
+        } finally {
+            operationGate.endOperation();
+        }
+    }
+
     /**
      * Opens an iterator for one segment with fail-fast isolation.
      *

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
@@ -86,6 +86,47 @@ public interface BlockingSegment<K, V> {
     void put(K key, V value);
 
     /**
+     * Performs a single-attempt conditional insert without retrying
+     * BUSY/CLOSED.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return raw segment result
+     */
+    OperationResult<Boolean> tryPutIfAbsent(K key, V value);
+
+    /**
+     * Performs a blocking insert only when the key is logically absent.
+     *
+     * @param key key to write
+     * @param value value to write
+     * @return true when the value was inserted
+     */
+    boolean putIfAbsent(K key, V value);
+
+    /**
+     * Performs a single-attempt conditional replacement without retrying
+     * BUSY/CLOSED.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return raw segment result
+     */
+    OperationResult<Boolean> tryReplace(K key, V expectedValue, V newValue);
+
+    /**
+     * Performs a blocking replacement when the current value matches the
+     * expected value.
+     *
+     * @param key key to replace
+     * @param expectedValue expected current value
+     * @param newValue replacement value
+     * @return true when the value was replaced
+     */
+    boolean replace(K key, V expectedValue, V newValue);
+
+    /**
      * Opens an iterator in a single attempt without retrying BUSY/CLOSED.
      *
      * @param isolation iterator isolation

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -102,6 +102,31 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
     }
 
     @Override
+    public OperationResult<Boolean> tryPutIfAbsent(final K key,
+            final V value) {
+        return currentSegment().putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean putIfAbsent(final K key, final V value) {
+        return runBlocking("putIfAbsent",
+                segmentValue -> segmentValue.putIfAbsent(key, value));
+    }
+
+    @Override
+    public OperationResult<Boolean> tryReplace(final K key,
+            final V expectedValue, final V newValue) {
+        return currentSegment().replace(key, expectedValue, newValue);
+    }
+
+    @Override
+    public boolean replace(final K key, final V expectedValue,
+            final V newValue) {
+        return runBlocking("replace", segmentValue -> segmentValue.replace(key,
+                expectedValue, newValue));
+    }
+
+    @Override
     public EntryIterator<K, V> openIterator() {
         return openIterator(SegmentIteratorIsolation.FAIL_FAST);
     }

--- a/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
@@ -106,6 +106,24 @@ class UniqueCacheTest {
     }
 
     @Test
+    void putIfAbsent_does_not_overwrite_existing_value() {
+        assertTrue(cache.putIfAbsent(Entry.of(10, "hello")));
+        assertFalse(cache.putIfAbsent(Entry.of(10, "dear")));
+
+        assertEquals("hello", cache.get(10));
+    }
+
+    @Test
+    void replace_requires_the_observed_value() {
+        cache.put(Entry.of(10, "hello"));
+
+        assertFalse(cache.replace(10, "other", "dear"));
+        assertTrue(cache.replace(10, "hello", "dear"));
+
+        assertEquals("dear", cache.get(10));
+    }
+
+    @Test
     void test_constructor_null_comparator_throws() {
         final Exception e = assertThrows(IllegalArgumentException.class,
                 this::buildWithNullComparator);

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentCacheTest.java
@@ -351,6 +351,23 @@ class SegmentCacheTest {
     }
 
     @Test
+    void conditional_write_primitives_are_atomic_and_preserve_capacity() {
+        final SegmentCache<Integer, String> cache = new SegmentCache<>(
+                keyType.getComparator(), valueType, List.of(), 1, 2, 1024);
+
+        assertTrue(cache.tryPutIfAbsentToWriteCacheWithoutWaiting(
+                Entry.of(1, "A")));
+        assertFalse(cache.tryPutIfAbsentToWriteCacheWithoutWaiting(
+                Entry.of(1, "B")));
+        assertFalse(cache.replaceInWriteCache(1, "B", "C"));
+        assertTrue(cache.replaceInWriteCache(1, "A", "C"));
+        assertEquals("C", cache.getFromWriteCache(1));
+        assertFalse(cache.tryPutIfAbsentToWriteCacheWithoutWaiting(
+                Entry.of(2, "D")));
+        assertEquals(1, cache.getNumberOfKeysInWriteCache());
+    }
+
+    @Test
     void put_overwrite_does_not_block_at_capacity() throws Exception {
         final SegmentCache<Integer, String> cache = new SegmentCache<>(
                 keyType.getComparator(), valueType, List.of(), 1, 2, 1024);

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentCoreTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentCoreTest.java
@@ -3,6 +3,7 @@ package org.hestiastore.index.segment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,7 +15,10 @@ import org.hestiastore.index.AbstractCloseableResource;
 import org.hestiastore.index.Entry;
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.EntryIteratorWithCurrent;
+import org.hestiastore.index.OperationResult;
+import org.hestiastore.index.OperationStatus;
 import org.hestiastore.index.chunkentryfile.ChunkEntryFile;
+import org.hestiastore.index.datatype.TypeDescriptor;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.junit.jupiter.api.AfterEach;
@@ -43,6 +47,8 @@ class SegmentCoreTest {
     private SegmentMaintenancePath<Integer, String> maintenancePath;
     @Mock
     private ChunkEntryFile<Integer, String> indexFile;
+    @Mock
+    private TypeDescriptor<String> conditionalValueDescriptor;
 
     private final TypeDescriptorInteger keyDescriptor = new TypeDescriptorInteger();
     private final TypeDescriptorShortString valueDescriptor = new TypeDescriptorShortString();
@@ -80,6 +86,66 @@ class SegmentCoreTest {
         assertEquals(0, core.getNumberOfKeysInWriteCache());
         assertTrue(core.tryPutWithoutWaiting(1, "one"));
         assertEquals(1, core.getNumberOfKeysInWriteCache());
+    }
+
+    @Test
+    void replace_uses_atomic_active_write_cache_replacement() {
+        when(segmentFiles.getValueTypeDescriptor())
+                .thenReturn(conditionalValueDescriptor);
+        when(conditionalValueDescriptor.getComparator())
+                .thenReturn(String.CASE_INSENSITIVE_ORDER);
+        when(segmentCache.getFromWriteCache(1)).thenReturn("ONE");
+        when(segmentCache.replaceInWriteCache(1, "ONE", "new"))
+                .thenReturn(true);
+
+        final OperationResult<Boolean> result = core
+                .tryReplaceWithoutWaiting(1, "one", "new");
+
+        assertEquals(OperationStatus.OK, result.getStatus());
+        assertTrue(result.getValue());
+        verify(readPath, never()).get(1);
+    }
+
+    @Test
+    void replace_returns_false_for_mismatched_active_value() {
+        when(segmentFiles.getValueTypeDescriptor())
+                .thenReturn(valueDescriptor);
+        when(segmentCache.getFromWriteCache(1)).thenReturn("other");
+
+        final OperationResult<Boolean> result = core
+                .tryReplaceWithoutWaiting(1, "one", "new");
+
+        assertEquals(OperationStatus.OK, result.getStatus());
+        assertFalse(result.getValue());
+        verify(segmentCache, never()).replaceInWriteCache(1, "other", "new");
+    }
+
+    @Test
+    void putIfAbsent_inserts_after_complete_logical_read() {
+        when(segmentFiles.getValueTypeDescriptor())
+                .thenReturn(valueDescriptor);
+        when(readPath.get(1)).thenReturn(null);
+        when(segmentCache.tryPutIfAbsentToWriteCacheWithoutWaiting(
+                Entry.of(1, "one"))).thenReturn(true);
+
+        final OperationResult<Boolean> result = core
+                .tryPutIfAbsentWithoutWaiting(1, "one");
+
+        assertEquals(OperationStatus.OK, result.getStatus());
+        assertTrue(result.getValue());
+        verify(readPath).get(1);
+    }
+
+    @Test
+    void putIfAbsent_reports_full_cache_when_insert_cannot_reserve_capacity() {
+        when(segmentFiles.getValueTypeDescriptor())
+                .thenReturn(valueDescriptor);
+        when(readPath.get(1)).thenReturn(null);
+
+        final OperationResult<Boolean> result = core
+                .tryPutIfAbsentWithoutWaiting(1, "one");
+
+        assertEquals(OperationStatus.WRITE_CACHE_FULL, result.getStatus());
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplConcurrencyContractTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.OperationResult;
@@ -174,6 +175,26 @@ class SegmentImplConcurrencyContractTest {
     }
 
     @Test
+    void conditional_mutation_reuses_active_slot_when_cache_is_full() {
+        final Segment<Integer, String> segment = newSegment(1);
+        try {
+            assertEquals(OperationStatus.OK,
+                    segment.put(1, "a").getStatus());
+            assertEquals(OperationStatus.WRITE_CACHE_FULL,
+                    segment.putIfAbsent(2, "b").getStatus());
+
+            final OperationResult<Boolean> replaced = segment.replace(1, "a",
+                    "c");
+
+            assertEquals(OperationStatus.OK, replaced.getStatus());
+            assertTrue(replaced.getValue());
+            assertEquals("c", segment.get(1).getValue());
+        } finally {
+            closeAndAssertClosed(segment);
+        }
+    }
+
+    @Test
     void put_returns_busy_when_write_cache_full_during_manual_maintenance() {
         final CapturingExecutor executor = new CapturingExecutor();
         final Segment<Integer, String> segment = newSegment(2, executor);
@@ -307,6 +328,68 @@ class SegmentImplConcurrencyContractTest {
                 assertEquals("v" + i, result.getValue());
             }
         } finally {
+            closeAndAssertClosed(segment);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void concurrent_conditional_mutations_have_one_winner()
+            throws Exception {
+        final Segment<Integer, String> segment = newSegment(32);
+        final int threads = 16;
+        final ExecutorService executor = Executors.newFixedThreadPool(threads);
+        final CountDownLatch ready = new CountDownLatch(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final AtomicInteger replaced = new AtomicInteger();
+        final AtomicInteger inserted = new AtomicInteger();
+        try {
+            assertEquals(OperationStatus.OK,
+                    segment.put(1, "start").getStatus());
+            final Future<?>[] tasks = new Future<?>[threads];
+            for (int i = 0; i < threads; i++) {
+                final int worker = i;
+                tasks[i] = executor.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(
+                                "Worker interrupted before start", e);
+                    }
+                    final OperationResult<Boolean> result = segment.replace(1,
+                            "start", "value-" + worker);
+                    if (result.getStatus() != OperationStatus.OK) {
+                        throw new IllegalStateException(
+                                "Replace returned " + result.getStatus());
+                    }
+                    if (Boolean.TRUE.equals(result.getValue())) {
+                        replaced.incrementAndGet();
+                    }
+                    final OperationResult<Boolean> insertResult = segment
+                            .putIfAbsent(2, "insert-" + worker);
+                    if (insertResult.getStatus() != OperationStatus.OK) {
+                        throw new IllegalStateException(
+                                "Put-if-absent returned "
+                                        + insertResult.getStatus());
+                    }
+                    if (Boolean.TRUE.equals(insertResult.getValue())) {
+                        inserted.incrementAndGet();
+                    }
+                });
+            }
+            assertTrue(ready.await(2, TimeUnit.SECONDS));
+            start.countDown();
+            for (final Future<?> task : tasks) {
+                task.get(2, TimeUnit.SECONDS);
+            }
+
+            assertEquals(1, replaced.get());
+            assertEquals(1, inserted.get());
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
             closeAndAssertClosed(segment);
         }
     }

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentImplTest.java
@@ -259,6 +259,32 @@ class SegmentImplTest {
     }
 
     @Test
+    void conditional_mutations_use_logical_value_across_cache_layers() {
+        assertTrue(subject.putIfAbsent(1, "A").getValue());
+        assertFalse(subject.putIfAbsent(1, "B").getValue());
+        assertEquals(OperationStatus.OK, subject.flush().getStatus());
+
+        assertFalse(subject.replace(1, "other", "B").getValue());
+        assertTrue(subject.replace(1, "A", "B").getValue());
+        assertEquals("B", subject.get(1).getValue());
+
+        assertEquals(OperationStatus.OK,
+                subject.put(1, tds.getTombstone()).getStatus());
+        assertTrue(subject.putIfAbsent(1, "C").getValue());
+        assertEquals("C", subject.get(1).getValue());
+    }
+
+    @Test
+    void conditional_mutations_reject_tombstones() {
+        assertThrows(IllegalArgumentException.class,
+                () -> subject.putIfAbsent(1, tds.getTombstone()));
+        assertThrows(IllegalArgumentException.class,
+                () -> subject.replace(1, tds.getTombstone(), "A"));
+        assertThrows(IllegalArgumentException.class,
+                () -> subject.replace(1, "A", tds.getTombstone()));
+    }
+
+    @Test
     void flush_noop_when_write_cache_empty() {
         assertEquals(OperationStatus.OK, subject.flush().getStatus());
 

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentTest.java
@@ -80,6 +80,18 @@ class SegmentTest {
         }
 
         @Override
+        public OperationResult<Boolean> putIfAbsent(final Integer key,
+                final String value) {
+            return OperationResult.ok(false);
+        }
+
+        @Override
+        public OperationResult<Boolean> replace(final Integer key,
+                final String expectedValue, final String newValue) {
+            return OperationResult.ok(false);
+        }
+
+        @Override
         public OperationResult<Void> flush() {
             return OperationResult.ok();
         }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/PointOperationCoordinatorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/PointOperationCoordinatorTest.java
@@ -1,11 +1,15 @@
 package org.hestiastore.index.segmentindex.core.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.segmentindex.core.routing.MappedSegmentLease;
 import org.hestiastore.index.segmentindex.core.routing.MappedSegmentLeaseService;
@@ -43,7 +47,7 @@ class PointOperationCoordinatorTest {
     void setUp() {
         statsRecorder = new IndexOperationStatsRecorder();
         coordinator = new PointOperationCoordinator<>(typeDescriptor,
-                statsRecorder, segmentLeaseService, storageService);
+                statsRecorder, segmentLeaseService, storageService, false);
     }
 
     @Test
@@ -123,5 +127,54 @@ class PointOperationCoordinatorTest {
         assertThrows(IllegalArgumentException.class,
                 () -> coordinator.put(1,
                         TypeDescriptorShortString.TOMBSTONE_VALUE));
+    }
+
+    @Test
+    void putIfAbsent_routes_without_wal_activity() {
+        when(segmentLeaseService.acquireForWrite(1)).thenReturn(segmentLease);
+        when(segmentLease.segment()).thenReturn(blockingSegment);
+        when(blockingSegment.putIfAbsent(1, "one")).thenReturn(true);
+
+        assertTrue(coordinator.putIfAbsent(1, "one"));
+
+        assertEquals(1L, statsRecorder.statsSnapshot().getPutCount());
+        verify(blockingSegment).putIfAbsent(1, "one");
+        verify(segmentLease).close();
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    void replace_routes_without_wal_activity() {
+        when(segmentLeaseService.acquireForWrite(1)).thenReturn(segmentLease);
+        when(segmentLease.segment()).thenReturn(blockingSegment);
+        when(blockingSegment.replace(1, "one", "new")).thenReturn(false);
+
+        assertFalse(coordinator.replace(1, "one", "new"));
+
+        assertEquals(1L, statsRecorder.statsSnapshot().getPutCount());
+        verify(blockingSegment).replace(1, "one", "new");
+        verify(segmentLease).close();
+        verifyNoInteractions(storageService);
+    }
+
+    @Test
+    void conditional_mutations_fail_before_routing_when_wal_is_enabled() {
+        coordinator = new PointOperationCoordinator<>(typeDescriptor,
+                statsRecorder, segmentLeaseService, storageService, true);
+
+        final IndexException putIfAbsentFailure = assertThrows(
+                IndexException.class,
+                () -> coordinator.putIfAbsent(1, "one"));
+        final IndexException replaceFailure = assertThrows(IndexException.class,
+                () -> coordinator.replace(1, "one", "new"));
+
+        assertEquals(
+                "Conditional mutations are supported only when WAL is disabled.",
+                putIfAbsentFailure.getMessage());
+        assertEquals(putIfAbsentFailure.getMessage(),
+                replaceFailure.getMessage());
+        assertEquals(0L, statsRecorder.statsSnapshot().getPutCount());
+        verifyNoInteractions(segmentLeaseService, storageService,
+                segmentLease, blockingSegment);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapterTest.java
@@ -1,9 +1,11 @@
 package org.hestiastore.index.segmentindex.core.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,6 +101,28 @@ class SegmentIndexMdcLoggingAdapterTest {
 
         adapter.close();
         assertEquals("idx", mdcAtClose.get());
+        assertNull(MDC.get("index.name"));
+    }
+
+    @Test
+    void wraps_conditional_mutations_with_mdc() {
+        final AtomicReference<String> mdcAtPutIfAbsent = new AtomicReference<>();
+        final AtomicReference<String> mdcAtReplace = new AtomicReference<>();
+        when(delegate.putIfAbsent("key", "value")).thenAnswer(invocation -> {
+            mdcAtPutIfAbsent.set(MDC.get("index.name"));
+            return true;
+        });
+        when(delegate.replace("key", "value", "new"))
+                .thenAnswer(invocation -> {
+                    mdcAtReplace.set(MDC.get("index.name"));
+                    return false;
+                });
+
+        assertTrue(adapter.putIfAbsent("key", "value"));
+        assertFalse(adapter.replace("key", "value", "new"));
+
+        assertEquals("idx", mdcAtPutIfAbsent.get());
+        assertEquals("idx", mdcAtReplace.get());
         assertNull(MDC.get("index.name"));
     }
 

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionPutTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSessionPutTest.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentindex.core.session;
 
 import static org.hestiastore.index.segmentindex.configuration.effective.EffectiveIndexConfigurationTestSupport.effective;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,6 +17,7 @@ import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.IndexException;
 import org.hestiastore.index.segment.Segment;
 import org.hestiastore.index.segment.SegmentId;
 import org.hestiastore.index.segment.SegmentState;
@@ -62,6 +64,44 @@ class SegmentIndexSessionPutTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> index.put(1, TypeDescriptorShortString.TOMBSTONE_VALUE));
+    }
+
+    @Test
+    void conditional_mutations_work_when_wal_is_disabled() {
+        resetIndex(10, 3);
+
+        assertTrue(index.putIfAbsent(1, "one"));
+        assertFalse(index.putIfAbsent(1, "other"));
+        index.maintenance().flushAndWait();
+
+        assertFalse(index.replace(1, "other", "new"));
+        assertTrue(index.replace(1, "one", "new"));
+        assertEquals("new", index.get(1));
+
+        index.delete(1);
+        assertTrue(index.putIfAbsent(1, "restored"));
+        assertEquals("restored", index.get(1));
+    }
+
+    @Test
+    void conditional_mutations_are_rejected_without_changes_when_wal_is_enabled() {
+        resetIndex(10, 2, IndexWalConfiguration.builder()
+                .durability(WalDurabilityMode.SYNC).build());
+
+        final IndexException putIfAbsentFailure = assertThrows(
+                IndexException.class, () -> index.putIfAbsent(1, "one"));
+        assertNull(index.get(1));
+
+        index.put(1, "one");
+        final IndexException replaceFailure = assertThrows(IndexException.class,
+                () -> index.replace(1, "one", "new"));
+
+        assertEquals(
+                "Conditional mutations are supported only when WAL is disabled.",
+                putIfAbsentFailure.getMessage());
+        assertEquals(putIfAbsentFailure.getMessage(),
+                replaceFailure.getMessage());
+        assertEquals("one", index.get(1));
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegmentTest.java
@@ -114,6 +114,30 @@ class DefaultBlockingSegmentTest {
     }
 
     @Test
+    void putIfAbsent_retries_write_cache_full_when_maintenance_enabled() {
+        handle = newHandle(true);
+        when(segment.putIfAbsent(1, "one"))
+                .thenReturn(OperationResult.writeCacheFull())
+                .thenReturn(OperationResult.ok(true));
+
+        assertTrue(handle.putIfAbsent(1, "one"));
+
+        verify(segment, times(2)).putIfAbsent(1, "one");
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
+    void replace_returns_condition_result() {
+        when(segment.replace(1, "one", "new"))
+                .thenReturn(OperationResult.ok(false));
+
+        assertFalse(handle.replace(1, "one", "new"));
+
+        verify(segment).replace(1, "one", "new");
+        verifyNoInteractions(segmentRegistry);
+    }
+
+    @Test
     void compactThrowsOnErrorStatus() {
         when(segment.compact()).thenReturn(OperationResult.error());
 


### PR DESCRIPTION
## Summary

- add atomic `putIfAbsent` and compare-and-replace operations to `SegmentIndex`
- use native concurrent-cache atomics across active and persisted segment layers without striped locks
- reject conditional mutations before routing or storage activity when WAL is enabled
- preserve the existing ordinary `put()` path

## Why

Conditional point mutations previously required a non-atomic get/put composition. This adds segment-native compare-and-set behavior while deliberately deferring the WAL protocol.

Closes #330

## Validation

- `mvn clean verify`
- focused conditional-mutation suite: 147 tests passed
- same-key concurrency tests verify a single winner for both operations
- existing hot-put JMH path was rechecked; measurements were too noisy for a regression conclusion, and the ordinary `put()` implementation remains unchanged

## WAL limitation

WAL-enabled indexes fail fast with `IndexException`; no lease, segment mutation, or WAL append occurs. WAL-enabled conditional durability remains intentionally out of scope.