### PR TITLE
Add efficient bounded key-range scans

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,6 +38,8 @@ java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar ByteSequenceCrc32Bench
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar StringEncodingBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexGetBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMultiSegmentGetBenchmark
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexRangeScanBenchmark
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentMergeSequentialBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexHotRoutePutBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMixedDrainBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexPersistedMutationBenchmark
@@ -61,7 +63,16 @@ java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "SortedDataFileWriterB
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "StringEncodingBenchmark" -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexGetBenchmark -p readPathMode=live -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMultiSegmentGetBenchmark -p workingSetMode=cold -prof gc
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexRangeScanBenchmark -prof gc
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentMergeSequentialBenchmark -prof gc
 ```
+
+The range-scan benchmark compares the bounded API with full-stream filtering
+and also measures a complete sequential read. All measurements use `FAIL_FAST`
+and reject an invocation unless it returns the complete expected result. This
+prevents maintenance, cache-capacity eviction, or index closing from appearing
+as an artificial speedup. The segment-merge benchmark isolates the unbounded
+per-entry hot loop so bounded-scan checks cannot regress it unnoticed.
 
 Mixed partitioned-ingest workloads with concurrent reads:
 

--- a/benchmarks/benchmark-history.md
+++ b/benchmarks/benchmark-history.md
@@ -27,6 +27,11 @@ Both SegmentIndex profiles currently include:
 - `SegmentIndexGetBenchmark` with `readPathMode=persisted`
 - `SegmentIndexGetBenchmark` with `readPathMode=live`
 - `SegmentIndexMultiSegmentGetBenchmark` with `workingSetMode=hot`
+- `SegmentIndexRangeScanBenchmark`, comparing the bounded API with full-stream
+  filtering, measuring complete sequential reads, and rejecting truncated
+  `FAIL_FAST` results
+- `SegmentMergeSequentialBenchmark`, protecting the unbounded per-entry merge
+  loop from bounded-scan overhead
 - `SegmentIndexPersistedMutationBenchmark` for persisted `put`/`delete` at one
   writer and 16 concurrent writers
 - `SegmentIndexHotRoutePutBenchmark` (20-thread hot `put` + `putThenGet`)

--- a/benchmarks/profiles/segment-index-nightly.json
+++ b/benchmarks/profiles/segment-index-nightly.json
@@ -100,6 +100,46 @@
       ]
     },
     {
+      "label": "segment-index-range-scan",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.boundedScan",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.fullStreamRangeFallback",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.sequentialRead"
+      ],
+      "expectedResultCount": 3,
+      "args": [
+        "-wi", "2",
+        "-i", "5",
+        "-f", "1",
+        "-r", "2s",
+        "-w", "2s",
+        "-t", "1",
+        "-p", "snappy=true",
+        "-p", "keyCount=32768",
+        "-p", "rangeSize=128",
+        "-p", "maxKeysInSegment=1024",
+        "-p", "valueLength=64"
+      ]
+    },
+    {
+      "label": "segment-merge-sequential",
+      "include": "org.hestiastore.index.segment.SegmentMergeSequentialBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.index.segment.SegmentMergeSequentialBenchmark.mergeSequential"
+      ],
+      "expectedResultCount": 1,
+      "args": [
+        "-wi", "2",
+        "-i", "5",
+        "-f", "1",
+        "-r", "2s",
+        "-w", "2s",
+        "-t", "1",
+        "-p", "keyCount=32768"
+      ]
+    },
+    {
       "label": "segment-index-persisted-mutation",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
       "expectedBenchmarks": [

--- a/benchmarks/profiles/segment-index-pr-smoke.json
+++ b/benchmarks/profiles/segment-index-pr-smoke.json
@@ -77,6 +77,46 @@
       ]
     },
     {
+      "label": "segment-index-range-scan",
+      "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.boundedScan",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.fullStreamRangeFallback",
+        "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark.sequentialRead"
+      ],
+      "expectedResultCount": 3,
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-t", "1",
+        "-p", "snappy=true",
+        "-p", "keyCount=32768",
+        "-p", "rangeSize=128",
+        "-p", "maxKeysInSegment=1024",
+        "-p", "valueLength=64"
+      ]
+    },
+    {
+      "label": "segment-merge-sequential",
+      "include": "org.hestiastore.index.segment.SegmentMergeSequentialBenchmark",
+      "expectedBenchmarks": [
+        "org.hestiastore.index.segment.SegmentMergeSequentialBenchmark.mergeSequential"
+      ],
+      "expectedResultCount": 1,
+      "args": [
+        "-wi", "1",
+        "-i", "3",
+        "-f", "1",
+        "-r", "1s",
+        "-w", "1s",
+        "-t", "1",
+        "-p", "keyCount=32768"
+      ]
+    },
+    {
       "label": "segment-index-persisted-mutation",
       "include": "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
       "expectedBenchmarks": [

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexBenchmarkSupport.java
@@ -68,6 +68,17 @@ final class SegmentIndexBenchmarkSupport {
         return valuePrefix + Character.toString(fillChar).repeat(suffixLength);
     }
 
+    /**
+     * Inserts fixture data without racing an explicit flush against background
+     * splits. Closing the setup index seals split scheduling before flushing.
+     */
+    static void putSequential(final SegmentIndex<Integer, String> index,
+            final int keyCount, final IntFunction<String> valueBuilder) {
+        for (int key = 0; key < keyCount; key++) {
+            index.put(Integer.valueOf(key), valueBuilder.apply(key));
+        }
+    }
+
     static void populateSequential(final SegmentIndex<Integer, String> index,
             final int keyCount, final int flushBatchSize,
             final IntFunction<String> valueBuilder) {

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexMultiSegmentGetBenchmark.java
@@ -87,8 +87,8 @@ public class SegmentIndexMultiSegmentGetBenchmark
 
     @Override
     protected void populateIndex(final SegmentIndex<Integer, String> created) {
-        SegmentIndexBenchmarkSupport.populateSequential(created, keyCount,
-                keyCount, this::buildValue);
+        SegmentIndexBenchmarkSupport.putSequential(created, keyCount,
+                this::buildValue);
     }
 
     @Override

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexRangeScanBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexRangeScanBenchmark.java
@@ -1,0 +1,221 @@
+package org.hestiastore.benchmark.segmentindex;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.directory.FsDirectory;
+import org.hestiastore.index.segment.SegmentIteratorIsolation;
+import org.hestiastore.index.segmentindex.SegmentIndex;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares a bounded key-range scan with the previous full-stream filtering
+ * fallback on a persisted multi-segment index.
+ * <p>
+ * Both paths intentionally use {@link SegmentIteratorIsolation#FAIL_FAST}.
+ * Every invocation verifies the expected result count so maintenance,
+ * cache-capacity eviction, or index closing cannot make a truncated iterator
+ * look artificially fast.
+ * </p>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class SegmentIndexRangeScanBenchmark {
+
+    private static final Comparator<Integer> KEY_COMPARATOR =
+            SegmentIndexBenchmarkSupport.KEY_DESCRIPTOR.getComparator();
+
+    @Param({ "32768" })
+    private int keyCount;
+
+    @Param({ "128" })
+    private int rangeSize;
+
+    @Param({ "1024" })
+    private int maxKeysInSegment;
+
+    @Param({ "64" })
+    private int valueLength;
+
+    @Param({ "false", "true" })
+    private boolean snappy;
+
+    private File tempDir;
+    private SegmentIndex<Integer, String> index;
+    private int fromInclusive;
+    private int toExclusive;
+
+    /**
+     * Creates and reopens a persisted multi-segment index for the measured
+     * scans.
+     *
+     * @throws IOException when benchmark storage cannot be created
+     */
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        if (keyCount <= 0 || maxKeysInSegment <= 0 || rangeSize <= 0
+                || rangeSize > keyCount) {
+            throw new IllegalArgumentException(
+                    "Key, segment, and range sizes must define a valid range.");
+        }
+        tempDir = SegmentIndexBenchmarkSupport
+                .createTempDir("hestia-jmh-range-scan");
+        try (SegmentIndex<Integer, String> created = SegmentIndex.create(
+                new FsDirectory(tempDir), buildConfiguration(true))) {
+            SegmentIndexBenchmarkSupport.populateSequential(created, keyCount,
+                    keyCount, this::buildValue);
+            SegmentIndexBenchmarkSupport.awaitCondition(() -> {
+                final var snapshot = created.runtimeMonitoring().snapshot();
+                return snapshot.segments().count() > 1
+                        && snapshot.split().inFlightCount() == 0;
+            }, 15_000L,
+                    "Expected persisted multi-segment range-scan layout.");
+        }
+
+        index = SegmentIndex.open(new FsDirectory(tempDir),
+                buildConfiguration(false));
+        if (index.runtimeMonitoring().snapshot().segments().count() <= 1) {
+            throw new IllegalStateException(
+                    "Expected reopened multi-segment range-scan layout.");
+        }
+        fromInclusive = (keyCount - rangeSize) / 2;
+        toExclusive = fromInclusive + rangeSize;
+    }
+
+    /**
+     * Closes the measured index and removes its temporary files.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (index != null) {
+            index.close();
+            index = null;
+        }
+        if (tempDir != null) {
+            SegmentIndexBenchmarkSupport.deleteRecursively(tempDir);
+            tempDir = null;
+        }
+    }
+
+    /**
+     * Measures the bounded range-scan API.
+     *
+     * @return verified number of scanned entries
+     */
+    @Benchmark
+    public long boundedScan() {
+        try (Stream<Entry<Integer, String>> stream = index.scan(fromInclusive,
+                toExclusive, SegmentIteratorIsolation.FAIL_FAST)) {
+            return requireExpectedCount(stream.count());
+        }
+    }
+
+    /**
+     * Measures the existing unbounded sequential-read API.
+     *
+     * @return verified number of sequentially read entries
+     */
+    @Benchmark
+    public long sequentialRead() {
+        try (Stream<Entry<Integer, String>> stream = index
+                .getStream(SegmentIteratorIsolation.FAIL_FAST)) {
+            return requireSequentialCount(stream.count());
+        }
+    }
+
+    /**
+     * Measures the former fallback of filtering the full ordered stream.
+     *
+     * @return verified number of scanned entries
+     */
+    @Benchmark
+    public long fullStreamRangeFallback() {
+        try (Stream<Entry<Integer, String>> stream = index
+                .getStream(SegmentIteratorIsolation.FAIL_FAST)) {
+            final long count = stream
+                    .dropWhile(entry -> KEY_COMPARATOR.compare(entry.getKey(),
+                            fromInclusive) < 0)
+                    .takeWhile(entry -> KEY_COMPARATOR.compare(entry.getKey(),
+                            toExclusive) < 0)
+                    .count();
+            return requireExpectedCount(count);
+        }
+    }
+
+    private IndexConfiguration<Integer, String> buildConfiguration(
+            final boolean backgroundAutoEnabled) {
+        final var builder = SegmentIndexBenchmarkSupport
+                .baseBuilder("segment-index-range-scan-benchmark")//
+                .segment(segment -> segment.cacheKeyLimit(32)
+                        .chunkKeyLimit(64).maxKeys(maxKeysInSegment)
+                        .cachedSegmentLimit(resolveCachedSegmentLimit())
+                        .deltaCacheFileLimit(2))//
+                .writePath(writePath -> writePath
+                        .segmentWriteCacheKeyLimit(256)
+                        .maintenanceWriteCacheKeyLimit(512)
+                        .indexBufferedWriteKeyLimit(8_192)
+                        .segmentSplitKeyThreshold(maxKeysInSegment))//
+                .bloomFilter(bloomFilter -> bloomFilter
+                        .indexSizeBytes(Math.max(16_384, keyCount))
+                        .hashFunctions(3).falsePositiveProbability(0.01D))//
+                .io(io -> io.diskBufferSizeBytes(8 * 1024))//
+                .maintenance(maintenance -> maintenance.indexThreads(2)
+                        .registryLifecycleThreads(1)
+                        .backgroundAutoEnabled(backgroundAutoEnabled));
+        SegmentIndexBenchmarkSupport.addIntegrityAndCompressionFilters(builder,
+                snappy);
+        return builder.build();
+    }
+
+    private int resolveCachedSegmentLimit() {
+        final int estimatedSegments = (keyCount + maxKeysInSegment - 1)
+                / maxKeysInSegment;
+        return Math.max(64, estimatedSegments * 4);
+    }
+
+    private String buildValue(final int key) {
+        return SegmentIndexBenchmarkSupport.buildFixedWidthValue("stable-", key,
+                valueLength, 'r');
+    }
+
+    private long requireExpectedCount(final long count) {
+        if (count != rangeSize) {
+            throw new IllegalStateException(
+                    "FAIL_FAST range scan was truncated: expected " + rangeSize
+                            + " entries but received " + count + '.');
+        }
+        return count;
+    }
+
+    private long requireSequentialCount(final long count) {
+        if (count != keyCount) {
+            throw new IllegalStateException(
+                    "FAIL_FAST sequential read was truncated: expected "
+                            + keyCount + " entries but received " + count + '.');
+        }
+        return count;
+    }
+}

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexRangeScanBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/segmentindex/SegmentIndexRangeScanBenchmark.java
@@ -85,8 +85,8 @@ public class SegmentIndexRangeScanBenchmark {
                 .createTempDir("hestia-jmh-range-scan");
         try (SegmentIndex<Integer, String> created = SegmentIndex.create(
                 new FsDirectory(tempDir), buildConfiguration(true))) {
-            SegmentIndexBenchmarkSupport.populateSequential(created, keyCount,
-                    keyCount, this::buildValue);
+            SegmentIndexBenchmarkSupport.putSequential(created, keyCount,
+                    this::buildValue);
             SegmentIndexBenchmarkSupport.awaitCondition(() -> {
                 final var snapshot = created.runtimeMonitoring().snapshot();
                 return snapshot.segments().count() > 1

--- a/benchmarks/src/main/java/org/hestiastore/index/segment/SegmentMergeSequentialBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/index/segment/SegmentMergeSequentialBenchmark.java
@@ -1,0 +1,86 @@
+package org.hestiastore.index.segment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.EntryIteratorList;
+import org.hestiastore.index.datatype.TypeDescriptor;
+import org.hestiastore.index.datatype.TypeDescriptorInteger;
+import org.hestiastore.index.datatype.TypeDescriptorShortString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Protects the unbounded segment merge loop from range-scan overhead.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class SegmentMergeSequentialBenchmark {
+
+    private static final TypeDescriptor<Integer> KEY_DESCRIPTOR = new TypeDescriptorInteger();
+    private static final TypeDescriptor<String> VALUE_DESCRIPTOR = new TypeDescriptorShortString();
+
+    @Param({ "32768" })
+    private int keyCount;
+
+    private List<Entry<Integer, String>> entries;
+    private long expectedKeySum;
+
+    /**
+     * Creates the immutable entry set consumed by each benchmark invocation.
+     */
+    @Setup(Level.Trial)
+    public void setup() {
+        final List<Entry<Integer, String>> preparedEntries = new ArrayList<>(
+                keyCount);
+        for (int key = 0; key < keyCount; key++) {
+            preparedEntries.add(Entry.of(key, "value"));
+        }
+        entries = List.copyOf(preparedEntries);
+        expectedKeySum = (long) keyCount * (keyCount - 1L) / 2L;
+    }
+
+    /**
+     * Measures the existing unbounded merge path with an empty delta cache.
+     *
+     * @return verified sum of all keys
+     */
+    @Benchmark
+    public long mergeSequential() {
+        try (EntryIterator<Integer, String> iterator = new MergeDeltaCacheWithIndexIterator<>(
+                new EntryIteratorList<>(entries.iterator()), KEY_DESCRIPTOR,
+                VALUE_DESCRIPTOR, Collections.emptyIterator())) {
+            long keySum = 0L;
+            int count = 0;
+            while (iterator.hasNext()) {
+                keySum += iterator.next().getKey();
+                count++;
+            }
+            if (count != keyCount || keySum != expectedKeySum) {
+                throw new IllegalStateException(
+                        "Sequential merge returned incomplete data.");
+            }
+            return keySum;
+        }
+    }
+}

--- a/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
+++ b/benchmarks/src/test/java/org/hestiastore/benchmark/BenchmarkProfileContractTest.java
@@ -31,6 +31,8 @@ class BenchmarkProfileContractTest {
             "segment-index-get-persisted",
             "segment-index-get-live",
             "segment-index-get-multisegment-hot",
+            "segment-index-range-scan",
+            "segment-merge-sequential",
             "segment-index-persisted-mutation",
             "segment-index-persisted-mutation-concurrent",
             "segment-index-hot-route-put",
@@ -41,6 +43,8 @@ class BenchmarkProfileContractTest {
             "segment-index-get-live",
             "segment-index-get-multisegment-hot",
             "segment-index-get-multisegment-cold",
+            "segment-index-range-scan",
+            "segment-merge-sequential",
             "segment-index-persisted-mutation",
             "segment-index-persisted-mutation-concurrent",
             "segment-index-lifecycle",
@@ -143,6 +147,9 @@ class BenchmarkProfileContractTest {
         assertEntry(byLabel.get("segment-index-get-multisegment-hot"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
                 Map.of("workingSetMode", "hot"));
+        assertEntry(byLabel.get("segment-index-range-scan"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark",
+                Map.of("keyCount", "32768", "rangeSize", "128"));
         assertEntry(byLabel.get("segment-index-persisted-mutation"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
                 Map.of("walMode", "sync"));
@@ -189,6 +196,9 @@ class BenchmarkProfileContractTest {
         assertEntry(byLabel.get("segment-index-get-multisegment-cold"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexMultiSegmentGetBenchmark",
                 Map.of("workingSetMode", "cold"));
+        assertEntry(byLabel.get("segment-index-range-scan"),
+                "org.hestiastore.benchmark.segmentindex.SegmentIndexRangeScanBenchmark",
+                Map.of("keyCount", "32768", "rangeSize", "128"));
         assertEntry(byLabel.get("segment-index-persisted-mutation"),
                 "org.hestiastore.benchmark.segmentindex.SegmentIndexPersistedMutationBenchmark",
                 Map.of("walMode", "sync"));

--- a/engine/src/main/java/org/hestiastore/index/segment/KeyRangeEntryIterator.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/KeyRangeEntryIterator.java
@@ -1,0 +1,96 @@
+package org.hestiastore.index.segment;
+
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+
+import org.hestiastore.index.AbstractCloseableResource;
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.Vldtn;
+
+/**
+ * Restricts an ordered entry iterator to a half-open key range.
+ * <p>
+ * The lower bound is applied only while positioning the iterator. Subsequent
+ * entries are ordered, so iteration only needs to enforce the optional upper
+ * bound.
+ * </p>
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class KeyRangeEntryIterator<K, V> extends AbstractCloseableResource
+        implements EntryIterator<K, V> {
+
+    private final EntryIterator<K, V> delegate;
+    private final Comparator<K> keyComparator;
+    private final K toExclusive;
+    private Entry<K, V> next;
+
+    /**
+     * Creates a range view over an ordered iterator.
+     *
+     * @param delegate ordered source iterator
+     * @param keyComparator key ordering
+     * @param fromInclusive required inclusive lower bound
+     * @param toExclusive optional exclusive upper bound
+     */
+    KeyRangeEntryIterator(final EntryIterator<K, V> delegate,
+            final Comparator<K> keyComparator, final K fromInclusive,
+            final K toExclusive) {
+        this.delegate = Vldtn.requireNonNull(delegate, "delegate");
+        this.keyComparator = Vldtn.requireNonNull(keyComparator,
+                "keyComparator");
+        this.toExclusive = toExclusive;
+        seekTo(Vldtn.requireNonNull(fromInclusive, "fromInclusive"));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Entry<K, V> next() {
+        if (next == null) {
+            throw new NoSuchElementException("No next element.");
+        }
+        final Entry<K, V> result = next;
+        advance();
+        return result;
+    }
+
+    private void seekTo(final K fromInclusive) {
+        while (delegate.hasNext()) {
+            final Entry<K, V> candidate = delegate.next();
+            if (keyComparator.compare(candidate.getKey(), fromInclusive) >= 0) {
+                next = belowUpperBound(candidate) ? candidate : null;
+                return;
+            }
+        }
+    }
+
+    private void advance() {
+        next = null;
+        if (delegate.hasNext()) {
+            final Entry<K, V> candidate = delegate.next();
+            if (belowUpperBound(candidate)) {
+                next = candidate;
+            }
+        }
+    }
+
+    private boolean belowUpperBound(final Entry<K, V> candidate) {
+        return toExclusive == null
+                || keyComparator.compare(candidate.getKey(), toExclusive) < 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void doClose() {
+        delegate.close();
+        next = null;
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/segment/Segment.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/Segment.java
@@ -163,6 +163,23 @@ public interface Segment<K, V> {
             SegmentIteratorIsolation isolation);
 
     /**
+     * Opens a read iterator over a half-open key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation level
+     * @return result with an ordered iterator over the requested range
+     * @throws UnsupportedOperationException when the implementation does not
+     *         support bounded iteration
+     */
+    default OperationResult<EntryIterator<K, V>> openIterator(
+            final K fromInclusive, final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        throw new UnsupportedOperationException(
+                "Bounded segment iteration is not implemented.");
+    }
+
+    /**
      * Writes directly into the in-memory segment cache without persisting to
      * disk. This is intended for specialized use cases.
      *

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentCore.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentCore.java
@@ -98,6 +98,20 @@ final class SegmentCore<K, V> {
     }
 
     /**
+     * Opens a read iterator over a half-open key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation mode
+     * @return bounded entry iterator
+     */
+    EntryIterator<K, V> openIterator(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        return readPath.openIterator(fromInclusive, toExclusive, isolation);
+    }
+
+    /**
      * Opens an iterator over the index and stable compaction snapshot.
      *
      * @return iterator over the merged snapshot view

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentImpl.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segment;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 
 import org.hestiastore.index.EntryIterator;
 import org.hestiastore.index.OperationResult;
@@ -149,15 +150,41 @@ class SegmentImpl<K, V> implements Segment<K, V> {
     @Override
     public OperationResult<EntryIterator<K, V>> openIterator(
             final SegmentIteratorIsolation isolation) {
-        Vldtn.requireNonNull(isolation, "isolation");
+        final SegmentIteratorIsolation nonNullIsolation = Vldtn.requireNonNull(
+                isolation, "isolation");
+        return openIteratorWithGate(nonNullIsolation,
+                () -> core.openIterator(nonNullIsolation));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OperationResult<EntryIterator<K, V>> openIterator(
+            final K fromInclusive, final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        final K lowerBound = Vldtn.requireNonNull(fromInclusive,
+                "fromInclusive");
+        final SegmentIteratorIsolation nonNullIsolation = Vldtn.requireNonNull(
+                isolation, "isolation");
+        if (toExclusive != null
+                && core.getKeyComparator().compare(lowerBound, toExclusive) > 0) {
+            throw new IllegalArgumentException(
+                    "fromInclusive must not sort after toExclusive.");
+        }
+        return openIteratorWithGate(nonNullIsolation,
+                () -> core.openIterator(lowerBound, toExclusive,
+                        nonNullIsolation));
+    }
+
+    private OperationResult<EntryIterator<K, V>> openIteratorWithGate(
+            final SegmentIteratorIsolation isolation,
+            final Supplier<EntryIterator<K, V>> iteratorSupplier) {
         if (isolation == SegmentIteratorIsolation.FULL_ISOLATION) {
             if (!gate.tryEnterFreezeAndDrain()) {
                 return resultForState(gate.getState());
             }
             try {
                 core.invalidateIterators();
-                final EntryIterator<K, V> iterator = core
-                        .openIterator(isolation);
+                final EntryIterator<K, V> iterator = iteratorSupplier.get();
                 return OperationResult.ok(
                         new ExclusiveAccessIterator<>(iterator, gate));
             } catch (final RuntimeException e) {
@@ -169,7 +196,7 @@ class SegmentImpl<K, V> implements Segment<K, V> {
             return resultForState(gate.getState());
         }
         try {
-            return OperationResult.ok(core.openIterator(isolation));
+            return OperationResult.ok(iteratorSupplier.get());
         } catch (final RuntimeException e) {
             failUnlessClosed();
             return OperationResult.error();

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentIteratorIsolation.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentIteratorIsolation.java
@@ -6,7 +6,10 @@ package org.hestiastore.index.segment;
 public enum SegmentIteratorIsolation {
     /**
      * Default behavior: concurrent writes invalidate the iterator and it
-     * returns no further entries.
+     * returns no further entries. Maintenance, segment eviction or unloading
+     * caused by cache capacity, and index closing can have the same effect.
+     * The caller can therefore receive only an ordered prefix without an
+     * exception that distinguishes truncation from normal exhaustion.
      */
     FAIL_FAST,
 

--- a/engine/src/main/java/org/hestiastore/index/segment/SegmentReadPath.java
+++ b/engine/src/main/java/org/hestiastore/index/segment/SegmentReadPath.java
@@ -8,6 +8,7 @@ import org.hestiastore.index.OptimisticLock;
 import org.hestiastore.index.Vldtn;
 import org.hestiastore.index.chunkstorecache.ChunkStoreCache;
 import org.hestiastore.index.chunkstorecache.LruChunkStoreCache;
+import org.hestiastore.index.sorteddatafile.EmptyEntryIteratorWithCurrent;
 
 /**
  * Encapsulates segment read operations and read-time state.
@@ -91,6 +92,50 @@ final class SegmentReadPath<K, V> {
                 segmentFiles.getKeyTypeDescriptor(),
                 segmentFiles.getValueTypeDescriptor(),
                 segmentCache.mergedIterator());
+        return applyIsolation(mergedEntryIterator, isolation);
+    }
+
+    /**
+     * Opens a merged iterator over a half-open key range. Persisted reads begin
+     * at the scarce-index page selected for the lower bound.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation mode
+     * @return bounded merged iterator
+     */
+    EntryIterator<K, V> openIterator(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        final K lowerBound = Vldtn.requireNonNull(fromInclusive,
+                "fromInclusive");
+        Vldtn.requireNonNull(isolation, "isolation");
+        final EntryIterator<K, V> mergedEntryIterator = new MergeDeltaCacheWithIndexIterator<>(
+                openPersistedIterator(lowerBound),
+                segmentFiles.getKeyTypeDescriptor(),
+                segmentFiles.getValueTypeDescriptor(),
+                segmentCache.mergedIterator());
+        final EntryIterator<K, V> rangeIterator = new KeyRangeEntryIterator<>(
+                mergedEntryIterator,
+                segmentFiles.getKeyTypeDescriptor().getComparator(), lowerBound,
+                toExclusive);
+        return applyIsolation(rangeIterator, isolation);
+    }
+
+    private EntryIterator<K, V> openPersistedIterator(
+            final K fromInclusive) {
+        final Integer position = segmentResources.getScarceIndex()
+                .get(fromInclusive);
+        if (position == null) {
+            return new EmptyEntryIteratorWithCurrent<>();
+        }
+        return segmentFiles.getIndexFile()
+                .openIteratorAtPosition(position.longValue());
+    }
+
+    private EntryIterator<K, V> applyIsolation(
+            final EntryIterator<K, V> mergedEntryIterator,
+            final SegmentIteratorIsolation isolation) {
         if (isolation == SegmentIteratorIsolation.FULL_ISOLATION) {
             return mergedEntryIterator;
         }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/SegmentIndex.java
@@ -357,6 +357,75 @@ public interface SegmentIndex<K, V> extends CloseableResource {
     void delete(K key);
 
     /**
+     * Lazily scans entries in configured key-comparator order. The lower bound
+     * is inclusive and the upper bound is exclusive. A {@code null} upper bound
+     * scans from {@code fromInclusive} through the end of the index.
+     * <p>
+     * Implementations must reject a lower bound that sorts after a non-null
+     * upper bound using the comparator supplied by the key type descriptor.
+     * Equal non-null bounds produce an empty stream. The returned stream must be
+     * closed after use.
+     * </p>
+     * <p>
+     * With {@link SegmentIteratorIsolation#FAIL_FAST}, iteration is
+     * optimistic and may end normally before reaching {@code toExclusive}.
+     * Maintenance, segment eviction or unloading caused by cache capacity,
+     * index closing, or another iterator invalidation can therefore reduce the
+     * number of returned entries without reporting an error. Callers must not
+     * interpret a fail-fast result count as proof that the complete range was
+     * visited.
+     * </p>
+     * <p>
+     * <strong>Experimental API:</strong> this contract may change before
+     * becoming stable. The default implementation is a compatibility
+     * placeholder.
+     * </p>
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound; {@code null} means
+     *        the end of the index
+     * @param isolation required iterator isolation mode
+     * @return ordered stream of entries within the requested key range
+     * @throws IllegalArgumentException if {@code fromInclusive} or
+     *         {@code isolation} is null, or if {@code fromInclusive} sorts
+     *         after a non-null {@code toExclusive}
+     * @throws UnsupportedOperationException if the implementation does not yet
+     *         support key-range scans
+     */
+    default Stream<Entry<K, V>> scan(final K fromInclusive,
+            final K toExclusive, final SegmentIteratorIsolation isolation) {
+        Vldtn.requireNonNull(fromInclusive, "fromInclusive");
+        Vldtn.requireNonNull(isolation, "isolation");
+        throw new UnsupportedOperationException(
+                "Key-range scans are not implemented.");
+    }
+
+    /**
+     * Lazily scans entries using {@link SegmentIteratorIsolation#FAIL_FAST}.
+     * Consequently, maintenance, segment eviction or unloading, and index
+     * closing may terminate the stream normally with only a prefix of the
+     * requested range.
+     * <p>
+     * <strong>Experimental API:</strong> this contract may change before
+     * becoming stable.
+     * </p>
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound; {@code null} means
+     *        the end of the index
+     * @return ordered stream of entries within the requested key range
+     * @throws IllegalArgumentException if {@code fromInclusive} is null, or if
+     *         it sorts after a non-null {@code toExclusive}
+     * @throws UnsupportedOperationException if the implementation does not yet
+     *         support key-range scans
+     */
+    default Stream<Entry<K, V>> scan(final K fromInclusive,
+            final K toExclusive) {
+        return scan(fromInclusive, toExclusive,
+                SegmentIteratorIsolation.FAIL_FAST);
+    }
+
+    /**
      * Went through all records. In fact read all index data. Doesn't use
      * indexes and caches in segments.
      * 

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/SegmentIteratorService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/SegmentIteratorService.java
@@ -126,6 +126,31 @@ public final class SegmentIteratorService<K, V> {
                 nonNullWindow), nonNullIsolation);
     }
 
+    /**
+     * Opens an iterator over routed segments intersecting a half-open key
+     * range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation mode
+     * @return bounded entry iterator
+     */
+    public EntryIterator<K, V> openRangeIterator(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        final K lowerBound = Vldtn.requireNonNull(fromInclusive,
+                "fromInclusive");
+        final SegmentIteratorIsolation nonNullIsolation = Vldtn.requireNonNull(
+                isolation, "isolation");
+        if (nonNullIsolation == SegmentIteratorIsolation.FULL_ISOLATION) {
+            return openStableRangeIteratorWithRouteSnapshot(lowerBound,
+                    toExclusive, nonNullIsolation);
+        }
+        return openStableRangeIterator(segmentLeaseService
+                .getSegmentIds(lowerBound, toExclusive), nonNullIsolation,
+                lowerBound, toExclusive);
+    }
+
     private EntryIterator<K, V> openStableIteratorWithRouteSnapshot(
             final SegmentWindow resolvedWindows,
             final SegmentIteratorIsolation isolation) {
@@ -144,11 +169,38 @@ public final class SegmentIteratorService<K, V> {
         }
     }
 
+    private EntryIterator<K, V> openStableRangeIteratorWithRouteSnapshot(
+            final K fromInclusive, final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        final long startNanos = retryPolicy.startNanos();
+        while (true) {
+            final RouteWindowSnapshot snapshot = segmentLeaseService
+                    .snapshotSegmentIds(fromInclusive, toExclusive);
+            final EntryIterator<K, V> iterator = openStableRangeIterator(
+                    snapshot.segmentIds(), isolation, fromInclusive,
+                    toExclusive);
+            if (segmentLeaseService.isCurrent(snapshot)) {
+                return iterator;
+            }
+            iterator.close();
+            retryPolicy.backoffOrThrow(startNanos,
+                    OPERATION_OPEN_FULL_ISOLATION_ITERATOR, null);
+        }
+    }
+
     private EntryIterator<K, V> openStableIterator(
             final List<SegmentId> segmentIds,
             final SegmentIteratorIsolation isolation) {
         return new StableSegmentsIterator<>(segmentIds, segmentLeaseService,
                 isolation);
+    }
+
+    private EntryIterator<K, V> openStableRangeIterator(
+            final List<SegmentId> segmentIds,
+            final SegmentIteratorIsolation isolation, final K fromInclusive,
+            final K toExclusive) {
+        return new StableSegmentsIterator<>(segmentIds, segmentLeaseService,
+                isolation, fromInclusive, toExclusive);
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/StableSegmentsIterator.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/execution/StableSegmentsIterator.java
@@ -42,6 +42,9 @@ class StableSegmentsIterator<K, V> extends AbstractCloseableResource
     private final SegmentIteratorIsolation isolation;
     private final BusyRetryPolicy retryPolicy;
     private final List<SegmentId> ids;
+    private final K fromInclusive;
+    private final K toExclusive;
+    private final boolean bounded;
     private Entry<K, V> nextEntry = null;
     private EntryIterator<K, V> currentIterator = null;
 
@@ -49,17 +52,46 @@ class StableSegmentsIterator<K, V> extends AbstractCloseableResource
 
     StableSegmentsIterator(final List<SegmentId> ids,
             final MappedSegmentLeaseService<K, V> segmentLeaseService) {
-        this(ids, segmentLeaseService, SegmentIteratorIsolation.FAIL_FAST);
+        this(ids, segmentLeaseService, SegmentIteratorIsolation.FAIL_FAST,
+                null, null, false);
     }
 
     StableSegmentsIterator(final List<SegmentId> ids,
             final MappedSegmentLeaseService<K, V> segmentLeaseService,
             final SegmentIteratorIsolation isolation) {
+        this(ids, segmentLeaseService, isolation, null, null, false);
+    }
+
+    /**
+     * Creates a stable-segment iterator restricted to a half-open key range.
+     *
+     * @param ids routed segment ids in key order
+     * @param segmentLeaseService segment lease service
+     * @param isolation iterator isolation mode
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     */
+    StableSegmentsIterator(final List<SegmentId> ids,
+            final MappedSegmentLeaseService<K, V> segmentLeaseService,
+            final SegmentIteratorIsolation isolation, final K fromInclusive,
+            final K toExclusive) {
+        this(ids, segmentLeaseService, isolation,
+                Vldtn.requireNonNull(fromInclusive, "fromInclusive"),
+                toExclusive, true);
+    }
+
+    private StableSegmentsIterator(final List<SegmentId> ids,
+            final MappedSegmentLeaseService<K, V> segmentLeaseService,
+            final SegmentIteratorIsolation isolation, final K fromInclusive,
+            final K toExclusive, final boolean bounded) {
         this.ids = Vldtn.requireNonNull(ids, "ids");
         this.segmentLeaseService = Vldtn.requireNonNull(segmentLeaseService,
                 "segmentLeaseService");
         this.isolation = Vldtn.requireNonNull(isolation, "isolation");
         this.retryPolicy = DEFAULT_RETRY_POLICY;
+        this.fromInclusive = fromInclusive;
+        this.toExclusive = toExclusive;
+        this.bounded = bounded;
         nextSegmentIterator();
     }
 
@@ -141,6 +173,10 @@ class StableSegmentsIterator<K, V> extends AbstractCloseableResource
         if (isolation == SegmentIteratorIsolation.FAIL_FAST) {
             return awaitOpenFailFastIterator(segmentHandle, segmentId);
         }
+        if (bounded) {
+            return segmentHandle.openIterator(fromInclusive, toExclusive,
+                    isolation);
+        }
         return segmentHandle.openIterator(isolation);
     }
 
@@ -149,8 +185,10 @@ class StableSegmentsIterator<K, V> extends AbstractCloseableResource
             final SegmentId segmentId) {
         final long startNanos = retryPolicy.startNanos();
         for (int attempt = 0; attempt < 2; attempt++) {
-            final OperationResult<EntryIterator<K, V>> result = segmentHandle
-                    .tryOpenIterator(isolation);
+            final OperationResult<EntryIterator<K, V>> result = bounded
+                    ? segmentHandle.tryOpenIterator(fromInclusive, toExclusive,
+                            isolation)
+                    : segmentHandle.tryOpenIterator(isolation);
             if (result.getStatus() == OperationStatus.OK
                     && result.getValue() != null) {
                 return result.getValue();

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/MappedSegmentLeaseService.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/routing/MappedSegmentLeaseService.java
@@ -122,6 +122,20 @@ public final class MappedSegmentLeaseService<K, V> {
     }
 
     /**
+     * Returns routed segment ids intersecting the requested key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @return routed segment ids in key order
+     */
+    public List<SegmentId> getSegmentIds(final K fromInclusive,
+            final K toExclusive) {
+        return keyToSegmentMap.getSegmentIds(
+                Vldtn.requireNonNull(fromInclusive, "fromInclusive"),
+                toExclusive);
+    }
+
+    /**
      * Returns a versioned snapshot of routed segment ids for the selected
      * window.
      *
@@ -135,6 +149,21 @@ public final class MappedSegmentLeaseService<K, V> {
                 snapshot.getSegmentIds(
                         Vldtn.requireNonNull(segmentWindow, "segmentWindow")),
                 snapshot.version());
+    }
+
+    /**
+     * Returns a versioned snapshot of segment ids intersecting a key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @return versioned routed range snapshot
+     */
+    public RouteWindowSnapshot snapshotSegmentIds(final K fromInclusive,
+            final K toExclusive) {
+        final RouteMapSnapshot<K> snapshot = keyToSegmentMap.snapshot();
+        return new RouteWindowSnapshot(snapshot.getSegmentIds(
+                Vldtn.requireNonNull(fromInclusive, "fromInclusive"),
+                toExclusive), snapshot.version());
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapter.java
@@ -90,6 +90,15 @@ final class SegmentIndexMdcLoggingAdapter<K, V>
     }
 
     @Override
+    public Stream<Entry<K, V>> scan(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        try (IndexMdcScope ignored = openScope()) {
+            return delegate.scan(fromInclusive, toExclusive, isolation);
+        }
+    }
+
+    @Override
     public Stream<Entry<K, V>> getStream(final SegmentWindow segmentWindows) {
         try (IndexMdcScope ignored = openScope()) {
             return delegate.getStream(segmentWindows);

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexSession.java
@@ -179,6 +179,36 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
 
     /** {@inheritDoc} */
     @Override
+    public Stream<Entry<K, V>> scan(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        beginOperationalOperation();
+        try {
+            final K lowerBound = Vldtn.requireNonNull(fromInclusive,
+                    "fromInclusive");
+            final SegmentIteratorIsolation nonNullIsolation = requireIsolation(
+                    isolation);
+            final int rangeComparison = toExclusive == null ? -1
+                    : keyTypeDescriptor.getComparator().compare(lowerBound,
+                            toExclusive);
+            if (rangeComparison > 0) {
+                throw new IllegalArgumentException(
+                        "fromInclusive must not sort after toExclusive.");
+            }
+            if (rangeComparison == 0) {
+                return Stream.empty();
+            }
+            final EntryIterator<K, V> iterator = decorateIterator(
+                    streamingService.openRangeIterator(lowerBound, toExclusive,
+                            nonNullIsolation));
+            return stream(iterator);
+        } finally {
+            operationGate.endOperation();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public Stream<Entry<K, V>> getStream(final SegmentWindow segmentWindow) {
         return getStream(segmentWindow, SegmentIteratorIsolation.FAIL_FAST);
     }
@@ -190,6 +220,11 @@ class SegmentIndexSession<K, V> extends AbstractCloseableResource
             final SegmentIteratorIsolation isolation) {
         final EntryIterator<K, V> iterator = openSegmentIterator(segmentWindow,
                 isolation);
+        return stream(iterator);
+    }
+
+    private Stream<Entry<K, V>> stream(
+            final EntryIterator<K, V> iterator) {
         return StreamSupport.stream(newEntryIteratorSpliterator(iterator), false)
                 .onClose(iterator::close);
     }

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshot.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshot.java
@@ -2,6 +2,7 @@ package org.hestiastore.index.segmentindex.routemap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 
 import org.hestiastore.index.Vldtn;
@@ -41,6 +42,38 @@ public final class RouteMapSnapshot<K> {
                 .limit(segmentWindow.getIntLimit())//
                 .map(entry -> entry.getValue())//
                 .toList();
+    }
+
+    /**
+     * Returns segment ids whose routed key intervals intersect the requested
+     * half-open key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound; {@code null}
+     *        selects through the tail segment
+     * @return ordered intersecting segment ids
+     */
+    public List<SegmentId> getSegmentIds(final K fromInclusive,
+            final K toExclusive) {
+        final K lowerBound = Vldtn.requireNonNull(fromInclusive,
+                "fromInclusive");
+        if (map.isEmpty()) {
+            return List.of();
+        }
+        final Map.Entry<K, SegmentId> first = segmentForKey(lowerBound);
+        if (toExclusive == null) {
+            return List.copyOf(
+                    map.tailMap(first.getKey(), true).values());
+        }
+        final Map.Entry<K, SegmentId> last = segmentForKey(toExclusive);
+        final NavigableMap<K, SegmentId> selected = map.subMap(first.getKey(),
+                true, last.getKey(), true);
+        return List.copyOf(selected.values());
+    }
+
+    private Map.Entry<K, SegmentId> segmentForKey(final K key) {
+        final Map.Entry<K, SegmentId> ceilingEntry = map.ceilingEntry(key);
+        return ceilingEntry == null ? map.lastEntry() : ceilingEntry;
     }
 
     /**

--- a/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMap.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentindex/routemap/SegmentRouteMap.java
@@ -38,5 +38,17 @@ public interface SegmentRouteMap<K> extends CloseableResource {
 
     List<SegmentId> getSegmentIds(SegmentWindow segmentWindow);
 
+    /**
+     * Returns segment ids whose routed intervals intersect a key range.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @return ordered intersecting segment ids
+     */
+    default List<SegmentId> getSegmentIds(final K fromInclusive,
+            final K toExclusive) {
+        return snapshot().getSegmentIds(fromInclusive, toExclusive);
+    }
+
     void flushIfDirty();
 }

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/BlockingSegment.java
@@ -136,6 +136,22 @@ public interface BlockingSegment<K, V> {
             SegmentIteratorIsolation isolation);
 
     /**
+     * Opens a bounded iterator in a single attempt without retrying
+     * BUSY/CLOSED.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation
+     * @return raw segment result
+     */
+    default OperationResult<EntryIterator<K, V>> tryOpenIterator(
+            final K fromInclusive, final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        throw new UnsupportedOperationException(
+                "Bounded segment iteration is not implemented.");
+    }
+
+    /**
      * Opens a blocking iterator using fail-fast isolation.
      *
      * @return iterator over segment entries
@@ -149,6 +165,21 @@ public interface BlockingSegment<K, V> {
      * @return iterator over segment entries
      */
     EntryIterator<K, V> openIterator(SegmentIteratorIsolation isolation);
+
+    /**
+     * Opens a blocking bounded iterator with the requested isolation.
+     *
+     * @param fromInclusive required inclusive lower key bound
+     * @param toExclusive optional exclusive upper key bound
+     * @param isolation iterator isolation
+     * @return iterator over the requested segment range
+     */
+    default EntryIterator<K, V> openIterator(final K fromInclusive,
+            final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        throw new UnsupportedOperationException(
+                "Bounded segment iteration is not implemented.");
+    }
 
     /**
      * Starts a flush in a single attempt without retrying BUSY/CLOSED.

--- a/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
+++ b/engine/src/main/java/org/hestiastore/index/segmentregistry/DefaultBlockingSegment.java
@@ -139,11 +139,31 @@ final class DefaultBlockingSegment<K, V> implements BlockingSegment<K, V> {
     }
 
     @Override
+    public OperationResult<EntryIterator<K, V>> tryOpenIterator(
+            final K fromInclusive, final K toExclusive,
+            final SegmentIteratorIsolation isolation) {
+        Vldtn.requireNonNull(fromInclusive, "fromInclusive");
+        Vldtn.requireNonNull(isolation, "isolation");
+        return currentSegment().openIterator(fromInclusive, toExclusive,
+                isolation);
+    }
+
+    @Override
     public EntryIterator<K, V> openIterator(
             final SegmentIteratorIsolation isolation) {
         Vldtn.requireNonNull(isolation, "isolation");
         return runBlocking("openIterator",
                 segmentValue -> segmentValue.openIterator(isolation));
+    }
+
+    @Override
+    public EntryIterator<K, V> openIterator(final K fromInclusive,
+            final K toExclusive, final SegmentIteratorIsolation isolation) {
+        Vldtn.requireNonNull(fromInclusive, "fromInclusive");
+        Vldtn.requireNonNull(isolation, "isolation");
+        return runBlocking("openIterator",
+                segmentValue -> segmentValue.openIterator(fromInclusive,
+                        toExclusive, isolation));
     }
 
     @Override

--- a/engine/src/test/java/org/hestiastore/index/segment/KeyRangeEntryIteratorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/KeyRangeEntryIteratorTest.java
@@ -1,0 +1,91 @@
+package org.hestiastore.index.segment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.EntryIteratorList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class KeyRangeEntryIteratorTest {
+
+    private EntryIteratorList<String, Integer> delegate;
+    private KeyRangeEntryIterator<String, Integer> iterator;
+
+    @BeforeEach
+    void setUp() {
+        openIterator("b", "d");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (!iterator.wasClosed()) {
+            iterator.close();
+        }
+    }
+
+    @Test
+    void returnsHalfOpenRange() {
+        assertEquals(List.of(Entry.of("b", 20), Entry.of("c", 30)),
+                readAll());
+    }
+
+    @Test
+    void nullUpperBoundReturnsTail() {
+        replaceIterator("c", null);
+
+        assertEquals(List.of(Entry.of("c", 30), Entry.of("d", 40)),
+                readAll());
+    }
+
+    @Test
+    void equalBoundsReturnEmptyIterator() {
+        replaceIterator("c", "c");
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void nextThrowsAfterRangeIsExhausted() {
+        readAll();
+
+        assertThrows(NoSuchElementException.class, iterator::next);
+    }
+
+    @Test
+    void closeClosesDelegate() {
+        iterator.close();
+
+        assertTrue(delegate.wasClosed());
+    }
+
+    private void replaceIterator(final String fromInclusive,
+            final String toExclusive) {
+        iterator.close();
+        openIterator(fromInclusive, toExclusive);
+    }
+
+    private void openIterator(final String fromInclusive,
+            final String toExclusive) {
+        delegate = new EntryIteratorList<>(List.of(Entry.of("a", 10),
+                Entry.of("b", 20), Entry.of("c", 30),
+                Entry.of("d", 40)));
+        iterator = new KeyRangeEntryIterator<>(delegate,
+                Comparator.naturalOrder(), fromInclusive, toExclusive);
+    }
+
+    private List<Entry<String, Integer>> readAll() {
+        final List<Entry<String, Integer>> result = new ArrayList<>();
+        iterator.forEachRemaining(result::add);
+        return result;
+    }
+}

--- a/engine/src/test/java/org/hestiastore/index/segment/SegmentReadPathTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segment/SegmentReadPathTest.java
@@ -36,6 +36,7 @@ import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.Directory;
 import org.hestiastore.index.directory.FileReaderSeekable;
 import org.hestiastore.index.directory.FileReaderSeekableSupplier;
+import org.hestiastore.index.scarceindex.ScarceSegmentIndex;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,8 @@ class SegmentReadPathTest {
     private SegmentFiles<Integer, String> segmentFiles;
     @Mock
     private SegmentResources<Integer> segmentResources;
+    @Mock
+    private ScarceSegmentIndex<Integer> scarceIndex;
     @Mock
     private SegmentSearcher<Integer, String> segmentSearcher;
     @Mock
@@ -92,6 +95,7 @@ class SegmentReadPathTest {
                 .withDecodingChunkFilters(List.of(new ChunkFilterDoNothing()))
                 .build();
         when(segmentFiles.getIndexFile()).thenReturn(chunkEntryFile);
+        when(segmentResources.getScarceIndex()).thenReturn(scarceIndex);
         when(segmentFiles.getKeyTypeDescriptor()).thenReturn(keyDescriptor);
         when(segmentFiles.getValueTypeDescriptor()).thenReturn(valueDescriptor);
         when(segmentFiles.getId()).thenReturn(SegmentId.of(1));
@@ -130,6 +134,21 @@ class SegmentReadPathTest {
                 .openIterator(SegmentIteratorIsolation.FULL_ISOLATION)) {
             assertFalse(iterator instanceof EntryIteratorWithLock);
         }
+    }
+
+    @Test
+    void openBoundedIteratorStartsAtScarceIndexPosition() {
+        when(scarceIndex.get(10)).thenReturn(3);
+        when(chunkEntryFile.openIteratorAtPosition(3L))
+                .thenReturn(baseIterator);
+
+        try (EntryIterator<Integer, String> iterator = subject.openIterator(10,
+                20, SegmentIteratorIsolation.FAIL_FAST)) {
+            assertFalse(iterator.hasNext());
+        }
+
+        verify(scarceIndex).get(10);
+        verify(chunkEntryFile).openIteratorAtPosition(3L);
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/SegmentIndexTest.java
@@ -7,14 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Optional;
 
-import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.hestiastore.index.Entry;
 import org.hestiastore.index.IndexException;
 import org.hestiastore.index.chunkstore.ChunkFilterDoNothing;
 import org.hestiastore.index.datatype.TypeDescriptorInteger;
 import org.hestiastore.index.datatype.TypeDescriptorShortString;
 import org.hestiastore.index.directory.MemDirectory;
-import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningResult;
+import org.hestiastore.index.segment.SegmentIteratorIsolation;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
 import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningPatch;
+import org.hestiastore.index.segmentindex.configuration.tuning.RuntimeTuningResult;
 import org.junit.jupiter.api.Test;
 
 class SegmentIndexTest {
@@ -90,6 +92,88 @@ class SegmentIndexTest {
         assertThrows(IndexException.class,
                 () -> SegmentIndex.create(directory,
                         buildConf("segment-index-create-existing-new", 1)));
+    }
+
+    @Test
+    void scanReturnsPersistedRangeWithLiveOverlayAndTombstones() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-range", 1))) {
+            index.put(5, "five");
+            index.put(10, "ten");
+            index.put(15, "fifteen");
+            index.put(20, "twenty");
+            index.put(25, "twenty-five");
+            index.maintenance().flushAndWait();
+            index.maintenance().compactAndWait();
+            index.put(15, "updated-fifteen");
+            index.delete(20);
+
+            try (var stream = index.scan(10, 25)) {
+                assertEquals(List.of(Entry.of(10, "ten"),
+                        Entry.of(15, "updated-fifteen")), stream.toList());
+            }
+        }
+    }
+
+    @Test
+    void scanWithNullUpperBoundReturnsTail() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-unbounded-upper", 1))) {
+            index.put(5, "five");
+            index.put(10, "ten");
+            index.put(15, "fifteen");
+
+            try (var stream = index.scan(10, null)) {
+                assertEquals(List.of(Entry.of(10, "ten"),
+                        Entry.of(15, "fifteen")), stream.toList());
+            }
+        }
+    }
+
+    @Test
+    void scanWithEqualBoundsReturnsEmptyStream() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-equal", 1));
+                var stream = index.scan(10, 10)) {
+            assertEquals(0L, stream.count());
+        }
+    }
+
+    @Test
+    void scanRejectsReversedRange() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-reversed", 1))) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> index.scan(20, 10));
+        }
+    }
+
+    @Test
+    void scanRejectsNullLowerBound() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-null-lower", 1))) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> index.scan(null, 20));
+        }
+    }
+
+    @Test
+    void scanRejectsNullIsolation() {
+        final MemDirectory directory = new MemDirectory();
+        try (SegmentIndex<Integer, String> index = SegmentIndex.create(directory,
+                buildConf("segment-index-scan-null-isolation", 1))) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> index.scan(10, 20, null));
+            try (var stream = index.scan(10, 20,
+                    SegmentIteratorIsolation.FAIL_FAST)) {
+                assertEquals(0L, stream.count());
+            }
+        }
     }
 
     @Test

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/SegmentIteratorServiceTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/SegmentIteratorServiceTest.java
@@ -1,10 +1,17 @@
 package org.hestiastore.index.segmentindex.core.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
+
+import org.hestiastore.index.EntryIterator;
+import org.hestiastore.index.segment.SegmentIteratorIsolation;
 import org.hestiastore.index.segmentindex.core.routing.MappedSegmentLeaseService;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +37,23 @@ class SegmentIteratorServiceTest {
 
         assertEquals("Property 'segmentLeaseService' must not be null.",
                 ex.getMessage());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void failFastRangeIteratorRequestsOnlyIntersectingSegments() {
+        final MappedSegmentLeaseService<Integer, String> segmentLeaseService = mock(
+                MappedSegmentLeaseService.class);
+        when(segmentLeaseService.getSegmentIds(10, 20))
+                .thenReturn(List.of());
+        final SegmentIteratorService<Integer, String> service =
+                SegmentIteratorService.create(segmentLeaseService, 1, 10);
+
+        try (EntryIterator<Integer, String> iterator = service.openRangeIterator(
+                10, 20, SegmentIteratorIsolation.FAIL_FAST)) {
+            assertFalse(iterator.hasNext());
+        }
+
+        verify(segmentLeaseService).getSegmentIds(10, 20);
     }
 }

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/StableSegmentsIteratorTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/execution/StableSegmentsIteratorTest.java
@@ -109,6 +109,26 @@ class StableSegmentsIteratorTest {
     }
 
     @Test
+    void boundedIteratorPassesRangeToSegment() {
+        when(segmentLeaseService.tryAcquireMappedSegment(SEGMENT_ID_17))
+                .thenReturn(Optional.of(lease17));
+        when(lease17.segment()).thenReturn(handle17);
+        when(handle17.tryOpenIterator("b", "d",
+                SegmentIteratorIsolation.FAIL_FAST))
+                .thenReturn(OperationResult.ok(entryIterator17));
+        when(entryIterator17.hasNext()).thenReturn(false);
+
+        try (StableSegmentsIterator<String, String> iterator = new StableSegmentsIterator<>(
+                List.of(SEGMENT_ID_17), segmentLeaseService,
+                SegmentIteratorIsolation.FAIL_FAST, "b", "d")) {
+            assertFalse(iterator.hasNext());
+        }
+
+        verify(handle17).tryOpenIterator("b", "d",
+                SegmentIteratorIsolation.FAIL_FAST);
+    }
+
+    @Test
     void test_fail_fast_skips_segment_when_registry_stays_busy() {
         when(segmentLeaseService.tryAcquireMappedSegment(SEGMENT_ID_17))
                 .thenReturn(Optional.empty());

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapterTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/core/session/SegmentIndexMdcLoggingAdapterTest.java
@@ -105,6 +105,22 @@ class SegmentIndexMdcLoggingAdapterTest {
     }
 
     @Test
+    void wrapsFailFastRangeScanWithMdc() {
+        final AtomicReference<String> mdcAtScan = new AtomicReference<>();
+        when(delegate.scan("a", "z", SegmentIteratorIsolation.FAIL_FAST))
+                .thenAnswer(invocation -> {
+                    mdcAtScan.set(MDC.get("index.name"));
+                    return Stream.empty();
+                });
+
+        try (Stream<Entry<String, String>> ignored = adapter.scan("a", "z")) {
+            assertEquals("idx", mdcAtScan.get());
+        }
+
+        assertNull(MDC.get("index.name"));
+    }
+
+    @Test
     void wraps_conditional_mutations_with_mdc() {
         final AtomicReference<String> mdcAtPutIfAbsent = new AtomicReference<>();
         final AtomicReference<String> mdcAtReplace = new AtomicReference<>();

--- a/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotTest.java
+++ b/engine/src/test/java/org/hestiastore/index/segmentindex/routemap/RouteMapSnapshotTest.java
@@ -1,9 +1,11 @@
 package org.hestiastore.index.segmentindex.routemap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.TreeMap;
 
 import org.hestiastore.index.segment.SegmentId;
@@ -30,5 +32,43 @@ class RouteMapSnapshotTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> snapshot.containsSegmentId(null));
+    }
+
+    @Test
+    void getSegmentIdsSelectsOnlyIntersectingRangeRoutes() {
+        final RouteMapSnapshot<Integer> snapshot = snapshotWithThreeRoutes();
+
+        assertEquals(List.of(SegmentId.of(2)),
+                snapshot.getSegmentIds(11, 19));
+        assertEquals(List.of(SegmentId.of(1), SegmentId.of(2)),
+                snapshot.getSegmentIds(10, 20));
+        assertEquals(List.of(SegmentId.of(2), SegmentId.of(3)),
+                snapshot.getSegmentIds(11, 21));
+    }
+
+    @Test
+    void getSegmentIdsSupportsOpenEndedTail() {
+        final RouteMapSnapshot<Integer> snapshot = snapshotWithThreeRoutes();
+
+        assertEquals(List.of(SegmentId.of(3)),
+                snapshot.getSegmentIds(21, null));
+        assertEquals(List.of(SegmentId.of(3)),
+                snapshot.getSegmentIds(40, null));
+    }
+
+    @Test
+    void getSegmentIdsReturnsEmptyForEmptyRouteMap() {
+        final RouteMapSnapshot<Integer> snapshot = new RouteMapSnapshot<>(
+                new TreeMap<>(), 0);
+
+        assertEquals(List.of(), snapshot.getSegmentIds(10, 20));
+    }
+
+    private RouteMapSnapshot<Integer> snapshotWithThreeRoutes() {
+        final TreeMap<Integer, SegmentId> routes = new TreeMap<>();
+        routes.put(10, SegmentId.of(1));
+        routes.put(20, SegmentId.of(2));
+        routes.put(30, SegmentId.of(3));
+        return new RouteMapSnapshot<>(routes, 0);
     }
 }


### PR DESCRIPTION
## Summary

- add an experimental half-open `SegmentIndex.scan(fromInclusive, toExclusive)` API
- route scans only through intersecting segments and seek persisted data from the scarce index
- keep ordinary unbounded sequential reads on their original merge hot path by applying bounds through a dedicated range iterator used only by `scan()`
- document `FAIL_FAST` behavior, including possible truncation when maintenance unloads segments, capacity eviction occurs, or the index closes
- add unit coverage and canonical JMH coverage for bounded scans and existing sequential reads

## Range contract

- `scan(10, 20)` returns keys `>= 10` and `< 20`
- `scan(10, 10)` returns an empty stream
- `scan(20, 10)` throws `IllegalArgumentException`
- `scan(null, 20)` is rejected because the API requires a lower bound
- `scan(10, null)` returns the tail of the index

Key ordering uses the comparator supplied by the key `TypeDescriptor`.

## Performance

The first bound-aware merger version added two null checks to every legacy sequential-read entry. This PR isolates range filtering from that hot loop.

Like-for-like JMH on Temurin JDK 21, 32,768 entries, 3 forks and 30 measurements:

- pre-range baseline: `141.350 ± 1.356 us/op`, `137.933 B/op`
- final unbounded path: `141.278 ± 0.380 us/op`, `137.932 B/op`

The repaired result is effectively identical to baseline (-0.05%). In the end-to-end multi-segment smoke fixture, the bounded 128-key scan measured `22.398 us/op` versus `1113.140 us/op` for full-stream filtering.

Both canonical SegmentIndex benchmark profiles now include the end-to-end sequential-read measurement and the isolated merge-loop regression guard.

## Validation

- `mvn clean verify`
- 2,122 engine unit tests plus the integration suite
- focused iterator tests: 23 passed
- `BenchmarkProfileContractTest`: 3 passed with benchmark tests explicitly enabled
- direct JMH execution of bounded, fallback, sequential-read, and merge-loop benchmarks
- `git diff --check`