### PR TITLE
Reduce sorted cache key snapshot allocation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,7 @@ java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SingleChunkEntryIterat
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SortedDataFileWriterBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar ByteSequenceCrc32Benchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar StringEncodingBenchmark
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar UniqueCacheSortedKeyIteratorBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexGetBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMultiSegmentGetBenchmark
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexRangeScanBenchmark
@@ -61,11 +62,15 @@ java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "DataBlockByteReaderBe
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "SingleChunkEntryIteratorBenchmark" -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "SortedDataFileWriterBenchmark" -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "StringEncodingBenchmark" -prof gc
+java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar "UniqueCacheSortedKeyIteratorBenchmark" -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexGetBenchmark -p readPathMode=live -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexMultiSegmentGetBenchmark -p workingSetMode=cold -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentIndexRangeScanBenchmark -prof gc
 java -jar benchmarks/target/benchmarks-0.0.6-SNAPSHOT.jar SegmentMergeSequentialBenchmark -prof gc
 ```
+
+The measured sorted-key snapshot comparison is documented in
+[`results/unique-cache-sorted-key-iterator-comparison.md`](results/unique-cache-sorted-key-iterator-comparison.md).
 
 The range-scan benchmark compares the bounded API with full-stream filtering
 and also measures a complete sequential read. All measurements use `FAIL_FAST`

--- a/benchmarks/results/unique-cache-sorted-key-iterator-comparison.md
+++ b/benchmarks/results/unique-cache-sorted-key-iterator-comparison.md
@@ -1,0 +1,47 @@
+# Unique Cache Sorted-Key Snapshot Comparison
+
+Comparison date: 2026-07-29
+
+Environment:
+
+- JMH 1.37
+- Eclipse Temurin 17.0.19
+- One benchmark thread
+- Three independent JVM forks
+- Three one-second warmups and five one-second measurements per fork
+- GC allocation profiler enabled
+
+The fixture inserts deterministic, distinct, mixed `Integer` keys. Trial setup
+also compares every key returned by the legacy and production iterators before
+measurement, including order and total count.
+
+## Command
+
+```sh
+java -jar benchmarks/target/benchmarks-1.0.1-SNAPSHOT.jar \
+  'UniqueCacheSortedKeyIteratorBenchmark' \
+  -wi 3 -i 5 -f 3 -w 1s -r 1s -prof gc \
+  -rf json -rff <output>.json
+```
+
+## Results
+
+| Keys | Measurement | `ArrayList` snapshot | Reused array | Observed change |
+| ---: | --- | ---: | ---: | ---: |
+| 100,000 | Allocation | 1,261,742 B/op | 861,717 B/op | -31.7% |
+| 500,000 | Allocation | 6,048,668 B/op | 4,048,667 B/op | -33.1% |
+| 100,000 | Mean time | 10.533 ± 0.184 ms/op | 10.472 ± 0.245 ms/op | -0.6% |
+| 500,000 | Mean time | 55.352 ± 0.509 ms/op | 58.943 ± 5.175 ms/op | +6.5% |
+
+Errors are JMH 99.9% confidence intervals.
+
+The allocation result is conclusive: reusing the key-set array removed about
+400 KB per 100,000 keys and 2.0 MB per 500,000 keys. The remaining allocation
+includes the key-set snapshot and the sorting algorithm's temporary storage.
+
+The timing result does not demonstrate a speedup or a regression. The
+100,000-key means are effectively equal, while the noisy 500,000-key reused
+array result has a confidence interval of 53.768–64.118 ms/op, overlapping the
+legacy interval of 54.843–55.861 ms/op. The justified benefit from this
+measurement is therefore lower temporary allocation and GC pressure, not faster
+sorting.

--- a/benchmarks/src/main/java/org/hestiastore/benchmark/cache/UniqueCacheSortedKeyIteratorBenchmark.java
+++ b/benchmarks/src/main/java/org/hestiastore/benchmark/cache/UniqueCacheSortedKeyIteratorBenchmark.java
@@ -1,0 +1,120 @@
+package org.hestiastore.benchmark.cache;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.hestiastore.index.Entry;
+import org.hestiastore.index.cache.UniqueCache;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares the sorted key snapshot with the previous
+ * {@code ArrayList(Collection)} implementation.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Thread)
+public class UniqueCacheSortedKeyIteratorBenchmark {
+
+    private static final Comparator<Integer> KEY_COMPARATOR = Integer::compare;
+    private static final int PERMUTATION_MULTIPLIER = 0x9E3779B9;
+
+    @Param({ "100000", "500000" })
+    private int numberOfKeys;
+
+    private UniqueCache<Integer, Integer> cache;
+    private Map<Integer, Integer> legacyMap;
+
+    /**
+     * Builds equivalent caches and validates output parity before measurement.
+     */
+    @Setup(Level.Trial)
+    public void setup() {
+        cache = UniqueCache.<Integer, Integer>builder()
+                .withKeyComparator(KEY_COMPARATOR)
+                .withInitialCapacity(numberOfKeys)
+                .buildEmpty();
+        legacyMap = new ConcurrentHashMap<>(numberOfKeys, 0.75f, 1);
+        for (int index = 0; index < numberOfKeys; index++) {
+            final Integer key = permutedKey(index);
+            cache.put(Entry.of(key, key));
+            legacyMap.put(key, key);
+        }
+        validateParity();
+    }
+
+    /**
+     * Measures the previous key-set copy into a second array before sorting.
+     *
+     * @return iterator over the legacy sorted snapshot
+     */
+    @Benchmark
+    public Iterator<Integer> legacyArrayListSnapshot() {
+        final List<Integer> keys = new ArrayList<>(legacyMap.keySet());
+        keys.sort(KEY_COMPARATOR);
+        return keys.iterator();
+    }
+
+    /**
+     * Measures the production implementation that sorts the key-set array.
+     *
+     * @return iterator over the current sorted snapshot
+     */
+    @Benchmark
+    public Iterator<Integer> reusedArraySnapshot() {
+        return cache.getSortedKeyIterator();
+    }
+
+    /**
+     * Verifies both implementations return the same ordered keys.
+     */
+    private void validateParity() {
+        final Iterator<Integer> legacy = legacyArrayListSnapshot();
+        final Iterator<Integer> current = reusedArraySnapshot();
+        int count = 0;
+        while (legacy.hasNext() && current.hasNext()) {
+            final Integer legacyKey = legacy.next();
+            final Integer currentKey = current.next();
+            if (!legacyKey.equals(currentKey)) {
+                throw new IllegalStateException(String.format(
+                        "Key mismatch at index '%d': legacy '%d', current '%d'",
+                        count, legacyKey, currentKey));
+            }
+            count++;
+        }
+        if (legacy.hasNext() || current.hasNext() || count != numberOfKeys) {
+            throw new IllegalStateException(String.format(
+                    "Iterator size mismatch: expected '%d', compared '%d'",
+                    numberOfKeys, count));
+        }
+    }
+
+    /**
+     * Produces each key exactly once in a deterministic non-sequential order.
+     *
+     * @param index source index
+     * @return permuted key
+     */
+    private int permutedKey(final int index) {
+        return Integer.rotateLeft(index * PERMUTATION_MULTIPLIER, 16);
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
+++ b/engine/src/main/java/org/hestiastore/index/cache/UniqueCache.java
@@ -1,6 +1,7 @@
 package org.hestiastore.index.cache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -166,7 +167,12 @@ public class UniqueCache<K, V> {
     }
 
     /**
-     * Returns an iterator over a sorted snapshot of keys.
+     * Returns an iterator over a sorted shallow snapshot of keys. Concurrent
+     * updates during snapshot creation may or may not be reflected. The
+     * returned iterator does not support removal. In the 100,000/500,000-key
+     * JMH comparison, this direct-array implementation allocated about 30%
+     * less memory per operation than sorting
+     * {@code new ArrayList<>(map.keySet())}.
      *
      * @return iterator over keys sorted by the configured comparator
      */
@@ -174,11 +180,13 @@ public class UniqueCache<K, V> {
         if (map.isEmpty()) {
             return List.<K>of().iterator();
         }
-        final List<K> keys = new ArrayList<>(map.keySet());
-        if (keys.size() > 1) {
-            keys.sort(keyComparator);
+        // The key-set array contains only K instances and remains internal.
+        @SuppressWarnings("unchecked")
+        final K[] keys = (K[]) map.keySet().toArray();
+        if (keys.length > 1) {
+            Arrays.sort(keys, keyComparator);
         }
-        return keys.iterator();
+        return Arrays.asList(keys).iterator();
     }
 
     /**

--- a/engine/src/test/java/org/hestiastore/index/ByteToolTest.java
+++ b/engine/src/test/java/org/hestiastore/index/ByteToolTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({ "deprecation", "removal" })
+@SuppressWarnings({ "removal" })
 class ByteToolTest {
 
     private static final byte[] BYTES_EMPTY_STR = "".getBytes();

--- a/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
+++ b/engine/src/test/java/org/hestiastore/index/cache/UniqueCacheTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -83,6 +85,29 @@ class UniqueCacheTest {
         assertEquals(Entry.of(13, "my"), out.get(2));
         assertEquals(Entry.of(15, "dear"), out.get(3));
         assertEquals(4, cache.size());
+    }
+
+    @Test
+    void getSortedKeyIterator_returns_sorted_shallow_snapshot() {
+        cache.put(Entry.of(15, "dear"));
+        cache.put(Entry.of(13, "my"));
+        cache.put(Entry.of(-199, "hello"));
+
+        final Iterator<Integer> iterator = cache.getSortedKeyIterator();
+        cache.clear();
+        final List<Integer> keys = new ArrayList<>();
+        iterator.forEachRemaining(keys::add);
+
+        assertEquals(List.of(-199, 13, 15), keys);
+    }
+
+    @Test
+    void getSortedKeyIterator_does_not_support_removal() {
+        cache.put(Entry.of(10, "hello"));
+        final Iterator<Integer> iterator = cache.getSortedKeyIterator();
+        iterator.next();
+
+        assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- sort the array returned by `map.keySet().toArray()` directly instead of copying it into an `ArrayList`
- document the shallow-snapshot and unsupported-removal iterator contract
- add correctness tests for sorting, snapshot independence, and iterator removal
- add a reproducible JMH comparison and record the measured results
- remove the obsolete `deprecation` suppression from `ByteToolTest`

## Why

`new ArrayList<>(map.keySet())` creates the key-set snapshot array and then copies those references into the list's backing array. For caches with hundreds of thousands of entries, that second temporary reference array creates avoidable allocation and GC pressure.

## Measured impact

With deterministic mixed keys on Temurin 17.0.19, three JVM forks, and GC allocation profiling:

- 100,000 keys: 1,261,742 B/op to 861,717 B/op, a 31.7% reduction (about 400 KB)
- 500,000 keys: 6,048,668 B/op to 4,048,667 B/op, a 33.1% reduction (about 2.0 MB)

Latency confidence intervals overlap, so the benchmark establishes lower allocation, not faster sorting.

## Validation

- `mvn clean verify` on Temurin 17.0.19 — passed across all ten modules
- `mvn -pl engine -Dtest=UniqueCacheTest,ByteToolTest test` — 24 tests passed
- `mvn -pl engine package -DskipTests` — production and Javadoc artifacts built
- `UniqueCacheSortedKeyIteratorBenchmark` executed with three forks and `-prof gc`; methodology and results are committed under `benchmarks/results/`
