### PR TITLE
Add composite key index example

### DIFF
--- a/engine/src/integration-test/java/org/hestiastore/index/it/TypeDescriptorCompositeExampleIT.java
+++ b/engine/src/integration-test/java/org/hestiastore/index/it/TypeDescriptorCompositeExampleIT.java
@@ -1,0 +1,68 @@
+package org.hestiastore.index.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.hestiastore.index.datatype.CompositeValue;
+import org.hestiastore.index.datatype.TypeDescriptorComposite;
+import org.hestiastore.index.datatype.TypeDescriptorLong;
+import org.hestiastore.index.datatype.TypeDescriptorUtf8String;
+import org.hestiastore.index.directory.Directory;
+import org.hestiastore.index.directory.MemDirectory;
+import org.hestiastore.index.segmentindex.SegmentIndex;
+import org.hestiastore.index.segmentindex.configuration.api.IndexConfiguration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Demonstrates a UTF-8 string and long composite key in a high-level index.
+ */
+public class TypeDescriptorCompositeExampleIT {
+
+    @Test
+    void test_write_close_reopen_and_read_composite_key() {
+        final Directory directory = new MemDirectory();
+        final IndexConfiguration<CompositeValue, String> configuration = IndexConfiguration
+                .<CompositeValue, String>builder()
+                .identity(identity -> identity.name("composite_key_example")
+                        .keyClass(CompositeValue.class)
+                        .valueClass(String.class)
+                        .keyTypeDescriptor(
+                                new Utf8StringLongKeyTypeDescriptor())
+                        .valueTypeDescriptor(new TypeDescriptorUtf8String()))
+                .build();
+        final SegmentIndex<CompositeValue, String> index = SegmentIndex
+                .create(directory, configuration);
+        final CompositeValue key = CompositeValue.of("customer-🤩",
+                42L);
+        final String value = "UTF-8 value: příliš žluťoučký kůň";
+
+        try (index) {
+            index.put(key, value);
+        }
+        assertTrue(index.wasClosed());
+
+        final SegmentIndex<CompositeValue, String> reopenedIndex = SegmentIndex
+                .open(directory);
+        try (reopenedIndex) {
+            assertEquals(value, reopenedIndex.get(key));
+        }
+        assertTrue(reopenedIndex.wasClosed());
+    }
+
+    /**
+     * Composite-key descriptor used by the example index.
+     */
+    public static final class Utf8StringLongKeyTypeDescriptor
+            extends TypeDescriptorComposite {
+
+        /**
+         * Creates a descriptor for a UTF-8 string followed by a long.
+         */
+        public Utf8StringLongKeyTypeDescriptor() {
+            super(List.of(new TypeDescriptorUtf8String(),
+                    new TypeDescriptorLong()));
+        }
+    }
+}

--- a/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorComposite.java
+++ b/engine/src/main/java/org/hestiastore/index/datatype/TypeDescriptorComposite.java
@@ -57,7 +57,13 @@ public class TypeDescriptorComposite implements TypeDescriptor<CompositeValue> {
     private final List<TypeDescriptor<?>> elementTypes;
     private final CompositeValue tombstoneValue;
 
-    TypeDescriptorComposite(final List<TypeDescriptor<?>> elementTypes) {
+    /**
+     * Creates a descriptor for the supplied ordered element types.
+     *
+     * @param elementTypes element descriptors in composite-key order
+     */
+    public TypeDescriptorComposite(
+            final List<TypeDescriptor<?>> elementTypes) {
         this.elementTypes = List
                 .copyOf(Vldtn.requireNotEmpty(elementTypes, "elementTypes"));
         final Object[] tmp = new Object[elementTypes.size()];


### PR DESCRIPTION
## Summary

- expose the `TypeDescriptorComposite` constructor for caller-defined composite descriptors
- add an integration example using a UTF-8 string plus `long` composite key
- store a UTF-8 string value, close the index, reopen it, and verify the persisted value

## Why

`SegmentIndex` persists descriptor class names and recreates them through public no-argument constructors. The example provides the required small descriptor subclass and demonstrates the complete persistence lifecycle.

## Impact

This is a source-compatible API expansion. Users can now define reusable composite descriptors outside the datatype package and use them with the high-level index.

## Validation

- `mvn -pl engine clean verify` — 2,124 unit tests and 44 integration tests passed
- `mvn -q -pl engine -Dtest=TypeDescriptorCompositeTest -Dit.test=TypeDescriptorCompositeExampleIT verify` — targeted unit and integration tests passed